### PR TITLE
feat(dashboard): đổi filter giải ngân theo năm & thêm API chi tiết giải ngân #9450

### DIFF
--- a/QLDA.Application/Dashboard/Queries/DashboardGetChiTietGiaiNganQuery.cs
+++ b/QLDA.Application/Dashboard/Queries/DashboardGetChiTietGiaiNganQuery.cs
@@ -1,0 +1,37 @@
+using QLDA.Domain.DTOs;
+using QLDA.Domain.Interfaces;
+
+namespace QLDA.Application.Dashboard.Queries;
+
+/// <summary>
+/// Query chi tiết giải ngân theo năm
+/// </summary>
+public record DashboardGetChiTietGiaiNganQuery(int Nam) : IRequest<List<DashboardChiTietGiaiNganDto>>;
+
+internal class DashboardGetChiTietGiaiNganQueryHandler(IServiceProvider serviceProvider)
+    : IRequestHandler<DashboardGetChiTietGiaiNganQuery, List<DashboardChiTietGiaiNganDto>> {
+
+    private readonly IDapperRepository _dapper = serviceProvider.GetRequiredService<IDapperRepository>();
+
+    public async Task<List<DashboardChiTietGiaiNganDto>> Handle(
+        DashboardGetChiTietGiaiNganQuery request, CancellationToken cancellationToken) {
+
+        const string sql = """
+            SELECT da.TenDuAn,
+                tt.GiaTri AS GiaTriGiaiNgan,
+                hd.GiaTri AS GiaTriHopDong,
+                tt.NgayHoaDon AS Ngay,
+                CASE WHEN tt.GiaTri > 0 THEN N'Đã giải ngân' ELSE N'Chưa giải ngân' END AS TrangThaiGiaiNgan
+            FROM dbo.ThanhToan tt
+            JOIN dbo.NghiemThu nt ON nt.Id = tt.NghiemThuId
+            JOIN dbo.HopDong hd ON hd.Id = nt.HopDongId
+            JOIN dbo.GoiThau gt ON gt.Id = hd.GoiThauId
+            JOIN dbo.DuAn da ON da.Id = gt.DuAnId
+            WHERE tt.IsDeleted = 0 AND hd.IsDeleted = 0
+            AND YEAR(tt.NgayHoaDon) = @Nam
+            """;
+
+        var result = await _dapper.QueryAsync<DashboardChiTietGiaiNganDto>(sql, new { request.Nam });
+        return [.. result];
+    }
+}

--- a/QLDA.Application/Dashboard/Queries/DashboardGetGiaiNganTheoNguonVonQuery.cs
+++ b/QLDA.Application/Dashboard/Queries/DashboardGetGiaiNganTheoNguonVonQuery.cs
@@ -4,9 +4,9 @@ using QLDA.Domain.Interfaces;
 namespace QLDA.Application.Dashboard.Queries;
 
 /// <summary>
-/// Query thống kê giải ngân theo nguồn vốn cho 1 dự án
+/// Query thống kê giải ngân theo nguồn vốn theo năm
 /// </summary>
