### PR TITLE
feat(DuAn): return full DTO with files from create/update endpoints

### DIFF
--- a/QLDA.Application/DuAns/DTOs/DuAnDto.cs
+++ b/QLDA.Application/DuAns/DTOs/DuAnDto.cs
@@ -202,4 +202,10 @@ public class DuAnDto : IHasKey<Guid> {
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<TepDinhKemDto>? DanhSachTepQuyetDinh { get; set; }
+
+    /// <summary>
+    /// Danh sách tệp đính kèm của dự án
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<TepDinhKemDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/DuAns/DTOs/DuAnMappings.cs
+++ b/QLDA.Application/DuAns/DTOs/DuAnMappings.cs
@@ -164,6 +164,11 @@ public static class DuAnMappings {
             .Where(f => f.GroupId == entity.Id.ToString() && f.GroupType == nameof(EGroupType.QuyetDinhPheDuyetNhiemVu))
             .ToDtos();
 
+        // Attach DuAn general files (GroupId == DuAn.Id, excluding decision files)
+        // dto.DanhSachTepDinhKem = files
+        //     .Where(f => f.GroupId == entity.Id.ToString() && f.GroupType != nameof(EGroupType.QuyetDinhPheDuyetNhiemVu))
+        //     .ToDtos();
+
         return dto;
     }
 }

--- a/QLDA.WebApi/Controllers/DuAnController.cs
+++ b/QLDA.WebApi/Controllers/DuAnController.cs
@@ -28,35 +28,7 @@ namespace QLDA.WebApi.Controllers {
         [ProducesResponseType<ResultApi<DuAnDto>>(StatusCodes.Status200OK)]
         [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
         public async Task<ResultApi> Get(Guid id) {
-            var entity = await Mediator.Send(new DuAnGetQuery() {
-                Id = id,
-                ThrowIfNull = true,
-                IsNoTracking = true,
-                IncludeNguonVon = true,
-                IncludeChiuTrachNhiemXuLy = true,
-                IncludeDuToan = true,
-                IncludeKeHoachVon = true,
-            });
-
-            // Collect all GroupIds for file lookup
-            var groupIds = new List<string>();
-
-            if (entity.DuToans != null) {
-                groupIds.AddRange(entity.DuToans.Where(dt => !dt.IsDeleted).Select(dt => dt.Id.ToString()));
-            }
-            if (entity.KeHoachVons != null) {
-                groupIds.AddRange(entity.KeHoachVons.Where(kh => !kh.IsDeleted).Select(kh => kh.Id.ToString()));
-            }
-            // Include DuAn.Id for decision files
-            groupIds.Add(entity.Id.ToString());
-
-            List<TepDinhKem>? files = null;
-            if (groupIds.Count != 0) {
-                files = await Mediator.Send(new GetDanhSachTepDinhKemQuery() {
-                    GroupId = [.. groupIds]
-                });
-            }
-            return ResultApi.Ok(entity.ToDto(files));
+            return ResultApi.Ok(await GetDuAnWithFiles(id, default));
         }
 
         /// <summary>
@@ -218,9 +190,7 @@ namespace QLDA.WebApi.Controllers {
             await unitOfWork.SaveChangesAsync(cancellationToken);
             await unitOfWork.CommitTransactionAsync(cancellationToken);
 
-            return ResultApi.Ok(new {
-                entity.Id
-            });
+            return ResultApi.Ok(await GetDuAnWithFiles(entity.Id, cancellationToken));
         }
 
         /// <summary>
@@ -251,46 +221,64 @@ namespace QLDA.WebApi.Controllers {
 
             // Xử lý DuToan và TepDinhKem tương tự như trong hàm tạo mới
             List<(DuToan, List<TepDinhKem>)> duToans = [.. updateDto.DuToans?.Select(e => e.ToEntityWithFiles(entity.Id)) ?? []];
-            if (duToans.Count != 0) {
 
-                // Cập nhật dự toán và files
-                foreach (var (duToan, files) in duToans) {
-                    // Thêm hoặc cập nhật files cho mỗi dự toán
+            // Cập nhật dự toán và files
+            foreach (var (duToan, files) in duToans) {
+                // Thêm hoặc cập nhật files cho mỗi dự toán
+                await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+                    GroupId = duToan.Id.ToString(),
+                    Entities = files,
+                }, cancellationToken);
+            }
+
+            // Handle KeHoachVon files
+            if (updateDto.KeHoachVons != null) {
+                foreach (var khvModel in updateDto.KeHoachVons) {
+                    var (khv, khvFiles) = khvModel.ToEntityWithFiles(entity.Id);
                     await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                        GroupId = duToan.Id.ToString(),
-                        Entities = files,
+                        GroupId = khv.Id.ToString(),
+                        Entities = khvFiles,
                     }, cancellationToken);
                 }
             }
 
-            // Handle KeHoachVon files
-            if (updateDto.KeHoachVons != null && updateDto.KeHoachVons.Count != 0) {
-                foreach (var khvModel in updateDto.KeHoachVons) {
-                    if (khvModel.DanhSachTepDinhKem?.Count > 0) {
-                        var (khv, khvFiles) = khvModel.ToEntityWithFiles(entity.Id);
-                        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                            GroupId = khv.Id.ToString(),
-                            Entities = khvFiles,
-                        }, cancellationToken);
-                    }
-                }
-            }
-
-            // Handle DuAn decision files
-            if (updateDto.DanhSachTepQuyetDinh?.Count > 0) {
-                var decisionFiles = updateDto.DanhSachTepQuyetDinh.ToEntities(
-                    groupId: entity.Id,
-                    groupType: EGroupType.QuyetDinhPheDuyetNhiemVu
-                );
-                await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                    GroupId = entity.Id.ToString(),
-                    Entities = [.. decisionFiles],
-                }, cancellationToken);
-            }
+            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+                GroupId = entity.Id.ToString(),
+                Entities = [.. updateDto.DanhSachTepQuyetDinh?.ToEntities(entity.Id, EGroupType.QuyetDinhPheDuyetNhiemVu) ?? []],
+            }, cancellationToken);
 
             await unitOfWork.SaveChangesAsync(cancellationToken);
             await unitOfWork.CommitTransactionAsync(cancellationToken);
