### PR TITLE
refactor(du-an): remove denormalized DuToan fields from DuAn entity

### DIFF
--- a/QLDA.Application/DuAns/Commands/DuAnInsertCommand.cs
+++ b/QLDA.Application/DuAns/Commands/DuAnInsertCommand.cs
@@ -58,16 +58,6 @@ internal class DuAnInsertCommandHandler : IRequestHandler<DuAnInsertCommand, DuA
         }
 
         DuAn.InitializeNode(entity, parent);
-
-        // Auto-set SoDuToanCuoiCung from DuToan list
-        if (entity.DuToans?.Count > 0) {
-            var sortedDuToans = entity.DuToans.OrderBy(d => d.Index).ToList();
-            if (sortedDuToans.Count > 1) {
-                var lastDuToan = sortedDuToans.Last();
-                entity.SoDuToanCuoiCung = lastDuToan.SoDuToan;
-            }
-            await DuAn.UpdateAsync(entity, cancellationToken);
-        }
     }
 
     #endregion

--- a/QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs
+++ b/QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs
@@ -58,8 +58,7 @@ internal class DuAnUpdateCommandHandler : IRequestHandler<DuAnUpdateCommand, DuA
             existing.SoQuyetDinhDuToan = request.SoQuyetDinhDuToan;
             existing.NgayKyDuToan = request.NgayKyDuToan;
             existing.GhiChu = request.GhiChu;
-        }
-          , cancellationToken);
+        }, cancellationToken);
 
         await SyncHelper.SyncCollection(KeHoachVon, entity.KeHoachVons, [.. request.Model.KeHoachVons?.Select(e => e.ToEntity(entity.Id)) ?? []], (existing, request) => {
             existing.NguonVonId = request.NguonVonId;
@@ -72,17 +71,6 @@ internal class DuAnUpdateCommandHandler : IRequestHandler<DuAnUpdateCommand, DuA
         }
           , cancellationToken);
 
-        // Update SoDuToanCuoiCung based on the updated DuToans list
-        if (entity.DuToans != null && entity.DuToans.Count > 0) {
-            var sortedDuToans = entity.DuToans.Where(d => !d.IsDeleted).OrderBy(d => d.Index).ToList();
-            if (sortedDuToans.Count > 1) {
-                var lastDuToan = sortedDuToans.Last();
-                entity.SoDuToanCuoiCung = lastDuToan.SoDuToan;
-            } else {
-                entity.SoDuToanCuoiCung = null;
-            }
-        }
-
         if (_unitOfWork.HasTransaction) {
             await UpdateAsync(entity, cancellationToken);
         } else {
@@ -90,29 +78,6 @@ internal class DuAnUpdateCommandHandler : IRequestHandler<DuAnUpdateCommand, DuA
             await UpdateAsync(entity, cancellationToken);
             await _unitOfWork.SaveChangesAsync(cancellationToken);
             await _unitOfWork.CommitTransactionAsync(cancellationToken);
-        }
-
-        // Query latest DuToan after save to include newly added records from SyncCollection
-        var duToanMoiNhat = await DuToan.GetQueryableSet()
-            .Where(d => d.DuAnId == entity.Id && !d.IsDeleted)
-            .OrderByDescending(d => d.NamDuToan)
-            .ThenByDescending(d => d.NgayKyDuToan)
-            .FirstOrDefaultAsync(cancellationToken);
-
-        if (duToanMoiNhat != null) {
-            entity.DuToanHienTaiId = duToanMoiNhat.Id;
-            entity.SoDuToan = duToanMoiNhat.SoDuToan;
-            entity.NamDuToan = duToanMoiNhat.NamDuToan;
-            entity.SoQuyetDinhDuToan = duToanMoiNhat.SoQuyetDinhDuToan;
-            entity.NgayKyDuToan = duToanMoiNhat.NgayKyDuToan;
-            await DuAn.UpdateAsync(entity, cancellationToken);
-        } else if (entity.DuToanHienTaiId != null) {
-            entity.DuToanHienTaiId = null;
-            entity.SoDuToan = 0;
-            entity.NamDuToan = 0;
-            entity.SoQuyetDinhDuToan = null;
-            entity.NgayKyDuToan = null;
-            await DuAn.UpdateAsync(entity, cancellationToken);
         }
 
         return entity;

