### PR TITLE
fix(Migration): guid-to-int column conversion for KeHoachVon.NguonVonId

### DIFF
--- a/QLDA.Migrator/Migrations/20260504051400_ChangeKeHoachVonNguonVonIdToInt.cs
+++ b/QLDA.Migrator/Migrations/20260504051400_ChangeKeHoachVonNguonVonIdToInt.cs
@@ -11,14 +11,23 @@ namespace QLDA.Migrator.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AlterColumn<int>(
-                name: "NguonVonId",
+            // SQL Server cannot ALTER COLUMN from uniqueidentifier to int directly.
+            // Workflow: add new int column → drop old guid column → rename new to old name
+
+            migrationBuilder.AddColumn<int>(
+                name: "NguonVonId_New",
                 table: "KeHoachVon",
                 type: "int",
-                nullable: true,
-                oldClrType: typeof(Guid),
-                oldType: "uniqueidentifier",
-                oldNullable: true);
+                nullable: true);
+
+            migrationBuilder.DropColumn(
+                name: "NguonVonId",
+                table: "KeHoachVon");
+
+            migrationBuilder.RenameColumn(
+                name: "NguonVonId_New",
+                table: "KeHoachVon",
+                newName: "NguonVonId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_KeHoachVon_NguonVonId",
@@ -45,14 +54,21 @@ namespace QLDA.Migrator.Migrations
                 name: "IX_KeHoachVon_NguonVonId",
                 table: "KeHoachVon");
 
-            migrationBuilder.AlterColumn<Guid>(
-                name: "NguonVonId",
+            // Reverse: add guid column → drop int column → rename back
+            migrationBuilder.AddColumn<Guid>(
+                name: "NguonVonId_Old",
                 table: "KeHoachVon",
                 type: "uniqueidentifier",
-                nullable: true,
-                oldClrType: typeof(int),
-                oldType: "int",
-                oldNullable: true);
+                nullable: true);
+
+            migrationBuilder.DropColumn(
+                name: "NguonVonId",
+                table: "KeHoachVon");
+
+            migrationBuilder.RenameColumn(
+                name: "NguonVonId_Old",
+                table: "KeHoachVon",
+                newName: "NguonVonId");
         }
     }
 }


### PR DESCRIPTION
## Summary
- SQL Server cannot `ALTER COLUMN` directly from `uniqueidentifier` to `int` — raises error 206 "Operand type clash"
- Fixed migration `20260504051400_ChangeKeHoachVonNguonVonIdToInt` to use add-drop-rename workflow instead of `AlterColumn`
- Both `Up` and `Down` migrations updated with the same pattern

## Changes
- `QLDA.Migrator/Migrations/20260504051400_ChangeKeHoachVonNguonVonIdToInt.cs`
  - **Up:** `AddColumn<int>(NguonVonId_New)` → `DropColumn(NguonVonId)` → `RenameColumn(NguonVonId_New → NguonVonId)` → `CreateIndex` → `AddForeignKey`
  - **Down:** `DropFK` → `DropIndex` → `AddColumn<Guid>(NguonVonId_Old)` → `DropColumn(NguonVonId)` → `RenameColumn(NguonVonId_Old → NguonVonId)`

## Test plan
- [x] Run `dotnet ef database update` against SQL Server — migration should succeed
- [x] Verify `KeHoachVon.NguonVonId` column is `int NULL` after migration
- [x] Verify FK `FK_KeHoachVon_DmNguonVon_NguonVonId` and index exist