### PR TITLE
fix(KeHoachVon): change NguonVonId type from Guid to int

### DIFF
--- a/QLDA.Application/KeHoachVons/DTOs/KeHoachVonDto.cs
+++ b/QLDA.Application/KeHoachVons/DTOs/KeHoachVonDto.cs
@@ -9,7 +9,7 @@ namespace QLDA.Application.KeHoachVons.DTOs;
 public class KeHoachVonDto : IHasKey<Guid>, IMayHaveTepDinhKemDto {
     public Guid Id { get; set; }
     public Guid DuAnId { get; set; }
-    public Guid? NguonVonId { get; set; }
+    public int? NguonVonId { get; set; }
     public int Nam { get; set; }
     public decimal SoVon { get; set; }
     public decimal? SoVonDieuChinh { get; set; }

--- a/QLDA.Application/KeHoachVons/DTOs/KeHoachVonInsertModel.cs
+++ b/QLDA.Application/KeHoachVons/DTOs/KeHoachVonInsertModel.cs
@@ -7,7 +7,7 @@ namespace QLDA.Application.KeHoachVons.DTOs;
 /// Input tạo mới kế hoạch vốn
 /// </summary>
 public class KeHoachVonInsertModel : IMayHaveTepDinhKemInsertDto {
-    public Guid? NguonVonId { get; set; }
+    public int? NguonVonId { get; set; }
     public int Nam { get; set; }
     public decimal SoVon { get; set; }
     public decimal? SoVonDieuChinh { get; set; }

--- a/QLDA.Application/KeHoachVons/DTOs/KeHoachVonUpdateModel.cs
+++ b/QLDA.Application/KeHoachVons/DTOs/KeHoachVonUpdateModel.cs
@@ -8,7 +8,7 @@ namespace QLDA.Application.KeHoachVons.DTOs;
 /// </summary>
 public class KeHoachVonUpdateModel : IHasKey<Guid?>, IMayHaveTepDinhKemInsertOrUpdateDto {
     public Guid? Id { get; set; }
-    public Guid? NguonVonId { get; set; }
+    public int? NguonVonId { get; set; }
     public int Nam { get; set; }
     public decimal SoVon { get; set; }
     public decimal? SoVonDieuChinh { get; set; }

--- a/QLDA.Domain/Entities/KeHoachVon.cs
+++ b/QLDA.Domain/Entities/KeHoachVon.cs
@@ -1,3 +1,5 @@
+using QLDA.Domain.Entities.DanhMuc;
+
 namespace QLDA.Domain.Entities;
 
 /// <summary>
@@ -13,7 +15,7 @@ public class KeHoachVon : Entity<Guid>, IAggregateRoot {
 	/// <summary>
 	/// ID nguồn vốn (Optional FK to funding source)
 	/// </summary>
-	public Guid? NguonVonId { get; set; }
+	public int? NguonVonId { get; set; }
 
 	/// <summary>
 	/// Năm kế hoạch
@@ -52,5 +54,10 @@ public class KeHoachVon : Entity<Guid>, IAggregateRoot {
 	/// </summary>
 	public DuAn? DuAn { get; set; }
 
-	#endregion
+		/// <summary>
+		/// Nguồn vốn
+		/// </summary>
+		public DanhMucNguonVon? NguonVon { get; set; }
+
+		#endregion
 }

--- a/QLDA.Migrator/Migrations/20260504051400_ChangeKeHoachVonNguonVonIdToInt.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260504051400_ChangeKeHoachVonNguonVonIdToInt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504051400_ChangeKeHoachVonNguonVonIdToInt")]
+    partial class ChangeKeHoachVonNguonVonIdToInt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260504051400_ChangeKeHoachVonNguonVonIdToInt.cs
+++ b/QLDA.Migrator/Migrations/20260504051400_ChangeKeHoachVonNguonVonIdToInt.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeKeHoachVonNguonVonIdToInt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "NguonVonId",
+                table: "KeHoachVon",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uniqueidentifier",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KeHoachVon_NguonVonId",
+                table: "KeHoachVon",
+                column: "NguonVonId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_KeHoachVon_DmNguonVon_NguonVonId",
+                table: "KeHoachVon",
+                column: "NguonVonId",
+                principalTable: "DmNguonVon",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_KeHoachVon_DmNguonVon_NguonVonId",
+                table: "KeHoachVon");
+
+            migrationBuilder.DropIndex(
+                name: "IX_KeHoachVon_NguonVonId",
+                table: "KeHoachVon");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "NguonVonId",
+                table: "KeHoachVon",
+                type: "uniqueidentifier",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+        }
+    }
+}

--- a/QLDA.Persistence/Configurations/KeHoachVonConfiguration.cs
+++ b/QLDA.Persistence/Configurations/KeHoachVonConfiguration.cs
@@ -30,5 +30,10 @@ public class KeHoachVonConfiguration : IEntityTypeConfiguration<KeHoachVon> {
             .WithMany(e => e.KeHoachVons)
             .HasForeignKey(e => e.DuAnId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(e => e.NguonVon)
+            .WithMany()
+            .HasForeignKey(e => e.NguonVonId)
+            .OnDelete(DeleteBehavior.Restrict);
     }
 }


### PR DESCRIPTION
## Summary
- Fix `KeHoachVon.NguonVonId` type from `Guid?` to `int?` to correctly reference `DanhMucNguonVon` which uses `int` PK
- Add FK navigation property and EF configuration with Restrict delete behavior
- Add migration to alter column type and create FK constraint

## Test plan
- [x] Build passes
- [x] Verify migration applies correctly
- [x] Verify API endpoints work with new int NguonVonId