-public record DashboardGetGiaiNganTheoNguonVonQuery(Guid DuAnId) : IRequest<List<DashboardGiaiNganTheoNguonVonDto>>;
+public record DashboardGetGiaiNganTheoNguonVonQuery(int Nam) : IRequest<List<DashboardGiaiNganTheoNguonVonDto>>;
 
 internal class DashboardGetGiaiNganTheoNguonVonQueryHandler(IServiceProvider serviceProvider)
     : IRequestHandler<DashboardGetGiaiNganTheoNguonVonQuery, List<DashboardGiaiNganTheoNguonVonDto>> {
@@ -26,11 +26,11 @@ internal class DashboardGetGiaiNganTheoNguonVonQueryHandler(IServiceProvider ser
             JOIN dbo.GoiThau gt ON gt.Id = hd.GoiThauId
             JOIN dbo.DmNguonVon nv ON nv.Id = gt.NguonVonId
             WHERE tt.IsDeleted = 0 AND hd.IsDeleted = 0
-            AND gt.DuAnId = @DuAnId
+            AND YEAR(tt.NgayHoaDon) = @Nam
             GROUP BY gt.NguonVonId, nv.Ten
             """;
 
-        var result = await _dapper.QueryAsync<DashboardGiaiNganTheoNguonVonDto>(sql, new { request.DuAnId });
+        var result = await _dapper.QueryAsync<DashboardGiaiNganTheoNguonVonDto>(sql, new { request.Nam });
         return [.. result];
     }
 }

--- a/QLDA.Domain/DTOs/DashboardGiaiNganDto.cs
+++ b/QLDA.Domain/DTOs/DashboardGiaiNganDto.cs
@@ -9,3 +9,16 @@ public class DashboardGiaiNganTheoNguonVonDto {
     public decimal GiaTriGiaiNgan { get; set; }
     public decimal GiaTriHopDong { get; set; }
 }
+
+/// <summary>
+/// DTO chi tiết giải ngân theo năm
+/// </summary>
+public class DashboardChiTietGiaiNganDto {
+    public string? TenDuAn { get; set; }
+    /// <summary>Số tiền đã giải ngân (ThanhToan.GiaTri)</summary>
+    public decimal GiaTriGiaiNgan { get; set; }
+    /// <summary>Giá trị hợp đồng (HopDong.GiaTri)</summary>
+    public decimal GiaTriHopDong { get; set; }
+    public DateTimeOffset? Ngay { get; set; }
+    public string? TrangThaiGiaiNgan { get; set; }
+}

--- a/QLDA.WebApi/Controllers/DashboardController.cs
+++ b/QLDA.WebApi/Controllers/DashboardController.cs
@@ -111,14 +111,26 @@ public class DashboardController(IServiceProvider serviceProvider)
     }
 
     /// <summary>
-    /// Thống kê giải ngân theo nguồn vốn
+    /// Thống kê giải ngân theo nguồn vốn theo năm
     /// </summary>
-    /// <param name="duAnId">ID dự án (bắt buộc)</param>
+    /// <param name="nam">Năm cần thống kê (bắt buộc)</param>
     /// <returns>Danh sách giải ngân theo nguồn vốn</returns>
     [HttpGet("api/thong-ke/giai-ngan-theo-nguon-von")]
     [ProducesResponseType<ResultApi<List<DashboardGiaiNganTheoNguonVonDto>>>(StatusCodes.Status200OK)]
-    public async Task<ResultApi> GetGiaiNganTheoNguonVon([FromQuery] Guid duAnId) {
-        var result = await Mediator.Send(new DashboardGetGiaiNganTheoNguonVonQuery(duAnId));
+    public async Task<ResultApi> GetGiaiNganTheoNguonVon([FromQuery] int nam) {
+        var result = await Mediator.Send(new DashboardGetGiaiNganTheoNguonVonQuery(nam));
+        return ResultApi.Ok(result);
+    }
+
+    /// <summary>
+    /// Chi tiết giải ngân theo năm
+    /// </summary>
+    /// <param name="nam">Năm cần thống kê (bắt buộc)</param>
+    /// <returns>Danh sách chi tiết giải ngân</returns>
+    [HttpGet("api/thong-ke/chi-tiet-giai-ngan")]
+    [ProducesResponseType<ResultApi<List<DashboardChiTietGiaiNganDto>>>(StatusCodes.Status200OK)]
+    public async Task<ResultApi> GetChiTietGiaiNgan([FromQuery] int nam) {
+        var result = await Mediator.Send(new DashboardGetChiTietGiaiNganQuery(nam));
         return ResultApi.Ok(result);
     }
 


### PR DESCRIPTION
## Summary
- Đổi `DashboardGetGiaiNganTheoNguonVonQuery` từ filter theo `DuAnId` sang filter theo năm (`YEAR(tt.NgayHoaDon) = @Nam`)
- Thêm API `GET api/thong-ke/chi-tiet-giai-ngan?nam={year}` — danh sách chi tiết giải ngân theo năm
- Thêm DTO `DashboardChiTietGiaiNganDto` với các field: TenDuAn, GiaTriGiaiNgan, GiaTriHopDong, Ngay, TrangThaiGiaiNgan

## Changes
- `DashboardGetGiaiNganTheoNguonVonQuery.cs` — đổi param `DuAnId` → `Nam`, filter bằng `YEAR(tt.NgayHoaDon)`
- `DashboardGetChiTietGiaiNganQuery.cs` —新增 chi tiết giải ngân query
- `DashboardGiaiNganDto.cs` — thêm `DashboardChiTietGiaiNganDto`
- `DashboardController.cs` — thêm endpoint chi-tiet-giai-ngan, cập nhật endpoint giai-ngan-theo-nguon-von

## Test plan
- [x] Verify `GET api/thong-ke/giai-ngan-theo-nguon-von?nam=2026` returns data grouped by NguonVon
- [x] Verify `GET api/thong-ke/chi-tiet-giai-ngan?nam=2026` returns detail list with correct field mappings