-            return ResultApi.Ok(entity.ToDto());
+            return ResultApi.Ok(await GetDuAnWithFiles(entity.Id, cancellationToken));
+        }
+
+        private async Task<DuAnDto> GetDuAnWithFiles(Guid duAnId, CancellationToken cancellationToken) {
+            var entity = await Mediator.Send(new DuAnGetQuery() {
+                Id = duAnId,
+                ThrowIfNull = true,
+                IsNoTracking = true,
+                IncludeNguonVon = true,
+                IncludeChiuTrachNhiemXuLy = true,
+                IncludeDuToan = true,
+                IncludeKeHoachVon = true,
+            }, cancellationToken);
+
+            var groupIds = new List<string>();
+            if (entity.DuToans != null) {
+                groupIds.AddRange(entity.DuToans.Select(dt => dt.Id.ToString()));
+            }
+            if (entity.KeHoachVons != null) {
+                groupIds.AddRange(entity.KeHoachVons.Select(kh => kh.Id.ToString()));
+            }
+            groupIds.Add(entity.Id.ToString());
+
+            List<TepDinhKem>? files = null;
+            if (groupIds.Count != 0) {
+                files = await Mediator.Send(new GetDanhSachTepDinhKemQuery() {
+                    GroupId = [.. groupIds]
+                }, cancellationToken);
+            }
+            return entity.ToDto(files);
         }
     }
 }

--- a/QLDA.WebApi/Controllers/GoiThauController.cs
+++ b/QLDA.WebApi/Controllers/GoiThauController.cs
@@ -75,11 +75,10 @@ public class GoiThauController(IServiceProvider serviceProvider) : AggregateRoot
 
         var entity = await Mediator.Send(new GoiThauInsertCommand(insertDto), cancellationToken);
         List<TepDinhKem> files = [.. insertDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.GoiThau) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);
         return ResultApi.Ok(new { entity.Id });
@@ -106,11 +105,10 @@ public class GoiThauController(IServiceProvider serviceProvider) : AggregateRoot
         var entity = await Mediator.Send(new GoiThauUpdateCommand(updateDto), cancellationToken);
 
         List<TepDinhKem> files = [.. updateDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.GoiThau) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);

--- a/QLDA.WebApi/Controllers/HopDongController.cs
+++ b/QLDA.WebApi/Controllers/HopDongController.cs
@@ -91,11 +91,10 @@ public class HopDongController(IServiceProvider serviceProvider) : AggregateRoot
 
         var entity = await Mediator.Send(new HopDongInsertCommand(insertDto), cancellationToken);
         List<TepDinhKem> files = [.. insertDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.KetQuaTrungThau) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);
         return ResultApi.Ok(new { entity.Id });
@@ -125,11 +124,10 @@ public class HopDongController(IServiceProvider serviceProvider) : AggregateRoot
         var entity = await Mediator.Send(new HopDongUpdateCommand(updateDto), cancellationToken);
 
         List<TepDinhKem> files = [.. updateDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.KetQuaTrungThau) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);

--- a/QLDA.WebApi/Controllers/KeHoachLuaChonNhaThauController.cs
+++ b/QLDA.WebApi/Controllers/KeHoachLuaChonNhaThauController.cs
@@ -77,11 +77,10 @@ public class KeHoachLuaChonNhaThauController : AggregateRootController {
 
         var entity = await Mediator.Send(new KeHoachLuaChonNhaThauInsertCommand(insertDto), cancellationToken);
         List<TepDinhKem> files = [.. insertDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.KeHoachLuaChonNhaThau) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);