--- a/QLDA.Application/DuAns/DTOs/BaoCaoDuAnDto.cs
+++ b/QLDA.Application/DuAns/DTOs/BaoCaoDuAnDto.cs
@@ -28,6 +28,4 @@ public class BaoCaoDuAnDto : IHasKey<Guid> {
 
     public int? HinhThucDauTuId { get; set; }
     public int? LoaiDuAnId { get; set; }
-    public DateTimeOffset? NgayQuyetDinhDuToan { get; set; }
-    public string? SoQuyetDinhDuToan { get; set; }
 }

--- a/QLDA.Application/DuAns/DTOs/DuAnDto.cs
+++ b/QLDA.Application/DuAns/DTOs/DuAnDto.cs
@@ -185,9 +185,4 @@ public class DuAnDto : IHasKey<Guid> {
     /// Khái toán kinh phí
     /// </summary>
     public decimal? KhaiToanKinhPhi { get; set; }
-    /// <summary>
-    /// Số dự toán cuối cùng (điều chỉnh)
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public long? SoDuToanCuoiCung { get; set; }
 }

--- a/QLDA.Application/DuAns/DTOs/DuAnInsertDto.cs
+++ b/QLDA.Application/DuAns/DTOs/DuAnInsertDto.cs
@@ -137,10 +137,6 @@ public class DuAnInsertDto : IMayHaveParent<Guid?> {
     /// </summary>
     public List<long>? DonViPhoiHopIds { get; set; }
     /// <summary>
-    /// Số dư dự toán cuối cùng
-    /// </summary>
-    public long? SoDuToanCuoiCung { get; set; }
-    /// <summary>
     /// Khái toán kinh phí
     /// </summary>
     public decimal? KhaiToanKinhPhi { get; set; }

--- a/QLDA.Application/DuAns/DTOs/DuAnMappings.cs
+++ b/QLDA.Application/DuAns/DTOs/DuAnMappings.cs
@@ -35,7 +35,6 @@ public static class DuAnMappings {
             NgayBatDau = dto.NgayBatDau,
             LanhDaoPhuTrachId = dto.LanhDaoPhuTrachId,
             DonViPhuTrachChinhId = dto.DonViPhuTrachChinhId,
-            SoDuToanCuoiCung = dto.SoDuToanCuoiCung,
             KhaiToanKinhPhi = dto.KhaiToanKinhPhi,
             DuAnNguonVons = [..dto.DanhSachNguonVon?.Select(nguonVonId => new DuAnNguonVon {
                 LeftId = id,
@@ -49,14 +48,11 @@ public static class DuAnMappings {
             KeHoachVons = [.. dto.KeHoachVons?.Select(e => e.ToEntity(id)) ?? []]
         };
 
-        // Set DuAnId for each DuToan entity and set DuToanHienTaiId if there's a latest DuToan
+        // Set DuAnId for each DuToan entity
         if (entity.DuToans != null && entity.DuToans.Count > 0) {
             foreach (var duToan in entity.DuToans) {
                 duToan.DuAnId = id;
             }
-            var latestDuToan = entity.DuToans.Last();
-            entity.DuToanHienTaiId = latestDuToan.Id;
-            entity.DuToanHienTai = latestDuToan;
         }
         return entity;
     }
@@ -87,7 +83,6 @@ public static class DuAnMappings {
         entity.GhiChu = dto.GhiChu;
         entity.LanhDaoPhuTrachId = dto.LanhDaoPhuTrachId;
         entity.DonViPhuTrachChinhId = dto.DonViPhuTrachChinhId;
-        entity.SoDuToanCuoiCung = dto.SoDuToanCuoiCung;
         entity.KhaiToanKinhPhi = dto.KhaiToanKinhPhi;
         entity.DuAnNguonVons = [.. dto.DanhSachNguonVon?.Select(nguonVonId => new DuAnNguonVon {
             LeftId = dto.Id,
@@ -128,7 +123,6 @@ public static class DuAnMappings {
             NgayBatDau = entity.NgayBatDau,
             LanhDaoPhuTrachId = entity.LanhDaoPhuTrachId,
             DonViPhuTrachChinhId = entity.DonViPhuTrachChinhId,
-            SoDuToanCuoiCung = entity.SoDuToanCuoiCung,
             KhaiToanKinhPhi = entity.KhaiToanKinhPhi,
             DanhSachNguonVon = [.. entity.DuAnNguonVons?.Select(nguonVon => nguonVon.RightId) ?? []],
             DonViPhoiHopIds = [.. entity.DuAnChiuTrachNhiemXuLys?.Where(e => e.Loai == EChiuTrachNhiemXuLy.DonViPhoiHop).Select(chiuTrachNhiemXuLy => chiuTrachNhiemXuLy.RightId) ?? []],
@@ -138,17 +132,6 @@ public static class DuAnMappings {
             KeHoachVons = [.. entity.KeHoachVons?.Where(e => !e.IsDeleted)
                 .Select(e => e.ToDto()) ?? []]
         };
-        if (entity.DuToanHienTaiId == null && entity.SoDuToan != 0) {
-            // Insert at the beginning of the list
-            dto.DuToans.Insert(0, new DuToanDto {
-                Id = Guid.NewGuid(), // Generate a new ID for this DTO
-                DuAnId = entity.Id,
-                SoDuToan = entity.SoDuToan,
-                NamDuToan = entity.NamDuToan,
-                SoQuyetDinhDuToan = entity.SoQuyetDinhDuToan,
-                NgayKyDuToan = entity.NgayKyDuToan,
-            });
-        }
 
         return dto;
     }

--- a/QLDA.Application/DuAns/DTOs/DuAnUpdateModel.cs
+++ b/QLDA.Application/DuAns/DTOs/DuAnUpdateModel.cs
@@ -35,10 +35,6 @@ public class DuAnUpdateModel : IHasKey<Guid>, IMayHaveParent<Guid?> {
     public List<DuToanUpdateModel>? DuToans { get; set; }
     public List<KeHoachVonUpdateModel>? KeHoachVons { get; set; }
     /// <summary>
-    /// Số dư dự toán cuối cùng
-    /// </summary>
-    public long? SoDuToanCuoiCung { get; set; }
-    /// <summary>
     /// Khái toán kinh phí
     /// </summary>
     public decimal? KhaiToanKinhPhi { get; set; }

--- a/QLDA.Application/DuAns/Queries/DuAnGetDanhSachQuery.cs
+++ b/QLDA.Application/DuAns/Queries/DuAnGetDanhSachQuery.cs
@@ -21,7 +21,6 @@ internal class DuAnGetDanhSachQueryHandler : IRequestHandler<DuAnGetDanhSachQuer
         CancellationToken cancellationToken = default) {
         var queryable = DuAn.GetQueryableSet().AsNoTracking()
             .Where(e => !e.IsDeleted)
-            .Include(e => e.DuToanHienTai)
             .Include(e => e.DuToans)
             .WhereIf(request.SearchDto.TenDuAn.IsNotNullOrWhitespace(),
                 e => e.TenDuAn!.ToLower().Contains(request.SearchDto.TenDuAn!.ToLower()))

--- a/QLDA.Application/DuAns/Queries/DuAnGetQuery.cs
+++ b/QLDA.Application/DuAns/Queries/DuAnGetQuery.cs
@@ -19,7 +19,6 @@ internal class DuAnGetQueryHandler(IServiceProvider serviceProvider) : IRequestH
         var queryable = DuAnRepository.GetOriginalSet()
                 .Where(o => o.Id == request.Id)
                 .Include(e => e.BuocHienTai!.Buoc!.GiaiDoan)
-                .Include(e => e.DuToanHienTai)
                 .WhereFunc(request.IsNoTracking, q => q.AsNoTracking())
                 .WhereFunc(request.IncludeChiuTrachNhiemXuLy, q => q.Include(o => o.DuAnChiuTrachNhiemXuLys))
                 .WhereFunc(request.IncludeNguonVon, q => q.Include(o => o.DuAnNguonVons))

--- a/QLDA.Domain/Entities/DuAn.cs
+++ b/QLDA.Domain/Entities/DuAn.cs
@@ -97,48 +97,10 @@ public class DuAn : MaterializedPathEntity<Guid>, IAggregateRoot {
     /// <remarks>: TMĐT theo QĐ phê duyệt chủ trương</remarks>
     public long? TongMucDauTu { get; set; }
 
-    #region Thông tin dự toán hiện tại - mới nhất
-
-    /// <summary>
-    /// Số dự toán
-    /// </summary>
-    public long SoDuToan { get; set; }
-
-    /// <summary>
-    /// Năm dự toán
-    /// </summary>
-    public int NamDuToan { get; set; }
-
-    /// <summary>
-    /// Số quyết định dự toán
-    /// </summary>
-    public string? SoQuyetDinhDuToan { get; set; }
-
-    /// <summary>
-    /// Ngày ký dự toán
-    /// </summary>
-    public DateTimeOffset? NgayKyDuToan { get; set; }
-
-    /// <summary>
-    /// Ngày quyết định dự toán
-    /// </summary>
-    public DateTimeOffset? NgayQuyetDinhDuToan { get; set; }
-
-    /// <summary>
-    /// Dự toán hiện tại
-    /// </summary>
-    public Guid? DuToanHienTaiId { get; set; }
-    #endregion
-
     /// <summary>
     /// Khái toán kinh phí
     /// </summary>
     public decimal? KhaiToanKinhPhi { get; set; }
-
-    /// <summary>
-    /// Số dự toán cuối cùng (điều chỉnh)
-    /// </summary>
-    public long? SoDuToanCuoiCung { get; set; }
 
     /// <summary>
     /// Danh mục quy trình
@@ -215,7 +177,6 @@ public class DuAn : MaterializedPathEntity<Guid>, IAggregateRoot {
     #region Navigation Properties
 
     #region Self Reference
-    public DuToan? DuToanHienTai { get; set; }
     public DuAnBuoc? BuocHienTai { get; set; }
     public DanhMucGiaiDoan? GiaiDoanHienTai { get; set; }
     public DanhMucTrangThaiDuAn? TrangThaiDuAn { get; set; }

--- a/QLDA.Migrator/Migrations/20260424101249_RemoveDenormalizedDuToanFieldsFromDuAn.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260424101249_RemoveDenormalizedDuToanFieldsFromDuAn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260424101249_RemoveDenormalizedDuToanFieldsFromDuAn")]
+    partial class RemoveDenormalizedDuToanFieldsFromDuAn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260424101249_RemoveDenormalizedDuToanFieldsFromDuAn.cs
+++ b/QLDA.Migrator/Migrations/20260424101249_RemoveDenormalizedDuToanFieldsFromDuAn.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveDenormalizedDuToanFieldsFromDuAn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_DuAn_DuToan_DuToanHienTaiId",
+                table: "DuAn");
+
+            migrationBuilder.DropIndex(
+                name: "IX_DuAn_DuToanHienTaiId",
+                table: "DuAn");
+
+            migrationBuilder.DropColumn(
+                name: "DuToanHienTaiId",
+                table: "DuAn");
+
+            migrationBuilder.DropColumn(
+                name: "NamDuToan",
+                table: "DuAn");
+
+            migrationBuilder.DropColumn(
+                name: "NgayKyDuToan",
+                table: "DuAn");
+
+            migrationBuilder.DropColumn(
+                name: "NgayQuyetDinhDuToan",
+                table: "DuAn");
+
+            migrationBuilder.DropColumn(
+                name: "SoDuToan",
+                table: "DuAn");
+
+            migrationBuilder.DropColumn(
+                name: "SoDuToanCuoiCung",
+                table: "DuAn");
+
+            migrationBuilder.DropColumn(
+                name: "SoQuyetDinhDuToan",
+                table: "DuAn");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "DuToanHienTaiId",
+                table: "DuAn",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "NamDuToan",
+                table: "DuAn",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "NgayKyDuToan",
+                table: "DuAn",
+                type: "datetimeoffset",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "NgayQuyetDinhDuToan",
+                table: "DuAn",
+                type: "datetimeoffset",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "SoDuToan",
+                table: "DuAn",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<long>(
+                name: "SoDuToanCuoiCung",
+                table: "DuAn",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SoQuyetDinhDuToan",
+                table: "DuAn",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DuAn_DuToanHienTaiId",
+                table: "DuAn",
+                column: "DuToanHienTaiId",
+                unique: true,
+                filter: "[DuToanHienTaiId] IS NOT NULL");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_DuAn_DuToan_DuToanHienTaiId",
+                table: "DuAn",
+                column: "DuToanHienTaiId",
+                principalTable: "DuToan",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/QLDA.Persistence/Configurations/DuAnConfiguration.cs
+++ b/QLDA.Persistence/Configurations/DuAnConfiguration.cs
@@ -8,6 +8,8 @@ public class DuAnConfiguration : AggregateRootConfiguration<DuAn> {
         builder.ToTable(nameof(DuAn));
         builder.ConfigureForBase();
 
+        builder.Property(e => e.KhaiToanKinhPhi).HasPrecision(18, 2);
+
         builder.Property(e => e.ParentId)
             .HasConversion(
                 toDb => toDb == Guid.Empty ? null : toDb, // EF insert sẽ chuyển 0 → null
@@ -98,18 +100,5 @@ public class DuAnConfiguration : AggregateRootConfiguration<DuAn> {
             .HasForeignKey(e => e.DuAnId)
             .OnDelete(DeleteBehavior.Restrict);
 
-        builder.Property(e => e.SoQuyetDinhDuToan)
-            .HasMaxLength(50);
-
-        builder.Property(e => e.NgayKyDuToan)
-            .HasConversion(
-                toDb => toDb.HasValue ? toDb.Value.ToUniversalTime() : (DateTimeOffset?)null,
-                fromDb => fromDb
-            );
-
-        builder.HasOne(e => e.DuToanHienTai)
-            .WithOne()
-            .HasForeignKey<DuAn>(e => e.DuToanHienTaiId)
-            .OnDelete(DeleteBehavior.NoAction);
     }
 }

--- a/QLDA.WebApi/Controllers/DuAnController.cs
+++ b/QLDA.WebApi/Controllers/DuAnController.cs
@@ -157,14 +157,7 @@ namespace QLDA.WebApi.Controllers {
             if (duToans.Count != 0) {
 
                 //Thêm dự toán
-                var duToanMoiNhat = await Mediator.Send(new DuToanInsertRangeCommand([.. duToans.Select(e => e.Item1)]), cancellationToken);
-                if (duToanMoiNhat != null) {
-                    entity.DuToanHienTai = duToanMoiNhat;
-                    entity.SoDuToan = duToanMoiNhat.SoDuToan;
-                    entity.SoQuyetDinhDuToan = duToanMoiNhat.SoQuyetDinhDuToan;
-                    entity.NamDuToan = duToanMoiNhat.NamDuToan;
-                    entity.NgayKyDuToan = duToanMoiNhat.NgayKyDuToan;
-                }
+                await Mediator.Send(new DuToanInsertRangeCommand([.. duToans.Select(e => e.Item1)]), cancellationToken);
 
                 //Thêm files
                 foreach (var (duToan, files) in duToans) {


### PR DESCRIPTION
## Summary
- Remove 7 denormalized DuToan fields (`SoDuToan`, `NamDuToan`, `SoQuyetDinhDuToan`, `NgayKyDuToan`, `NgayQuyetDinhDuToan`, `DuToanHienTaiId`, `SoDuToanCuoiCung`) and `DuToanHienTai` navigation from `DuAn` entity
- Remove sync logic in `DuAnUpdateCommand` and `DuAnController` that kept these fields in sync with `DuToan` table
- Remove `SoQuyetDinhDuToan` and `NgayQuyetDinhDuToan` from `BaoCaoDuAnDto`
- Also includes `feat(ket-qua-trung-thau): add SoNgayThucHienHopDong property`

## Motivation
These fields were redundant copies of `DuToan` data. DuToan info should be queried directly from the `DuToan` table via the `DuToans` navigation collection when needed, rather than duplicated on `DuAn`.

## Migration
**BREAKING**: Drops 7 columns + FK + index from `DuAn` table. Data in these columns will be lost. The source of truth is the `DuToan` table.

## Test plan
- [x] Build succeeds with 0 errors, 0 warnings
- [ ] Verify DuAn CRUD still works (create, update, list, detail)
- [ ] Verify DuToan CRUD still works independently
- [ ] Verify BaoCaoDuAn query still works (user already commented out affected fields)
- [ ] Run migration on staging to verify column drops