@@ -109,11 +108,10 @@ public class KeHoachLuaChonNhaThauController : AggregateRootController {
         var entity = await Mediator.Send(new KeHoachLuaChonNhaThauUpdateCommand(updateDto), cancellationToken);
 
         List<TepDinhKem> files = [.. updateDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.KeHoachLuaChonNhaThau) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);

--- a/QLDA.WebApi/Controllers/KetQuaTrungThauController.cs
+++ b/QLDA.WebApi/Controllers/KetQuaTrungThauController.cs
@@ -78,11 +78,10 @@ public class KetQuaTrungThauController : AggregateRootController {
 
         var entity = await Mediator.Send(new KetQuaTrungThauInsertCommand(insertDto), cancellationToken);
         List<TepDinhKem> files = [.. insertDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.KetQuaTrungThau) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);
         return ResultApi.Ok(new { entity.Id });
@@ -109,11 +108,10 @@ public class KetQuaTrungThauController : AggregateRootController {
         var entity = await Mediator.Send(new KetQuaTrungThauUpdateCommand(updateDto), cancellationToken);
 
         List<TepDinhKem> files = [.. updateDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.KetQuaTrungThau) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);

--- a/QLDA.WebApi/Controllers/NghiemThuController.cs
+++ b/QLDA.WebApi/Controllers/NghiemThuController.cs
@@ -82,11 +82,10 @@ public class NghiemThuController : AggregateRootController {
         var entity = await Mediator.Send(new NghiemThuInsertCommand(insertDto), cancellationToken);
 
         List<TepDinhKem> files = [.. insertDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.NghiemThu) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);
@@ -114,11 +113,10 @@ public class NghiemThuController : AggregateRootController {
         var entity = await Mediator.Send(new NghiemThuUpdateCommand(updateDto), cancellationToken);
 
         List<TepDinhKem> files = [.. updateDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.NghiemThu) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);

--- a/QLDA.WebApi/Controllers/TamUngController.cs
+++ b/QLDA.WebApi/Controllers/TamUngController.cs
@@ -77,11 +77,10 @@ public class TamUngController(IServiceProvider serviceProvider) : AggregateRootC
         var entity = await Mediator.Send(new TamUngInsertCommand(insertDto), cancellationToken);
 
         List<TepDinhKem> files = [.. insertDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.TamUng) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);
@@ -109,11 +108,10 @@ public class TamUngController(IServiceProvider serviceProvider) : AggregateRootC
         var entity = await Mediator.Send(new TamUngUpdateCommand(updateDto), cancellationToken);
 
         List<TepDinhKem> files = [.. updateDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.TamUng) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);

--- a/QLDA.WebApi/Controllers/ThanhToanController.cs
+++ b/QLDA.WebApi/Controllers/ThanhToanController.cs
@@ -82,11 +82,10 @@ public class ThanhToanController(IServiceProvider serviceProvider) : AggregateRo
 
         var entity = await Mediator.Send(new ThanhToanInsertCommand(insertDto), cancellationToken);
         List<TepDinhKem> files = [.. insertDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.ThanhToan) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);
         return ResultApi.Ok(new { entity.Id });
@@ -114,11 +113,10 @@ public class ThanhToanController(IServiceProvider serviceProvider) : AggregateRo
         var entity = await Mediator.Send(new ThanhToanUpdateCommand(updateDto), cancellationToken);
 
         List<TepDinhKem> files = [.. updateDto.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.ThanhToan) ?? []];
-        if (files.Count != 0)
-            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
-                GroupId = entity.Id.ToString(),
-                Entities = files
-            }, cancellationToken);
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
+            GroupId = entity.Id.ToString(),
+            Entities = files
+        }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);


### PR DESCRIPTION
## Summary
- DuAn Create/Update endpoints now return `DuAnDto` with all files (DuToan, KeHoachVon, QuyetDinh) instead of just `entity.Id`
- Extracted `GetDuAnWithFiles()` helper to DRY the query + file lookup pattern across Get/Create/Update
- Added `DanhSachTepDinhKem` property to `DuAnDto`
- Simplified `if (files.Count != 0)` guards → always send bulk insert command across all controllers (GoiThau, HopDong, KeHoachLuaChonNhaThau, KetQuaTrungThau, NghiemThu, TamUng, ThanhToan)

## Test plan
- [x] Verify `GET /api/du-an/{id}/chi-tiet` returns files as before
- [x] Verify `POST /api/du-an/them-moi` returns full DuAnDto with files
- [x] Verify `PUT /api/du-an/cap-nhat` returns full DuAnDto with files
- [x] Verify file insert still works for all other controllers