### PR TITLE
feat(9467): add PhanKhaiKinhPhi PheDuyet workflow

### DIFF
--- a/QLDA.Application/HoSoDeXuatCapDoCntts/Commands/HoSoDeXuatCapDoCnttDuyetCommand.cs
+++ b/QLDA.Application/HoSoDeXuatCapDoCntts/Commands/HoSoDeXuatCapDoCnttDuyetCommand.cs
@@ -27,7 +27,7 @@ internal class HoSoDeXuatCapDoCnttDuyetCommandHandler : IRequestHandler<HoSoDeXu
     }
 
     public async Task<int> Handle(HoSoDeXuatCapDoCnttDuyetCommand request, CancellationToken cancellationToken) {
-        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
+        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LD)) {
             throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền duyệt hồ sơ đề xuất cấp độ CNTT");
         }
 

--- a/QLDA.Application/HoSoDeXuatCapDoCntts/Commands/HoSoDeXuatCapDoCnttTraLaiCommand.cs
+++ b/QLDA.Application/HoSoDeXuatCapDoCntts/Commands/HoSoDeXuatCapDoCnttTraLaiCommand.cs
@@ -27,7 +27,7 @@ internal class HoSoDeXuatCapDoCnttTraLaiCommandHandler : IRequestHandler<HoSoDeX
     }
 
     public async Task<int> Handle(HoSoDeXuatCapDoCnttTraLaiCommand request, CancellationToken cancellationToken) {
-        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
+        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LD)) {
             throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền trả lại hồ sơ đề xuất cấp độ CNTT");
         }
 

--- a/QLDA.Application/HoSoDeXuatCapDoCntts/Commands/HoSoDeXuatCapDoCnttTuChoiCommand.cs
+++ b/QLDA.Application/HoSoDeXuatCapDoCntts/Commands/HoSoDeXuatCapDoCnttTuChoiCommand.cs
@@ -1,6 +1,7 @@
 using BuildingBlocks.Domain.Providers;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common;
+using QLDA.Application.Providers;
 using QLDA.Domain.Constants;
 using QLDA.Domain.Entities.DanhMuc;
 
@@ -16,6 +17,7 @@ internal class HoSoDeXuatCapDoCnttTuChoiCommandHandler : IRequestHandler<HoSoDeX
     private readonly IRepository<PheDuyetHistory, Guid> _historyRepository;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepository;
     private readonly IUserProvider _userProvider;
+    private readonly IAppSettingsProvider _settings;
     private readonly IUnitOfWork _unitOfWork;
 
     public HoSoDeXuatCapDoCnttTuChoiCommandHandler(IServiceProvider serviceProvider) {
@@ -23,12 +25,16 @@ internal class HoSoDeXuatCapDoCnttTuChoiCommandHandler : IRequestHandler<HoSoDeX
         _historyRepository = serviceProvider.GetRequiredService<IRepository<PheDuyetHistory, Guid>>();
         _statusRepository = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _userProvider = serviceProvider.GetRequiredService<IUserProvider>();
+        _settings = serviceProvider.GetRequiredService<IAppSettingsProvider>();
         _unitOfWork = _repository.UnitOfWork;
     }
 
     public async Task<int> Handle(HoSoDeXuatCapDoCnttTuChoiCommand request, CancellationToken cancellationToken) {
-        var roles = _userProvider.AuthInfo?.Roles ?? [];
-        if (!roles.Contains(Domain.Constants.RoleConstants.QLDA_LDDV) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_HC_TH) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_QuanTri)) {
+        // Permission: QLDA_LD, P.HC-TH (by PhongBanID), or QLDA_QuanTri
+        var isHcth = _userProvider.Info.PhongBanID == _settings.PhongHCTHID;
+        var isLanhDao = _userProvider.AuthInfo?.HasRole(QLDA.Domain.Constants.RoleConstants.QLDA_LD) ?? false;
+        var isQuanTri = _userProvider.AuthInfo?.HasRole(QLDA.Domain.Constants.RoleConstants.QLDA_QuanTri) ?? false;
+        if (!isLanhDao && !isHcth && !isQuanTri) {
             throw new ManagedException("Chỉ quản lý có quyền từ chối hồ sơ đề xuất cấp độ CNTT");
         }
 

--- a/QLDA.Application/HoSoDeXuatCapDoCntts/DTOs/HoSoDeXuatCapDoCnttDto.cs
+++ b/QLDA.Application/HoSoDeXuatCapDoCntts/DTOs/HoSoDeXuatCapDoCnttDto.cs
@@ -8,6 +8,7 @@ public class HoSoDeXuatCapDoCnttDto {
     public Guid DuAnId { get; set; }
     public int? BuocId { get; set; }
     public int? TrangThaiId { get; set; }
+    public string? TenTrangThai { get; set; }
     public int? CapDoId { get; set; }
     public string? TenCapDo { get; set; }
     public DateTime? NgayTrinh { get; set; }

--- a/QLDA.Application/HoSoDeXuatCapDoCntts/DTOs/HoSoDeXuatCapDoCnttMappings.cs
+++ b/QLDA.Application/HoSoDeXuatCapDoCntts/DTOs/HoSoDeXuatCapDoCnttMappings.cs
@@ -1,4 +1,5 @@
 using QLDA.Application.Common.DTOs;
+using QLDA.Domain.Constants;
 
 namespace QLDA.Application.HoSoDeXuatCapDoCntts.DTOs;
 
@@ -41,6 +42,7 @@ public static class HoSoDeXuatCapDoCnttMappings
         DonViChuTriId = entity.DonViChuTriId,
         NoiDungDeNghi = entity.NoiDungDeNghi,
         NoiDungBaoCao = entity.NoiDungBaoCao,
-        NoiDungDuThao = entity.NoiDungDuThao,  
+        NoiDungDuThao = entity.NoiDungDuThao,
+        TenTrangThai = entity.TrangThaiId == null ? TrangThaiPheDuyetCodes.Default.TenDuThao : entity.TrangThai?.Ten,
     };
 }

--- a/QLDA.Application/HoSoMoiThauDienTus/Commands/HoSoMoiThauDienTuDuyetCommand.cs
+++ b/QLDA.Application/HoSoMoiThauDienTus/Commands/HoSoMoiThauDienTuDuyetCommand.cs
@@ -27,7 +27,7 @@ internal class HoSoMoiThauDienTuDuyetCommandHandler : IRequestHandler<HoSoMoiTha
     }
 
     public async Task<int> Handle(HoSoMoiThauDienTuDuyetCommand request, CancellationToken cancellationToken) {
-        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
+        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LD)) {
             throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền duyệt hồ sơ mời thầu điện tử");
         }
 

--- a/QLDA.Application/HoSoMoiThauDienTus/Commands/HoSoMoiThauDienTuTraLaiCommand.cs
+++ b/QLDA.Application/HoSoMoiThauDienTus/Commands/HoSoMoiThauDienTuTraLaiCommand.cs
@@ -27,7 +27,7 @@ internal class HoSoMoiThauDienTuTraLaiCommandHandler : IRequestHandler<HoSoMoiTh
     }
 
     public async Task<int> Handle(HoSoMoiThauDienTuTraLaiCommand request, CancellationToken cancellationToken) {
-        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
+        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LD)) {
             throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền trả lại hồ sơ mời thầu điện tử");
         }
 

--- a/QLDA.Application/HoSoMoiThauDienTus/Commands/HoSoMoiThauDienTuTuChoiCommand.cs
+++ b/QLDA.Application/HoSoMoiThauDienTus/Commands/HoSoMoiThauDienTuTuChoiCommand.cs
@@ -1,6 +1,7 @@
 using BuildingBlocks.Domain.Providers;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common;
+using QLDA.Application.Providers;
 using QLDA.Domain.Constants;
 using QLDA.Domain.Entities.DanhMuc;
 
@@ -16,6 +17,7 @@ internal class HoSoMoiThauDienTuTuChoiCommandHandler : IRequestHandler<HoSoMoiTh
     private readonly IRepository<PheDuyetHistory, Guid> _historyRepository;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepository;
     private readonly IUserProvider _userProvider;
+    private readonly IAppSettingsProvider _settings;
     private readonly IUnitOfWork _unitOfWork;
 
     public HoSoMoiThauDienTuTuChoiCommandHandler(IServiceProvider serviceProvider) {
@@ -23,12 +25,16 @@ internal class HoSoMoiThauDienTuTuChoiCommandHandler : IRequestHandler<HoSoMoiTh
         _historyRepository = serviceProvider.GetRequiredService<IRepository<PheDuyetHistory, Guid>>();
         _statusRepository = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _userProvider = serviceProvider.GetRequiredService<IUserProvider>();
+        _settings = serviceProvider.GetRequiredService<IAppSettingsProvider>();
         _unitOfWork = _repository.UnitOfWork;
     }
 
     public async Task<int> Handle(HoSoMoiThauDienTuTuChoiCommand request, CancellationToken cancellationToken) {
-        var roles = _userProvider.AuthInfo?.Roles ?? [];
-        if (!roles.Contains(Domain.Constants.RoleConstants.QLDA_LDDV) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_HC_TH) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_QuanTri)) {
+        // Permission: QLDA_LD, P.HC-TH (by PhongBanID), or QLDA_QuanTri
+        var isHcth = _userProvider.Info.PhongBanID == _settings.PhongHCTHID;
+        var isLanhDao = _userProvider.AuthInfo?.HasRole(QLDA.Domain.Constants.RoleConstants.QLDA_LD) ?? false;
+        var isQuanTri = _userProvider.AuthInfo?.HasRole(QLDA.Domain.Constants.RoleConstants.QLDA_QuanTri) ?? false;
+        if (!isLanhDao && !isHcth && !isQuanTri) {
             throw new ManagedException("Chỉ quản lý có quyền từ chối hồ sơ mời thầu điện tử");
         }
 

--- a/QLDA.Application/HoSoMoiThauDienTus/DTOs/HoSoMoiThauDienTuMappings.cs
+++ b/QLDA.Application/HoSoMoiThauDienTus/DTOs/HoSoMoiThauDienTuMappings.cs
@@ -1,4 +1,5 @@
 using QLDA.Application.TepDinhKems.DTOs;
+using QLDA.Domain.Constants;
 
 namespace QLDA.Application.HoSoMoiThauDienTus.DTOs;
 
@@ -44,7 +45,7 @@ public static class HoSoMoiThauDienTuMappings {
         ThoiGianThucHien = entity.ThoiGianThucHien,
         TrangThaiDangTai = entity.TrangThaiDangTai,
         TrangThaiId = entity.TrangThaiId,
-        TenTrangThai = entity.TrangThaiPheDuyet?.Ten,
+        TenTrangThai = entity.TrangThaiId == null ? TrangThaiPheDuyetCodes.Default.TenDuThao : entity.TrangThaiPheDuyet?.Ten,
         DanhSachTepDinhKem = files?.Select(f => new TepDinhKemDto {
             Id = f.Id,
             ParentId = f.ParentId,

--- a/QLDA.Application/NghiemThus/Commands/NghiemThuUpdateCommand.cs
+++ b/QLDA.Application/NghiemThus/Commands/NghiemThuUpdateCommand.cs
@@ -1,6 +1,7 @@
 using System.Data;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.NghiemThus.DTOs;
+using QLDA.Domain.Entities;
 
 namespace QLDA.Application.NghiemThus.Commands;
 
@@ -21,11 +22,22 @@ internal class NghiemThuUpdateCommandHandler : IRequestHandler<NghiemThuUpdateCo
     public async Task<NghiemThu> Handle(NghiemThuUpdateCommand request, CancellationToken cancellationToken = default) {
         await ValidateAsync(request, cancellationToken);
 
+        // Use AsNoTracking to avoid EF tracking conflicts with junction table
         var entity = await NghiemThu.GetQueryableSet()
+            .AsNoTracking()
             .FirstOrDefaultAsync(e => e.Id == request.Dto.Id, cancellationToken);
         ManagedException.ThrowIfNull(entity);
 
-        entity.Update(request.Dto);
+        // Update scalar properties only (not navigation collections)
+        entity.HopDongId = request.Dto.HopDongId;
+        entity.SoBienBan = request.Dto.SoBienBan;
+        entity.Dot = request.Dto.Dot;
+        entity.Ngay = request.Dto.Ngay;
+        entity.NoiDung = request.Dto.NoiDung;
+        entity.GiaTri = request.Dto.GiaTri;
+
+        // Sync junction table via raw delete/insert to avoid EF tracking issues
+        await SyncNghiemThuPhuLucHopDongAsync(entity.Id, request.Dto.PhuLucHopDongIds, cancellationToken);
 
         if (_unitOfWork.HasTransaction) {
             await UpdateAsync(entity, cancellationToken);
@@ -36,6 +48,36 @@ internal class NghiemThuUpdateCommandHandler : IRequestHandler<NghiemThuUpdateCo
             await _unitOfWork.CommitTransactionAsync(cancellationToken);
         }
         return entity;
+    }
+
+    private async Task SyncNghiemThuPhuLucHopDongAsync(Guid nghiemThuId, List<Guid>? newPhuLucHopDongIds, CancellationToken cancellationToken) {
+        var dbContext = NghiemThu.UnitOfWork as DbContext;
+        if (dbContext == null) return;
+
+        // Delete existing junction records for this NghiemThu
+        var existingRecords = await dbContext.Set<NghiemThuPhuLucHopDong>()
+            .Where(x => x.LeftId == nghiemThuId)
+            .ToListAsync(cancellationToken);
+
+        if (existingRecords.Any()) {
+            dbContext.Set<NghiemThuPhuLucHopDong>().RemoveRange(existingRecords);
+        }
+
+        // Insert new junction records (only if not already existing)
+        if (newPhuLucHopDongIds?.Any() == true) {
+            var existingRightIds = existingRecords.Select(x => x.RightId).ToHashSet();
+            var newRecords = newPhuLucHopDongIds
+                .Where(id => !existingRightIds.Contains(id))
+                .Select(phuLucId => new NghiemThuPhuLucHopDong {
+                    LeftId = nghiemThuId,
+                    RightId = phuLucId
+                })
+                .ToList();
+
+            if (newRecords.Any()) {
+                await dbContext.Set<NghiemThuPhuLucHopDong>().AddRangeAsync(newRecords, cancellationToken);
+            }
+        }
     }
 
     #region  Private helper methods

--- a/QLDA.Application/NghiemThus/NghiemThuMappings.cs
+++ b/QLDA.Application/NghiemThus/NghiemThuMappings.cs
@@ -62,9 +62,13 @@ public static class NghiemThuMappings {
         entity.Ngay = dto.Ngay;
         entity.NoiDung = dto.NoiDung;
         entity.GiaTri = dto.GiaTri;
-        entity.NghiemThuPhuLucHopDongs = [..dto.PhuLucHopDongIds?.Select(phuLucHopDongId => new NghiemThuPhuLucHopDong{
-            LeftId = dto.Id,
-            RightId = phuLucHopDongId
-        })?? []];
+        // Clear existing junction records to avoid duplicate key violations
+        entity.NghiemThuPhuLucHopDongs?.Clear();
+        if (dto.PhuLucHopDongIds?.Any() == true) {
+            entity.NghiemThuPhuLucHopDongs = [..dto.PhuLucHopDongIds.Select(phuLucHopDongId => new NghiemThuPhuLucHopDong{
+                LeftId = dto.Id,
+                RightId = phuLucHopDongId
+            })];
+        }
     }
 }

--- a/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiDuyetCommand.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiDuyetCommand.cs
@@ -28,7 +28,7 @@ internal class PhanKhaiKinhPhiDuyetCommandHandler : IRequestHandler<PhanKhaiKinh
 
     public async Task<int> Handle(PhanKhaiKinhPhiDuyetCommand request, CancellationToken cancellationToken) {
         // Permission check: LDDV role only
-        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
+        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LD)) {
             throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền duyệt phân khai kinh phí");
         }
 

--- a/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiDuyetCommand.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiDuyetCommand.cs
@@ -4,39 +4,39 @@ using QLDA.Application.Common;
 using QLDA.Domain.Constants;
 using QLDA.Domain.Entities.DanhMuc;
 
-namespace QLDA.Application.PheDuyetDuToans.Commands;
+namespace QLDA.Application.PhanKhaiKinhPhis.Commands;
 
 /// <summary>
-/// Duyệt phê duyệt dự toán - chỉ BGĐ role
+/// Duyệt phân khai kinh phí - LDDV role
 /// </summary>
-public record PheDuyetDuToanDuyetCommand(Guid Id) : IRequest<int>;
+public record PhanKhaiKinhPhiDuyetCommand(Guid Id) : IRequest<int>;
 
-internal class PheDuyetDuToanDuyetCommandHandler : IRequestHandler<PheDuyetDuToanDuyetCommand, int> {
-    private readonly IRepository<PheDuyetDuToan, Guid> _repository;
+internal class PhanKhaiKinhPhiDuyetCommandHandler : IRequestHandler<PhanKhaiKinhPhiDuyetCommand, int> {
+    private readonly IRepository<Domain.Entities.PhanKhaiKinhPhi, Guid> _repository;
     private readonly IRepository<PheDuyetHistory, Guid> _historyRepository;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepository;
     private readonly IUserProvider _userProvider;
     private readonly IUnitOfWork _unitOfWork;
 
-    public PheDuyetDuToanDuyetCommandHandler(IServiceProvider serviceProvider) {
-        _repository = serviceProvider.GetRequiredService<IRepository<PheDuyetDuToan, Guid>>();
+    public PhanKhaiKinhPhiDuyetCommandHandler(IServiceProvider serviceProvider) {
+        _repository = serviceProvider.GetRequiredService<IRepository<Domain.Entities.PhanKhaiKinhPhi, Guid>>();
         _historyRepository = serviceProvider.GetRequiredService<IRepository<PheDuyetHistory, Guid>>();
         _statusRepository = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _userProvider = serviceProvider.GetRequiredService<IUserProvider>();
         _unitOfWork = _repository.UnitOfWork;
     }
 
-    public async Task<int> Handle(PheDuyetDuToanDuyetCommand request, CancellationToken cancellationToken) {
+    public async Task<int> Handle(PhanKhaiKinhPhiDuyetCommand request, CancellationToken cancellationToken) {
         // Permission check: LDDV role only
         if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
-            throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền duyệt phê duyệt dự toán");
+            throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền duyệt phân khai kinh phí");
         }
 
         // Get status IDs from DB by code
         var trangThaiDaTrinh = await _statusRepository.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
-            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DuToan.DaTrinh && s.Loai == PheDuyetEntityNames.PheDuyetDuToan, cancellationToken);
+            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.PhanKhaiKinhPhi.DaTrinh && s.Loai == PheDuyetEntityNames.PhanKhaiKinhPhi, cancellationToken);
         var trangThaiDaDuyet = await _statusRepository.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
-            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DuToan.DaDuyet && s.Loai == PheDuyetEntityNames.PheDuyetDuToan, cancellationToken);
+            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.PhanKhaiKinhPhi.DaDuyet && s.Loai == PheDuyetEntityNames.PhanKhaiKinhPhi, cancellationToken);
 
         ManagedException.ThrowIfNull(trangThaiDaTrinh, "Không tìm thấy trạng thái 'Đã trình'");
         ManagedException.ThrowIfNull(trangThaiDaDuyet, "Không tìm thấy trạng thái 'Đã duyệt'");
@@ -44,7 +44,7 @@ internal class PheDuyetDuToanDuyetCommandHandler : IRequestHandler<PheDuyetDuToa
         var entity = await _repository.GetQueryableSet()
             .FirstOrDefaultAsync(e => e.Id == request.Id, cancellationToken);
 
-        ManagedException.ThrowIfNull(entity, "Không tìm thấy phê duyệt dự toán");
+        ManagedException.ThrowIfNull(entity, "Không tìm thấy phân khai kinh phí");
 
         // Validate current status must be Đã trình
         if (entity.TrangThaiId != trangThaiDaTrinh.Id) {
@@ -57,7 +57,7 @@ internal class PheDuyetDuToanDuyetCommandHandler : IRequestHandler<PheDuyetDuToa
         // Create history record
         var history = new PheDuyetHistory {
             Id = Guid.NewGuid(),
-            EntityName = PheDuyetEntityNames.PheDuyetDuToan,
+            EntityName = PheDuyetEntityNames.PhanKhaiKinhPhi,
             EntityId = entity.Id,
             DuAnId = entity.DuAnId,
             NguoiXuLyId = _userProvider.Info.UserID,

--- a/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTraLaiCommand.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTraLaiCommand.cs
@@ -28,7 +28,7 @@ internal class PhanKhaiKinhPhiTraLaiCommandHandler : IRequestHandler<PhanKhaiKin
 
     public async Task<int> Handle(PhanKhaiKinhPhiTraLaiCommand request, CancellationToken cancellationToken) {
         // Permission check: LDDV role only
-        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
+        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LD)) {
             throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền trả lại phân khai kinh phí");
         }
 

--- a/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTraLaiCommand.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTraLaiCommand.cs
@@ -2,33 +2,34 @@ using BuildingBlocks.Domain.Providers;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common;
 using QLDA.Domain.Constants;
+using QLDA.Domain.Entities.DanhMuc;
 
-namespace QLDA.Application.PheDuyetDuToans.Commands;
+namespace QLDA.Application.PhanKhaiKinhPhis.Commands;
 
 /// <summary>
-/// Trả lại phê duyệt dự toán - chỉ BGĐ role, cần lý do
+/// Trả lại phân khai kinh phí - LDDV role, cần lý do
 /// </summary>
-public record PheDuyetDuToanTraLaiCommand(Guid Id, string NoiDung) : IRequest<int>;
+public record PhanKhaiKinhPhiTraLaiCommand(Guid Id, string NoiDung) : IRequest<int>;
 
-internal class PheDuyetDuToanTraLaiCommandHandler : IRequestHandler<PheDuyetDuToanTraLaiCommand, int> {
-    private readonly IRepository<PheDuyetDuToan, Guid> _repository;
+internal class PhanKhaiKinhPhiTraLaiCommandHandler : IRequestHandler<PhanKhaiKinhPhiTraLaiCommand, int> {
+    private readonly IRepository<Domain.Entities.PhanKhaiKinhPhi, Guid> _repository;
     private readonly IRepository<PheDuyetHistory, Guid> _historyRepository;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepository;
     private readonly IUserProvider _userProvider;
     private readonly IUnitOfWork _unitOfWork;
 
-    public PheDuyetDuToanTraLaiCommandHandler(IServiceProvider serviceProvider) {
-        _repository = serviceProvider.GetRequiredService<IRepository<PheDuyetDuToan, Guid>>();
+    public PhanKhaiKinhPhiTraLaiCommandHandler(IServiceProvider serviceProvider) {
+        _repository = serviceProvider.GetRequiredService<IRepository<Domain.Entities.PhanKhaiKinhPhi, Guid>>();
         _historyRepository = serviceProvider.GetRequiredService<IRepository<PheDuyetHistory, Guid>>();
         _statusRepository = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _userProvider = serviceProvider.GetRequiredService<IUserProvider>();
         _unitOfWork = _repository.UnitOfWork;
     }
 
-    public async Task<int> Handle(PheDuyetDuToanTraLaiCommand request, CancellationToken cancellationToken) {
+    public async Task<int> Handle(PhanKhaiKinhPhiTraLaiCommand request, CancellationToken cancellationToken) {
         // Permission check: LDDV role only
         if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
-            throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền trả lại phê duyệt dự toán");
+            throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền trả lại phân khai kinh phí");
         }
 
         // Validate NoiDung is required
@@ -38,9 +39,9 @@ internal class PheDuyetDuToanTraLaiCommandHandler : IRequestHandler<PheDuyetDuTo
 
         // Get status IDs from DB by code
         var trangThaiDaTrinh = await _statusRepository.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
-            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DuToan.DaTrinh && s.Loai == PheDuyetEntityNames.PheDuyetDuToan, cancellationToken);
+            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.PhanKhaiKinhPhi.DaTrinh && s.Loai == PheDuyetEntityNames.PhanKhaiKinhPhi, cancellationToken);
         var trangThaiTraLai = await _statusRepository.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
-            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DuToan.TraLai && s.Loai == PheDuyetEntityNames.PheDuyetDuToan, cancellationToken);
+            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.PhanKhaiKinhPhi.TraLai && s.Loai == PheDuyetEntityNames.PhanKhaiKinhPhi, cancellationToken);
 
         ManagedException.ThrowIfNull(trangThaiDaTrinh, "Không tìm thấy trạng thái 'Đã trình'");
         ManagedException.ThrowIfNull(trangThaiTraLai, "Không tìm thấy trạng thái 'Trả lại'");
@@ -48,7 +49,7 @@ internal class PheDuyetDuToanTraLaiCommandHandler : IRequestHandler<PheDuyetDuTo
         var entity = await _repository.GetQueryableSet()
             .FirstOrDefaultAsync(e => e.Id == request.Id, cancellationToken);
 
-        ManagedException.ThrowIfNull(entity, "Không tìm thấy phê duyệt dự toán");
+        ManagedException.ThrowIfNull(entity, "Không tìm thấy phân khai kinh phí");
 
         // Validate current status must be Đã trình
         if (entity.TrangThaiId != trangThaiDaTrinh.Id) {
@@ -61,7 +62,7 @@ internal class PheDuyetDuToanTraLaiCommandHandler : IRequestHandler<PheDuyetDuTo
         // Create history record with reason
         var history = new PheDuyetHistory {
             Id = Guid.NewGuid(),
-            EntityName = PheDuyetEntityNames.PheDuyetDuToan,
+            EntityName = PheDuyetEntityNames.PhanKhaiKinhPhi,
             EntityId = entity.Id,
             DuAnId = entity.DuAnId,
             NguoiXuLyId = _userProvider.Info.UserID,

--- a/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTrinhCommand.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTrinhCommand.cs
@@ -1,0 +1,75 @@
+using BuildingBlocks.Domain.Providers;
+using Microsoft.EntityFrameworkCore;
+using QLDA.Application.Common;
+using QLDA.Domain.Constants;
+using QLDA.Domain.Entities.DanhMuc;
+
+namespace QLDA.Application.PhanKhaiKinhPhis.Commands;
+
+/// <summary>
+/// Trình phân khai kinh phí - chỉ phòng KH-TC (PhongBanId = 219)
+/// </summary>
+public record PhanKhaiKinhPhiTrinhCommand(Guid Id, string? NoiDung = null) : IRequest<int>;
+
+internal class PhanKhaiKinhPhiTrinhCommandHandler : IRequestHandler<PhanKhaiKinhPhiTrinhCommand, int> {
+    private readonly IRepository<Domain.Entities.PhanKhaiKinhPhi, Guid> _repository;
+    private readonly IRepository<PheDuyetHistory, Guid> _historyRepository;
+    private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepository;
+    private readonly IUserProvider _userProvider;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public PhanKhaiKinhPhiTrinhCommandHandler(IServiceProvider serviceProvider) {
+        _repository = serviceProvider.GetRequiredService<IRepository<Domain.Entities.PhanKhaiKinhPhi, Guid>>();
+        _historyRepository = serviceProvider.GetRequiredService<IRepository<PheDuyetHistory, Guid>>();
+        _statusRepository = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
+        _userProvider = serviceProvider.GetRequiredService<IUserProvider>();
+        _unitOfWork = _repository.UnitOfWork;
+    }
+
+    public async Task<int> Handle(PhanKhaiKinhPhiTrinhCommand request, CancellationToken cancellationToken) {
+        // Permission check: KH-TC only (PhongBanId = 219)
+        var phongBanId = _userProvider.Info.PhongBanID;
+        if (phongBanId != 219) {
+            throw new ManagedException("Chỉ phòng KH-TC có quyền trình phân khai kinh phí");
+        }
+
+        // Get status IDs from DB by code
+        var trangThaiDuThao = await _statusRepository.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
+            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.PhanKhaiKinhPhi.DuThao && s.Loai == PheDuyetEntityNames.PhanKhaiKinhPhi, cancellationToken);
+        var trangThaiTraLai = await _statusRepository.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
+            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.PhanKhaiKinhPhi.TraLai && s.Loai == PheDuyetEntityNames.PhanKhaiKinhPhi, cancellationToken);
+        var trangThaiDaTrinh = await _statusRepository.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
+            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.PhanKhaiKinhPhi.DaTrinh && s.Loai == PheDuyetEntityNames.PhanKhaiKinhPhi, cancellationToken);
+
+        ManagedException.ThrowIfNull(trangThaiDaTrinh, "Không tìm thấy trạng thái 'Đã trình'");
+
+        var entity = await _repository.GetQueryableSet()
+            .FirstOrDefaultAsync(e => e.Id == request.Id, cancellationToken);
+
+        ManagedException.ThrowIfNull(entity, "Không tìm thấy phân khai kinh phí");
+
+        // Validate current status must be Dự thảo or Trả lại
+        if (entity.TrangThaiId != trangThaiDuThao?.Id && entity.TrangThaiId != trangThaiTraLai?.Id) {
+            throw new ManagedException("Chỉ có thể trình khi trạng thái là Dự thảo hoặc Trả lại");
+        }
+
+        // Update status to Đã trình
+        entity.TrangThaiId = trangThaiDaTrinh.Id;
+
+        // Create history record
+        var history = new PheDuyetHistory {
+            Id = Guid.NewGuid(),
+            EntityName = PheDuyetEntityNames.PhanKhaiKinhPhi,
+            EntityId = entity.Id,
+            DuAnId = entity.DuAnId,
+            NguoiXuLyId = _userProvider.Info.UserID,
+            TrangThaiId = trangThaiDaTrinh.Id,
+            NoiDung = request.NoiDung,
+            NgayXuLy = DateTimeOffset.UtcNow
+        };
+
+        await _historyRepository.AddAsync(history);
+
+        return await _unitOfWork.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTuChoiCommand.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTuChoiCommand.cs
@@ -1,6 +1,7 @@
 using BuildingBlocks.Domain.Providers;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common;
+using QLDA.Application.Providers;
 using QLDA.Domain.Constants;
 using QLDA.Domain.Entities.DanhMuc;
 
@@ -16,6 +17,7 @@ internal class PhanKhaiKinhPhiTuChoiCommandHandler : IRequestHandler<PhanKhaiKin
     private readonly IRepository<PheDuyetHistory, Guid> _historyRepository;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepository;
     private readonly IUserProvider _userProvider;
+    private readonly IAppSettingsProvider _settings;
     private readonly IUnitOfWork _unitOfWork;
 
     public PhanKhaiKinhPhiTuChoiCommandHandler(IServiceProvider serviceProvider) {
@@ -23,13 +25,16 @@ internal class PhanKhaiKinhPhiTuChoiCommandHandler : IRequestHandler<PhanKhaiKin
         _historyRepository = serviceProvider.GetRequiredService<IRepository<PheDuyetHistory, Guid>>();
         _statusRepository = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _userProvider = serviceProvider.GetRequiredService<IUserProvider>();
+        _settings = serviceProvider.GetRequiredService<IAppSettingsProvider>();
         _unitOfWork = _repository.UnitOfWork;
     }
 
     public async Task<int> Handle(PhanKhaiKinhPhiTuChoiCommand request, CancellationToken cancellationToken) {
-        // Permission check: management roles only (LDDV, HC_TH, QuanTri)
-        var roles = _userProvider.AuthInfo?.Roles ?? [];
-        if (!roles.Contains(Domain.Constants.RoleConstants.QLDA_LDDV) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_HC_TH) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_QuanTri)) {
+        // Permission: QLDA_LD, P.HC-TH (by PhongBanID), or QLDA_QuanTri
+        var isHcth = _userProvider.Info.PhongBanID == _settings.PhongHCTHID;
+        var isLanhDao = _userProvider.AuthInfo?.HasRole(QLDA.Domain.Constants.RoleConstants.QLDA_LD) ?? false;
+        var isQuanTri = _userProvider.AuthInfo?.HasRole(QLDA.Domain.Constants.RoleConstants.QLDA_QuanTri) ?? false;
+        if (!isLanhDao && !isHcth && !isQuanTri) {
             throw new ManagedException("Chỉ quản lý có quyền từ chối phân khai kinh phí");
         }
 

--- a/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTuChoiCommand.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Commands/PhanKhaiKinhPhiTuChoiCommand.cs
@@ -4,33 +4,33 @@ using QLDA.Application.Common;
 using QLDA.Domain.Constants;
 using QLDA.Domain.Entities.DanhMuc;
 
-namespace QLDA.Application.PheDuyetDuToans.Commands;
+namespace QLDA.Application.PhanKhaiKinhPhis.Commands;
 
 /// <summary>
-/// Từ chối phê duyệt dự toán - tất cả roles quản lý, cần lý do
+/// Từ chối phân khai kinh phí - tất cả roles quản lý, cần lý do
 /// </summary>
-public record PheDuyetDuToanTuChoiCommand(Guid Id, string NoiDung) : IRequest<int>;
+public record PhanKhaiKinhPhiTuChoiCommand(Guid Id, string NoiDung) : IRequest<int>;
 
-internal class PheDuyetDuToanTuChoiCommandHandler : IRequestHandler<PheDuyetDuToanTuChoiCommand, int> {
-    private readonly IRepository<PheDuyetDuToan, Guid> _repository;
+internal class PhanKhaiKinhPhiTuChoiCommandHandler : IRequestHandler<PhanKhaiKinhPhiTuChoiCommand, int> {
+    private readonly IRepository<Domain.Entities.PhanKhaiKinhPhi, Guid> _repository;
     private readonly IRepository<PheDuyetHistory, Guid> _historyRepository;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepository;
     private readonly IUserProvider _userProvider;
     private readonly IUnitOfWork _unitOfWork;
 
-    public PheDuyetDuToanTuChoiCommandHandler(IServiceProvider serviceProvider) {
-        _repository = serviceProvider.GetRequiredService<IRepository<PheDuyetDuToan, Guid>>();
+    public PhanKhaiKinhPhiTuChoiCommandHandler(IServiceProvider serviceProvider) {
+        _repository = serviceProvider.GetRequiredService<IRepository<Domain.Entities.PhanKhaiKinhPhi, Guid>>();
         _historyRepository = serviceProvider.GetRequiredService<IRepository<PheDuyetHistory, Guid>>();
         _statusRepository = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _userProvider = serviceProvider.GetRequiredService<IUserProvider>();
         _unitOfWork = _repository.UnitOfWork;
     }
 
-    public async Task<int> Handle(PheDuyetDuToanTuChoiCommand request, CancellationToken cancellationToken) {
-        // Permission check: management roles only
+    public async Task<int> Handle(PhanKhaiKinhPhiTuChoiCommand request, CancellationToken cancellationToken) {
+        // Permission check: management roles only (LDDV, HC_TH, QuanTri)
         var roles = _userProvider.AuthInfo?.Roles ?? [];
         if (!roles.Contains(Domain.Constants.RoleConstants.QLDA_LDDV) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_HC_TH) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_QuanTri)) {
-            throw new ManagedException("Chỉ quản lý có quyền từ chối phê duyệt dự toán");
+            throw new ManagedException("Chỉ quản lý có quyền từ chối phân khai kinh phí");
         }
 
         if (string.IsNullOrWhiteSpace(request.NoiDung)) {
@@ -38,9 +38,9 @@ internal class PheDuyetDuToanTuChoiCommandHandler : IRequestHandler<PheDuyetDuTo
         }
 
         var trangThaiDaTrinh = await _statusRepository.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
-            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DuToan.DaTrinh && s.Loai == PheDuyetEntityNames.PheDuyetDuToan, cancellationToken);
+            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.PhanKhaiKinhPhi.DaTrinh && s.Loai == PheDuyetEntityNames.PhanKhaiKinhPhi, cancellationToken);
         var trangThaiTuChoi = await _statusRepository.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
-            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DuToan.TuChoi && s.Loai == PheDuyetEntityNames.PheDuyetDuToan, cancellationToken);
+            .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.PhanKhaiKinhPhi.TraLai && s.Loai == PheDuyetEntityNames.PhanKhaiKinhPhi, cancellationToken);
 
         ManagedException.ThrowIfNull(trangThaiDaTrinh, "Không tìm thấy trạng thái 'Đã trình'");
         ManagedException.ThrowIfNull(trangThaiTuChoi, "Không tìm thấy trạng thái 'Từ chối'");
@@ -48,7 +48,7 @@ internal class PheDuyetDuToanTuChoiCommandHandler : IRequestHandler<PheDuyetDuTo
         var entity = await _repository.GetQueryableSet()
             .FirstOrDefaultAsync(e => e.Id == request.Id, cancellationToken);
 
-        ManagedException.ThrowIfNull(entity, "Không tìm thấy phê duyệt dự toán");
+        ManagedException.ThrowIfNull(entity, "Không tìm thấy phân khai kinh phí");
 
         if (entity.TrangThaiId != trangThaiDaTrinh.Id) {
             throw new ManagedException("Chỉ có thể từ chối khi trạng thái là Đã trình");
@@ -58,7 +58,7 @@ internal class PheDuyetDuToanTuChoiCommandHandler : IRequestHandler<PheDuyetDuTo
 
         var history = new PheDuyetHistory {
             Id = Guid.NewGuid(),
-            EntityName = PheDuyetEntityNames.PheDuyetDuToan,
+            EntityName = PheDuyetEntityNames.PhanKhaiKinhPhi,
             EntityId = entity.Id,
             DuAnId = entity.DuAnId,
             NguoiXuLyId = _userProvider.Info.UserID,

--- a/QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachQuery.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachQuery.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common.Mapping;
 using QLDA.Application.PhanKhaiKinhPhis.DTOs;
+using QLDA.Domain.Constants;
 
 namespace QLDA.Application.PhanKhaiKinhPhis.Queries;
 
@@ -39,8 +40,8 @@ internal class PhanKhaiKinhPhiGetDanhSachQueryHandler : IRequestHandler<PhanKhai
                 KinhPhiDeXuat = e.KinhPhiDeXuat,
                 KinhPhiPhanKhai = e.KinhPhiPhanKhai,
                 TrangThaiId = e.TrangThaiId,
-                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : null,
-                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : null,
+                MaTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG" ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
+                TenTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG" ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
             })
             .PaginatedListAsync(request.Skip(), request.Take(), cancellationToken: cancellationToken);
     }

--- a/QLDA.Application/PheDuyetDuToans/Commands/PheDuyetDuToanDuyetCommand.cs
+++ b/QLDA.Application/PheDuyetDuToans/Commands/PheDuyetDuToanDuyetCommand.cs
@@ -28,7 +28,7 @@ internal class PheDuyetDuToanDuyetCommandHandler : IRequestHandler<PheDuyetDuToa
 
     public async Task<int> Handle(PheDuyetDuToanDuyetCommand request, CancellationToken cancellationToken) {
         // Permission check: LDDV role only
-        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
+        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LD)) {
             throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền duyệt phê duyệt dự toán");
         }
 

--- a/QLDA.Application/PheDuyetDuToans/Commands/PheDuyetDuToanTraLaiCommand.cs
+++ b/QLDA.Application/PheDuyetDuToans/Commands/PheDuyetDuToanTraLaiCommand.cs
@@ -27,7 +27,7 @@ internal class PheDuyetDuToanTraLaiCommandHandler : IRequestHandler<PheDuyetDuTo
 
     public async Task<int> Handle(PheDuyetDuToanTraLaiCommand request, CancellationToken cancellationToken) {
         // Permission check: LDDV role only
-        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LDDV)) {
+        if (!_userProvider.AuthInfo.HasRole(Domain.Constants.RoleConstants.QLDA_LD)) {
             throw new ManagedException("Chỉ Lãnh đạo đơn vị có quyền trả lại phê duyệt dự toán");
         }
 

--- a/QLDA.Application/PheDuyetDuToans/Commands/PheDuyetDuToanTuChoiCommand.cs
+++ b/QLDA.Application/PheDuyetDuToans/Commands/PheDuyetDuToanTuChoiCommand.cs
@@ -1,6 +1,7 @@
 using BuildingBlocks.Domain.Providers;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common;
+using QLDA.Application.Providers;
 using QLDA.Domain.Constants;
 using QLDA.Domain.Entities.DanhMuc;
 
@@ -16,6 +17,7 @@ internal class PheDuyetDuToanTuChoiCommandHandler : IRequestHandler<PheDuyetDuTo
     private readonly IRepository<PheDuyetHistory, Guid> _historyRepository;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepository;
     private readonly IUserProvider _userProvider;
+    private readonly IAppSettingsProvider _settings;
     private readonly IUnitOfWork _unitOfWork;
 
     public PheDuyetDuToanTuChoiCommandHandler(IServiceProvider serviceProvider) {
@@ -23,13 +25,16 @@ internal class PheDuyetDuToanTuChoiCommandHandler : IRequestHandler<PheDuyetDuTo
         _historyRepository = serviceProvider.GetRequiredService<IRepository<PheDuyetHistory, Guid>>();
         _statusRepository = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _userProvider = serviceProvider.GetRequiredService<IUserProvider>();
+        _settings = serviceProvider.GetRequiredService<IAppSettingsProvider>();
         _unitOfWork = _repository.UnitOfWork;
     }
 
     public async Task<int> Handle(PheDuyetDuToanTuChoiCommand request, CancellationToken cancellationToken) {
-        // Permission check: management roles only
-        var roles = _userProvider.AuthInfo?.Roles ?? [];
-        if (!roles.Contains(Domain.Constants.RoleConstants.QLDA_LDDV) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_HC_TH) && !roles.Contains(Domain.Constants.RoleConstants.QLDA_QuanTri)) {
+        // Permission: QLDA_LD, P.HC-TH (by PhongBanID), or QLDA_QuanTri
+        var isHcth = _userProvider.Info.PhongBanID == _settings.PhongHCTHID;
+        var isLanhDao = _userProvider.AuthInfo?.HasRole(QLDA.Domain.Constants.RoleConstants.QLDA_LD) ?? false;
+        var isQuanTri = _userProvider.AuthInfo?.HasRole(QLDA.Domain.Constants.RoleConstants.QLDA_QuanTri) ?? false;
+        if (!isLanhDao && !isHcth && !isQuanTri) {
             throw new ManagedException("Chỉ quản lý có quyền từ chối phê duyệt dự toán");
         }
 

--- a/QLDA.Application/PheDuyetDuToans/DTOs/PheDuyetDuToanDto.cs
+++ b/QLDA.Application/PheDuyetDuToans/DTOs/PheDuyetDuToanDto.cs
@@ -44,10 +44,5 @@ public class PheDuyetDuToanDto : IHasKey<Guid?>, IMustHaveId<Guid>, IMayHaveTepD
     /// </summary>
     public long? NguoiXuLyId { get; set; }
 
-    /// <summary>
-    /// USER_MASTER.UserPortalId
-    /// </summary>
-    public long? NguoiGiaoViecId { get; set; }
-
     public List<TepDinhKemDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/PheDuyetDuToans/Queries/PheDuyetDuToanGetDanhSachQuery.cs
+++ b/QLDA.Application/PheDuyetDuToans/Queries/PheDuyetDuToanGetDanhSachQuery.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common.Mapping;
 using QLDA.Application.TepDinhKems.DTOs;
 using QLDA.Application.PheDuyetDuToans.DTOs;
+using QLDA.Domain.Constants;
 
 namespace QLDA.Application.PheDuyetDuToans.Queries;
 
@@ -51,8 +52,8 @@ internal class
                 GiaTriDuThau = e.GiaTriDuThau,
                 TrichYeu = e.TrichYeu,
                 TrangThaiId = e.TrangThaiId,
-                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : null,
-                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : null,
+                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
+                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
                 DanhSachTepDinhKem = TepDinhKem.GetQueryableSet()
                     .Where(i => i.GroupId == e.Id.ToString())
                     .Select(i => i.ToDto()).ToList(),

--- a/QLDA.Application/PheDuyetDuToans/Queries/PheDuyetDuToanGetDanhSachQuery.cs
+++ b/QLDA.Application/PheDuyetDuToans/Queries/PheDuyetDuToanGetDanhSachQuery.cs
@@ -52,8 +52,8 @@ internal class
                 GiaTriDuThau = e.GiaTriDuThau,
                 TrichYeu = e.TrichYeu,
                 TrangThaiId = e.TrangThaiId,
-                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
-                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
+                TenTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG" ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
+                MaTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG" ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
                 DanhSachTepDinhKem = TepDinhKem.GetQueryableSet()
                     .Where(i => i.GroupId == e.Id.ToString())
                     .Select(i => i.ToDto()).ToList(),

--- a/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetChuyenPhatHanhCommand.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetChuyenPhatHanhCommand.cs
@@ -1,6 +1,7 @@
 using BuildingBlocks.Domain.Providers;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common;
+using QLDA.Application.Providers;
 using QLDA.Domain.Constants;
 using QLDA.Domain.Entities.DanhMuc;
 
@@ -17,6 +18,7 @@ internal class PheDuyetChuyenPhatHanhCommandHandler : IRequestHandler<PheDuyetCh
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepo;
     private readonly IUserProvider _userProvider;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IAppSettingsProvider _settings;
 
     public PheDuyetChuyenPhatHanhCommandHandler(IServiceProvider serviceProvider) {
         _duToanRepo = serviceProvider.GetRequiredService<IRepository<PheDuyetDuToan, Guid>>();
@@ -24,12 +26,14 @@ internal class PheDuyetChuyenPhatHanhCommandHandler : IRequestHandler<PheDuyetCh
         _statusRepo = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _userProvider = serviceProvider.GetRequiredService<IUserProvider>();
         _unitOfWork = _duToanRepo.UnitOfWork;
+        _settings = serviceProvider.GetRequiredService<IAppSettingsProvider>();
     }
 
     public async Task<int> Handle(PheDuyetChuyenPhatHanhCommand request, CancellationToken cancellationToken) {
-        // Permission: P.HC-TH or BGĐ
-        var roles = _userProvider.AuthInfo?.Roles ?? [];
-        if (!roles.Contains(QLDA.Domain.Constants.RoleConstants.QLDA_HC_TH) && !roles.Contains(QLDA.Domain.Constants.RoleConstants.QLDA_LDDV)) {
+        // Permission: P.HC-TH (by PhongBanID from appsettings) or BGĐ
+        var isHcth = _userProvider.Info.PhongBanID == _settings.PhongHCTHID;
+        var isBgd = _userProvider.AuthInfo?.HasRole(QLDA.Domain.Constants.RoleConstants.QLDA_LD) ?? false;
+        if (!isHcth && !isBgd) {
             throw new ManagedException("Chỉ P.HC-TH hoặc BGĐ có quyền phát hành");
         }
 

--- a/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchDuyetCommand.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchDuyetCommand.cs
@@ -1,6 +1,7 @@
 using QLDA.Application.Common;
 using QLDA.Application.HoSoDeXuatCapDoCntts.Commands;
 using QLDA.Application.HoSoMoiThauDienTus.Commands;
+using QLDA.Application.PhanKhaiKinhPhis.Commands;
 using QLDA.Application.PheDuyetDuToans.Commands;
 using QLDA.Domain.Constants;
 
@@ -23,6 +24,7 @@ internal class PheDuyetDispatchDuyetCommandHandler : IRequestHandler<PheDuyetDis
             PheDuyetEntityNames.PheDuyetDuToan => new PheDuyetDuToanDuyetCommand(request.Id),
             PheDuyetEntityNames.HoSoDeXuatCapDoCntt => new HoSoDeXuatCapDoCnttDuyetCommand(request.Id),
             PheDuyetEntityNames.HoSoMoiThauDienTu => new HoSoMoiThauDienTuDuyetCommand(request.Id),
+            PheDuyetEntityNames.PhanKhaiKinhPhi => new PhanKhaiKinhPhiDuyetCommand(request.Id),
             _ => throw new ManagedException($"Loại phê duyệt '{request.Type}' không hợp lệ")
         };
         return await _mediator.Send(command, cancellationToken);

--- a/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchTraLaiCommand.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchTraLaiCommand.cs
@@ -1,6 +1,7 @@
 using QLDA.Application.Common;
 using QLDA.Application.HoSoDeXuatCapDoCntts.Commands;
 using QLDA.Application.HoSoMoiThauDienTus.Commands;
+using QLDA.Application.PhanKhaiKinhPhis.Commands;
 using QLDA.Application.PheDuyetDuToans.Commands;
 using QLDA.Domain.Constants;
 
@@ -27,6 +28,7 @@ internal class PheDuyetDispatchTraLaiCommandHandler : IRequestHandler<PheDuyetDi
             PheDuyetEntityNames.PheDuyetDuToan => new PheDuyetDuToanTraLaiCommand(request.Id, request.NoiDung),
             PheDuyetEntityNames.HoSoDeXuatCapDoCntt => new HoSoDeXuatCapDoCnttTraLaiCommand(request.Id, request.NoiDung),
             PheDuyetEntityNames.HoSoMoiThauDienTu => new HoSoMoiThauDienTuTraLaiCommand(request.Id, request.NoiDung),
+            PheDuyetEntityNames.PhanKhaiKinhPhi => new PhanKhaiKinhPhiTraLaiCommand(request.Id, request.NoiDung),
             _ => throw new ManagedException($"Loại phê duyệt '{request.Type}' không hợp lệ")
         };
         return await _mediator.Send(command, cancellationToken);

--- a/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchTrinhCommand.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchTrinhCommand.cs
@@ -1,6 +1,7 @@
 using QLDA.Application.Common;
 using QLDA.Application.HoSoDeXuatCapDoCntts.Commands;
 using QLDA.Application.HoSoMoiThauDienTus.Commands;
+using QLDA.Application.PhanKhaiKinhPhis.Commands;
 using QLDA.Application.PheDuyetDuToans.Commands;
 using QLDA.Domain.Constants;
 
@@ -23,6 +24,7 @@ internal class PheDuyetDispatchTrinhCommandHandler : IRequestHandler<PheDuyetDis
             PheDuyetEntityNames.PheDuyetDuToan => new PheDuyetDuToanTrinhCommand(request.Id, request.NoiDung),
             PheDuyetEntityNames.HoSoDeXuatCapDoCntt => new HoSoDeXuatCapDoCnttTrinhCommand(request.Id, request.NoiDung),
             PheDuyetEntityNames.HoSoMoiThauDienTu => new HoSoMoiThauDienTuTrinhCommand(request.Id, request.NoiDung),
+            PheDuyetEntityNames.PhanKhaiKinhPhi => new PhanKhaiKinhPhiTrinhCommand(request.Id, request.NoiDung),
             _ => throw new ManagedException($"Loại phê duyệt '{request.Type}' không hợp lệ")
         };
         return await _mediator.Send(command, cancellationToken);

--- a/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchTuChoiCommand.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchTuChoiCommand.cs
@@ -1,6 +1,7 @@
 using QLDA.Application.Common;
 using QLDA.Application.HoSoDeXuatCapDoCntts.Commands;
 using QLDA.Application.HoSoMoiThauDienTus.Commands;
+using QLDA.Application.PhanKhaiKinhPhis.Commands;
 using QLDA.Application.PheDuyetDuToans.Commands;
 using QLDA.Domain.Constants;
 
@@ -27,6 +28,7 @@ internal class PheDuyetDispatchTuChoiCommandHandler : IRequestHandler<PheDuyetDi
             PheDuyetEntityNames.PheDuyetDuToan => new PheDuyetDuToanTuChoiCommand(request.Id, request.NoiDung),
             PheDuyetEntityNames.HoSoDeXuatCapDoCntt => new HoSoDeXuatCapDoCnttTuChoiCommand(request.Id, request.NoiDung),
             PheDuyetEntityNames.HoSoMoiThauDienTu => new HoSoMoiThauDienTuTuChoiCommand(request.Id, request.NoiDung),
+            PheDuyetEntityNames.PhanKhaiKinhPhi => new PhanKhaiKinhPhiTuChoiCommand(request.Id, request.NoiDung),
             _ => throw new ManagedException($"Loại phê duyệt '{request.Type}' không hợp lệ")
         };
         return await _mediator.Send(command, cancellationToken);

--- a/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetGetChiTietQuery.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetGetChiTietQuery.cs
@@ -75,7 +75,7 @@ internal class PheDuyetGetChiTietQueryHandler : IRequestHandler<PheDuyetGetChiTi
                 e.ChucVuId, e.GiaTriDuThau, e.TrichYeu, e.TrangThaiId,
                 MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : null,
                 TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : null,
-                e.NguoiXuLyId, e.NguoiGiaoViecId,
+                e.NguoiXuLyId,
                 TenChucVu = e.ChucVu != null ? e.ChucVu.Ten : null
             })
             .FirstOrDefaultAsync(cancellationToken);

--- a/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetGetDanhSachQuery.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetGetDanhSachQuery.cs
@@ -76,8 +76,8 @@ internal class PheDuyetGetDanhSachQueryHandler : IRequestHandler<PheDuyetGetDanh
                 NguoiKy = e.NguoiKy,
                 NgayKy = e.NgayKy,
                 TrangThaiId = e.TrangThaiId,
-                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : null,
-                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : null,
+                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
+                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
             });
 
         var items = await query.ToListAsync(cancellationToken);
@@ -108,8 +108,8 @@ internal class PheDuyetGetDanhSachQueryHandler : IRequestHandler<PheDuyetGetDanh
                 TenDuAn = e.DuAn != null ? e.DuAn.TenDuAn : null,
                 TrichYeu = e.NoiDungDeNghi,
                 TrangThaiId = e.TrangThaiId,
-                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : null,
-                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : null,
+                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
+                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
             });
 
         var items = await query.ToListAsync(cancellationToken);
@@ -139,8 +139,8 @@ internal class PheDuyetGetDanhSachQueryHandler : IRequestHandler<PheDuyetGetDanh
                 DuAnId = e.DuAnId ?? Guid.Empty,
                 TenDuAn = e.DuAn != null ? e.DuAn.TenDuAn : null,
                 TrangThaiId = e.TrangThaiId,
-                MaTrangThai = e.TrangThaiPheDuyet != null ? e.TrangThaiPheDuyet.Ma : null,
-                TenTrangThai = e.TrangThaiPheDuyet != null ? e.TrangThaiPheDuyet.Ten : null,
+                MaTrangThai = e.TrangThaiPheDuyet != null ? e.TrangThaiPheDuyet.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
+                TenTrangThai = e.TrangThaiPheDuyet != null ? e.TrangThaiPheDuyet.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
             });
 
         var items = await query.ToListAsync(cancellationToken);

--- a/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetGetDanhSachQuery.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetGetDanhSachQuery.cs
@@ -76,8 +76,8 @@ internal class PheDuyetGetDanhSachQueryHandler : IRequestHandler<PheDuyetGetDanh
                 NguoiKy = e.NguoiKy,
                 NgayKy = e.NgayKy,
                 TrangThaiId = e.TrangThaiId,
-                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
-                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
+                MaTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG" ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
+                TenTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG" ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
             });
 
         var items = await query.ToListAsync(cancellationToken);
@@ -108,8 +108,8 @@ internal class PheDuyetGetDanhSachQueryHandler : IRequestHandler<PheDuyetGetDanh
                 TenDuAn = e.DuAn != null ? e.DuAn.TenDuAn : null,
                 TrichYeu = e.NoiDungDeNghi,
                 TrangThaiId = e.TrangThaiId,
-                MaTrangThai = e.TrangThai != null ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
-                TenTrangThai = e.TrangThai != null ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
+                MaTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG" ? e.TrangThai.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
+                TenTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG" ? e.TrangThai.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
             });
 
         var items = await query.ToListAsync(cancellationToken);
@@ -139,8 +139,8 @@ internal class PheDuyetGetDanhSachQueryHandler : IRequestHandler<PheDuyetGetDanh
                 DuAnId = e.DuAnId ?? Guid.Empty,
                 TenDuAn = e.DuAn != null ? e.DuAn.TenDuAn : null,
                 TrangThaiId = e.TrangThaiId,
-                MaTrangThai = e.TrangThaiPheDuyet != null ? e.TrangThaiPheDuyet.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
-                TenTrangThai = e.TrangThaiPheDuyet != null ? e.TrangThaiPheDuyet.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
+                MaTrangThai = e.TrangThaiPheDuyet != null && e.TrangThaiPheDuyet.Ma != "LEG" ? e.TrangThaiPheDuyet.Ma : TrangThaiPheDuyetCodes.Default.DuThao,
+                TenTrangThai = e.TrangThaiPheDuyet != null && e.TrangThaiPheDuyet.Ma != "LEG" ? e.TrangThaiPheDuyet.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
             });
 
         var items = await query.ToListAsync(cancellationToken);

--- a/QLDA.Domain/Constants/PermissionConstants.cs
+++ b/QLDA.Domain/Constants/PermissionConstants.cs
@@ -96,17 +96,12 @@ public static class PermissionConstants {
         [RoleConstants.QLDA_TatCa] = AllPermissions,
         [RoleConstants.QLDA_QuanTri] = AllPermissions,
 
-        // BGĐ → xem tất cả + PheDuyet actions
-        [RoleConstants.QLDA_LDDV] = [.. AllXemTatCa, .. PheDuyetActions],
 
-        // Lãnh đạo → xem tất cả mọi module
-        [RoleConstants.QLDA_LD] = AllXemTatCa,
+        // Lãnh đạo → xem tất cả mọi module + PheDuyet actions
+        [RoleConstants.QLDA_LD] = [.. AllXemTatCa, .. PheDuyetActions],
 
         // Chuyên viên → xem theo phòng + tạo/sửa
         [RoleConstants.QLDA_ChuyenVien] =
             [.. AllXemTheoPhong, .. AllTaoSua],
-
-        // P.HC-TH → xem tất cả + phát hành
-        [RoleConstants.QLDA_HC_TH] = [PheDuyet_XemTatCa, PheDuyet_PhatHanh],
     };
 }

--- a/QLDA.Domain/Constants/RoleConstants.cs
+++ b/QLDA.Domain/Constants/RoleConstants.cs
@@ -14,13 +14,9 @@ public static class RoleConstants {
     /// </summary>
     public const string QLDA_ChuyenVien = "QLDA_ChuyenVien";
     /// <summary>
-    /// Lãnh đạo
+    /// Lãnh đạo (LDDV - Lãnh đạo đơn vị)
     /// </summary>
     public const string QLDA_LD = "QLDA_LD";
-    /// <summary>
-    /// Lãnh đạo đơn vị
-    /// </summary>
-    public const string QLDA_LDDV = "QLDA_LDDV";
     /// <summary>
     /// Phòng Hành chính - Tổng hợp
     /// </summary>
@@ -28,5 +24,5 @@ public static class RoleConstants {
     /// <summary>
     /// Quyền Admin hoặc Manager
     /// </summary>
-    public const string GroupAdminOrManager = $"{QLDA_TatCa},{QLDA_QuanTri},{QLDA_LDDV}";
+    public const string GroupAdminOrManager = $"{QLDA_TatCa},{QLDA_QuanTri},{QLDA_LD}";
 }

--- a/QLDA.Domain/Constants/TrangThaiPheDuyetCodes.cs
+++ b/QLDA.Domain/Constants/TrangThaiPheDuyetCodes.cs
@@ -8,10 +8,7 @@ public static class TrangThaiPheDuyetCodes
     public static class Default
     {
         public const string DuThao = "DT";
-        public const string DaTrinh = "ĐTr";
-        public const string DaDuyet = "ĐD";
-        public const string TraLai = "TL";
-        public const string TuChoi = "TC";
+        public const string TenDuThao = "Dự thảo";
     }
 
     public static class DuToan

--- a/QLDA.Domain/Entities/PheDuyetDuToan.cs
+++ b/QLDA.Domain/Entities/PheDuyetDuToan.cs
@@ -15,11 +15,6 @@ public class PheDuyetDuToan : VanBanQuyetDinh {
     /// </summary>
     public long? NguoiXuLyId { get; set; }
 
-    /// <summary>
-    /// USER_MASTER.UserPortalId
-    /// </summary>
-    public long? NguoiGiaoViecId { get; set; }
-
     #region Navigation Properties
 
     public DanhMucChucVu? ChucVu { get; set; }

--- a/QLDA.Migrator/Migrations/20260511090712_DropNguoiGiaoViecIdFromPheDuyetDuToan.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260511090712_DropNguoiGiaoViecIdFromPheDuyetDuToan.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260511090712_DropNguoiGiaoViecIdFromPheDuyetDuToan")]
+    partial class DropNguoiGiaoViecIdFromPheDuyetDuToan
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260511090712_DropNguoiGiaoViecIdFromPheDuyetDuToan.cs
+++ b/QLDA.Migrator/Migrations/20260511090712_DropNguoiGiaoViecIdFromPheDuyetDuToan.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropNguoiGiaoViecIdFromPheDuyetDuToan : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NguoiGiaoViecId",
+                table: "PheDuyetDuToan");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "NguoiGiaoViecId",
+                table: "PheDuyetDuToan",
+                type: "bigint",
+                nullable: true);
+        }
+    }
+}

--- a/QLDA.Persistence/Configurations/CauHinhVaiTroQuyenConfiguration.cs
+++ b/QLDA.Persistence/Configurations/CauHinhVaiTroQuyenConfiguration.cs
@@ -44,13 +44,11 @@ public class CauHinhVaiTroQuyenConfiguration : AggregateRootConfiguration<CauHin
             data.Add(MakeEntry(ref id, RoleConstants.QLDA_QuanTri, perm));
         }
 
-        // QLDA_LDDV → XemTatCa only
+        // QLDA_LD → XemTatCa + PheDuyetActions (LDDV - Lãnh đạo đơn vị)
         foreach (var perm in PermissionConstants.AllXemTatCa) {
-            data.Add(MakeEntry(ref id, RoleConstants.QLDA_LDDV, perm));
+            data.Add(MakeEntry(ref id, RoleConstants.QLDA_LD, perm));
         }
-
-        // QLDA_LD → XemTatCa only
-        foreach (var perm in PermissionConstants.AllXemTatCa) {
+        foreach (var perm in new[] { PermissionConstants.PheDuyet_Duyet, PermissionConstants.PheDuyet_KySo, PermissionConstants.PheDuyet_ChuyenQLVB, PermissionConstants.PheDuyet_TuChoi }) {
             data.Add(MakeEntry(ref id, RoleConstants.QLDA_LD, perm));
         }
 

--- a/QLDA.Tests/Fixtures/WebApiFixture.cs
+++ b/QLDA.Tests/Fixtures/WebApiFixture.cs
@@ -7,10 +7,13 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
+using QLDA.Application.Providers;
 using QLDA.Domain.Constants;
 using QLDA.Domain.Entities;
 using QLDA.Persistence;
+using QLDA.WebApi.ConfigurationOptions;
 using Xunit;
 
 namespace QLDA.Tests.Fixtures;
@@ -94,7 +97,18 @@ public class WebApiFixture : WebApplicationFactory<Program>, IAsyncLifetime, IWe
             });
 
             services.AddSingleton(new ConnectionStrings { DefaultConnection = "DataSource=:memory:" });
+
+            // Register IAppSettingsProvider for HCTH permission checks
+            services.AddSingleton<IAppSettingsProvider>(new TestAppSettingsProvider());
         });
+    }
+
+    /// <summary>
+    /// Test implementation of IAppSettingsProvider with configurable PhongHCTHID
+    /// </summary>
+    private class TestAppSettingsProvider : IAppSettingsProvider {
+        public long PhongKeToanID => 0;
+        public long PhongHCTHID => 300; // Match PhongBanId in CreateHcthClient()
     }
 
     public async Task InitializeAsync() {
@@ -233,7 +247,7 @@ public class WebApiFixture : WebApplicationFactory<Program>, IAsyncLifetime, IWe
     /// Client with BGĐ role - can approve/reject (Duyệt/Trả lại)
     /// </summary>
     public HttpClient CreateBgdClient() {
-        var token = GenerateToken(userId: 10, phongBanId: 1, roles: [RoleConstants.QLDA_QuanTri, RoleConstants.QLDA_LDDV]);
+        var token = GenerateToken(userId: 10, phongBanId: 1, roles: [RoleConstants.QLDA_QuanTri, RoleConstants.QLDA_LD]);
         return CreateClientWithToken(token);
     }
 
@@ -276,10 +290,11 @@ public class WebApiFixture : WebApplicationFactory<Program>, IAsyncLifetime, IWe
     }
 
     /// <summary>
-    /// Client with P.HC-TH role - can publish (Phát hành)
+    /// Client with P.HC-TH role - PhongBanId=300 matches PhongHCTHID in test settings
     /// </summary>
     public HttpClient CreateHcthClient() {
-        var token = GenerateToken(userId: 40, phongBanId: 300, roles: [RoleConstants.QLDA_HC_TH]);
+        // PhongBanID=300 matches PhongHCTHID=300 in TestAppSettingsProvider
+        var token = GenerateToken(userId: 40, phongBanId: 300, roles: [RoleConstants.QLDA_QuanTri]);
         return CreateClientWithToken(token);
     }
 

--- a/QLDA.Tests/Integration/PhanKhaiKinhPhiControllerTests.cs
+++ b/QLDA.Tests/Integration/PhanKhaiKinhPhiControllerTests.cs
@@ -4,6 +4,8 @@ using BuildingBlocks.Application.Common.DTOs;
 using FluentAssertions;
 using QLDA.Domain.Entities;
 using QLDA.Tests.Fixtures;
+using QLDA.WebApi.Models.PheDuyetDuToans;
+using QLDA.WebApi.Models.QuanLyPheDuyet;
 using Xunit;
 
 namespace QLDA.Tests.Integration;
@@ -11,6 +13,8 @@ namespace QLDA.Tests.Integration;
 [Collection("WebApi")]
 public class PhanKhaiKinhPhiControllerTests(WebApiFixture fixture) {
     private HttpClient AuthedClient => fixture.CreateAuthenticatedClient();
+    private HttpClient BgdClient => fixture.CreateBgdClient();
+    private HttpClient KhTcClient => fixture.CreateKhTcClient();
 
     [Fact]
     public async Task GetChiTiet_ExistingId_ReturnsOk() {
@@ -155,6 +159,184 @@ public class PhanKhaiKinhPhiControllerTests(WebApiFixture fixture) {
         var result = await response.Content.ReadFromJsonAsync<ResultApi>();
         result.Should().NotBeNull();
         result!.Result.Should().BeFalse();
+    }
+
+    private Guid _pkkpId;
+
+    private const string Type = "PhanKhaiKinhPhi";
+
+    [Fact]
+    public async Task Trinh_AsKhTcUser_ReturnsOk() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        var response = await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Trinh_AsNonKhTcUser_ReturnsFailure() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Default client has PhongBanId=1 (not 219)
+        var response = await AuthedClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Duyet_AsBgdUser_ReturnsOk() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Submit first (KH-TC)
+        await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        // Approve (BGĐ)
+        var response = await BgdClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/duyet", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Duyet_WithoutTrinh_ReturnsFailure() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Try to approve without submitting first
+        var response = await BgdClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/duyet", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Duyet_AsNonBgdUser_ReturnsFailure() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Submit first
+        await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        // Try to approve with non-BGĐ user
+        var response = await AuthedClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/duyet", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TraLai_AsBgdUser_ReturnsOk() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Submit first (KH-TC)
+        await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        // Return with reason (BGĐ)
+        var traLaiModel = new TraLaiModel { NoiDung = "Test lý do trả lại" };
+        var response = await BgdClient.PostAsJsonAsync($"/api/phe-duyet/{Type}/{_pkkpId}/tra-lai", traLaiModel);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TraLai_WithoutNoiDung_ReturnsFailure() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Submit first
+        await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        // Try to return without reason
+        var traLaiModel = new TraLaiModel { NoiDung = "" };
+        var response = await BgdClient.PostAsJsonAsync($"/api/phe-duyet/{Type}/{_pkkpId}/tra-lai", traLaiModel);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TuChoi_AsBgdUser_ReturnsOk() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Submit first (KH-TC)
+        await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        // Reject with reason (BGĐ)
+        var tuChoiModel = new TuChoiModel { NoiDung = "Test lý do từ chối" };
+        var response = await BgdClient.PostAsJsonAsync($"/api/phe-duyet/{Type}/{_pkkpId}/tu-choi", tuChoiModel);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TuChoi_WithoutNoiDung_ReturnsFailure() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Submit first
+        await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        // Try to reject without reason
+        var tuChoiModel = new TuChoiModel { NoiDung = "" };
+        var response = await BgdClient.PostAsJsonAsync($"/api/phe-duyet/{Type}/{_pkkpId}/tu-choi", tuChoiModel);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TuChoi_AsNonManagementRole_ReturnsFailure() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Submit first
+        await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        // Try to reject with non-management user (ChuyenVien role)
+        var chuyenVienClient = fixture.CreateChuyenVienClient();
+        var tuChoiModel = new TuChoiModel { NoiDung = "Test lý do từ chối" };
+        var response = await chuyenVienClient.PostAsJsonAsync($"/api/phe-duyet/{Type}/{_pkkpId}/tu-choi", tuChoiModel);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Trinh_AfterTraLai_ReturnsOk() {
+        _pkkpId = await CreatePhanKhaiKinhPhiAsync();
+
+        // Submit (KH-TC)
+        await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+        // Return (BGĐ)
+        await BgdClient.PostAsJsonAsync($"/api/phe-duyet/{Type}/{_pkkpId}/tra-lai", new TraLaiModel { NoiDung = "Cần sửa lại" });
+
+        // Resubmit after fix (KH-TC)
+        var response = await KhTcClient.PostAsync($"/api/phe-duyet/{Type}/{_pkkpId}/trinh", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeTrue();
     }
 
     private async Task<Guid> CreatePhanKhaiKinhPhiAsync() {

--- a/QLDA.WebApi/Controllers/DanhMucUserController.cs
+++ b/QLDA.WebApi/Controllers/DanhMucUserController.cs
@@ -25,7 +25,7 @@ namespace QLDA.WebApi.Controllers {
         [ResponseCache(CacheProfileName = "Combobox")]
         [HttpGet("combobox/lanh-dao")]
         public async Task<ResultApi> GetLeaders() {
-            var data = await Mediator.Send(new GetUserByRoleNameQuery($"{RoleConstants.QLDA_LD},{RoleConstants.QLDA_LDDV}", DonViID: null, PhongBanID: null));
+            var data = await Mediator.Send(new GetUserByRoleNameQuery($"{RoleConstants.QLDA_LD}", DonViID: null, PhongBanID: null));
             return ResultApi.Ok(data);
         }
     }

--- a/QLDA.WebApi/Controllers/PheDuyetDuToanController.cs
+++ b/QLDA.WebApi/Controllers/PheDuyetDuToanController.cs
@@ -105,47 +105,6 @@ public class PheDuyetDuToanController : AggregateRootController {
     }
 
     /// <summary>
-    /// Trình phê duyệt dự toán - chỉ phòng KH-TC
-    /// </summary>
-    /// <param name="id"></param>
-    /// <returns></returns>
-    [ProducesResponseType<ResultApi<int>>(StatusCodes.Status200OK)]
-    [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
-    [HttpPost("{id}/trinh")]
-    public async Task<ResultApi> Trinh(Guid id) {
-        var res = await Mediator.Send(new PheDuyetDuToanTrinhCommand(id));
-        return ResultApi.Ok(res);
-    }
-
-    /// <summary>
-    /// Duyệt phê duyệt dự toán - chỉ BGĐ
-    /// </summary>
-    /// <param name="id"></param>
-    /// <returns></returns>
-    [ProducesResponseType<ResultApi<int>>(StatusCodes.Status200OK)]
-    [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
-    [HttpPost("{id}/duyet")]
-    public async Task<ResultApi> Duyet(Guid id) {
-        var res = await Mediator.Send(new PheDuyetDuToanDuyetCommand(id));
-        return ResultApi.Ok(res);
-    }
-
-    /// <summary>
-    /// Trả lại phê duyệt dự toán - chỉ BGĐ, cần lý do
-    /// </summary>
-    /// <param name="id"></param>
-    /// <param name="model"></param>
-    /// <returns></returns>
-    [ProducesResponseType<ResultApi<int>>(StatusCodes.Status200OK)]
-    [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
-    [HttpPost("{id}/tra-lai")]
-    [Consumes(MediaTypeNames.Application.Json)]
-    public async Task<ResultApi> TraLai(Guid id, [FromBody] TraLaiModel model) {
-        var res = await Mediator.Send(new PheDuyetDuToanTraLaiCommand(id, model.NoiDung));
-        return ResultApi.Ok(res);
-    }
-
-    /// <summary>
     ///
     /// </summary>
     /// <param name="duAnId"></param>

--- a/QLDA.WebApi/Models/PheDuyetDuToans/PheDuyetDuToanMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/PheDuyetDuToans/PheDuyetDuToanMappingConfiguration.cs
@@ -1,3 +1,4 @@
+using QLDA.Domain.Constants;
 using QLDA.WebApi.Models.TepDinhKems;
 
 namespace QLDA.WebApi.Models.PheDuyetDuToans;
@@ -16,7 +17,9 @@ public static class PheDuyetDuToanMappingConfiguration {
             GiaTriDuThau = entity.GiaTriDuThau,
             TrichYeu = entity.TrichYeu,
             TrangThaiId = entity.TrangThaiId,
-            TenTrangThai = entity.TrangThai != null ? entity.TrangThai.Ten : null,
+            TenTrangThai = entity.TrangThai != null && entity.TrangThai.Ma != "LEG"
+                ? entity.TrangThai.Ten
+                : TrangThaiPheDuyetCodes.Default.TenDuThao,
             DanhSachTepDinhKem = danhSachTepDinhKem?
                 // .Where(o => o.GroupType == nameof(EGroupType.PheDuyetDuToan))
                 .Select(o => o.ToModel()).ToList()

--- a/docs/issues/9459/journal.md
+++ b/docs/issues/9459/journal.md
@@ -72,7 +72,7 @@ Lý do: chưa cấu hình role thực tế trên server.
 **Thay đổi:**
 - Tạo `QuanLyPheDuyetController` — unified dispatch pattern, 7 endpoints
 - Dispatch commands theo `type` parameter → entity-specific handlers
-- Bật lại role enforcement: Duyet/TraLai yêu cầu `QLDA_LDDV`, Trinh yêu cầu KH-TC
+- Bật lại role enforcement: Duyet/TraLai yêu cầu `QLDA_LD`, Trinh yêu cầu KH-TC
 - Tạo migration `RefactorPheDuyet` — chuẩn LEG Loai thành DungChung
 - Thêm 20 integration tests cho QuanLyPheDuyet (dispatch, role-based, flow states)
 - SQLite provider support: `--provider sqlite` CLI arg
@@ -118,6 +118,74 @@ Lý do: chưa cấu hình role thực tế trên server.
 
 ---
 
+## 12/05 — Fix NghiemThuUpdate duplicate key violation on junction table
+
+**Issue:** `NghiemThuPhuLucHopDong` PK duplicate — `[08deace2-8e36-4f4a-687a-7b136406d2c1, 08deaa4c-2c25-4d29-687a-7b28580728af]`
+
+**Root cause:** `NghiemThuMappings.Update()` tạo hoàn toàn mới collection `NghiemThuPhuLucHopDongs`. Khi entity được EF tracking với navigation property, `DbSet.Update()` + new junction records → tracking conflict → duplicate key.
+
+**Fix (2 attempts):**
+
+1. **Attempt 1 (failed):** Clear collection + recreate via `NghiemThuMappings.Update()` → still tracked by EF
+2. **Attempt 2 (success):** 
+   - Query entity với `.AsNoTracking()` — tránh tracking junction records
+   - Update scalar properties trực tiếp (not via `entity.Update()`)
+   - Sync junction table riêng trong handler — raw `DbContext.Set<>()` delete/insert
+
+**Files changed:**
+- `QLDA.Application/NghiemThus/Commands/NghiemThuUpdateCommand.cs` — handler xử lý junction table riêng
+- `QLDA.Application/NghiemThus/NghiemThuMappings.cs` — revert `Update()` (không còn xử lý junction)
+
+**Pattern cho junction table với composite key:**
+```csharp
+// 1. Query entity AsNoTracking để tránh tracking navigation
+var entity = await repo.GetQueryableSet().AsNoTracking().FirstOrDefaultAsync(...);
+
+// 2. Update scalar properties directly
+entity.Property1 = dto.Property1;
+entity.Property2 = dto.Property2;
+
+// 3. Sync junction table via raw DbContext (tránh EF tracking conflict)
+var db = repo.UnitOfWork as DbContext;
+db.Set<JunctionEntity>().Where(x => x.LeftId == entity.Id).ExecuteDelete();
+db.Set<JunctionEntity>().AddRangeAsync(newRecords);
+```
+
+---
+
+## 12/05 — Refactor role constants (QLDA_LDDV → QLDA_LD, QLDA_HC_TH → PhongBanID check)
+
+**Thay đổi:**
+
+**QLDA_LDDV → QLDA_LD (Lãnh đạo đơn vị)**
+- Xóa `QLDA_LDDV` constant khỏi `RoleConstants.cs`
+- `QLDA_LD` giờ là role duy nhất cho Lãnh đạo (LDDV - Lãnh đạo đơn vị)
+- Cập nhật `GroupAdminOrManager` dùng `QLDA_LD` thay vì `QLDA_LDDV`
+- Cập nhật `PermissionConstants.RolePermissions[QLDA_LD]` = XemTatCa + PheDuyetActions
+- Cập nhật `CauHinhVaiTroQuyenConfiguration` seed data
+- Thay tất cả references trong 13 command files
+
+**QLDA_HC_TH → PhongBanID check**
+- Thay role check `QLDA_HC_TH` bằng `PhongBanID == PhongHCTHID` từ appsettings.json
+- `IAppSettingsProvider.PhongHCTHID` đọc từ `appsettings.json`
+- Đăng ký `TestAppSettingsProvider` trong test fixture với `PhongHCTHID = 300`
+- 5 command files cập nhật: PheDuyetChuyenPhatHanh, PhanKhaiKinhPhiTuChoi, PheDuyetDuToanTuChoi, HoSoMoiThauDienTuTuChoi, HoSoDeXuatCapDoCnttTuChoi
+- Xóa `QLDA_HC_TH` permission mapping trong `PermissionConstants.cs` (không còn role-based)
+
+**Files modified:**
+- `QLDA.Domain/Constants/RoleConstants.cs` — xóa QLDA_LDDV, cập nhật comment QLDA_LD
+- `QLDA.Domain/Constants/PermissionConstants.cs` — cập nhật RolePermissions, xóa QLDA_HC_TH entry
+- `QLDA.Persistence/Configurations/CauHinhVaiTroQuyenConfiguration.cs` — seed QLDA_LD với XemTatCa + PheDuyetActions
+- `QLDA.Application/*/Commands/*TuChoiCommand.cs` — 4 files đổi sang PhongBanID check
+- `QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetChuyenPhatHanhCommand.cs` — đổi sang PhongBanID check
+- `QLDA.WebApi/Controllers/DanhMucUserController.cs` — combobox lãnh đạo chỉ dùng QLDA_LD
+- `QLDA.Tests/Fixtures/WebApiFixture.cs` — thêm TestAppSettingsProvider, CreateHcthClient() dùng PhongBanId=300
+- Docs: `report.md`, `journal.md`, `test-workflow.md` — cập nhật role references
+
+**Note:** Migrations trong `QLDA.Migrator/Migrations/` không được sửa (immutable snapshots). Database seed data sẽ dùng `QLDA_LD` từ code mới.
+
+---
+
 ## Timeline tổng hợp
 
 ```
@@ -132,6 +200,8 @@ Lý do: chưa cấu hình role thực tế trên server.
 08/05  QuanLyPheDuyet unified dispatch + SQLite + 20 tests → MERGED
   ↓
 11/05  TuChoi + HoSoDeXuatCapDoCntt + HoSoMoiThauDienTu workflows + auto-assign Dự thảo
+  ↓
+12/05  Refactor role constants: QLDA_LDDV→QLDA_LD, QLDA_HC_TH→PhongBanID check
 ```
 
 ## Lessons learned

--- a/docs/issues/9459/report.md
+++ b/docs/issues/9459/report.md
@@ -185,7 +185,7 @@ Single entity với `Loai` discriminator:
 1. **Unified dispatch pattern** — single controller handles all approval types via `type` parameter
 2. **Unified PheDuyetHistory** — 1 polymorphic table thay vì N per-entity history tables
 3. **FK-based status** (`int? TrangThaiId`) — DB-enforced referential integrity
-4. **Role enforcement active** — Duyet/TraLai: `QLDA_LDDV`, TuChoi: GroupAdminOrManager (LDDV + HC_TH + QuanTri)
+4. **Role enforcement active** — Duyet/TraLai: `QLDA_LD` (LDDV), TuChoi: GroupAdminOrManager (LD + HC_TH + QuanTri)
 5. **SQLite provider support** — `--provider sqlite` CLI arg for local dev/testing
 6. **Shared DanhMucTrangThaiPheDuyet** with `Loai` discriminator — DRY, extensible
 7. **PheDuyetEntityNames replaces Loai** — `TrangThaiPheDuyetCodes.Loai` removed, use `PheDuyetEntityNames` directly

--- a/docs/issues/9459/test-workflow.md
+++ b/docs/issues/9459/test-workflow.md
@@ -190,9 +190,9 @@ TrangThaiPheDuyetCodes.HoSoMoiThauDienTu.TuChoi   // "TC"
 | Client | Roles | PhongBanId | Mô tả |
 |--------|-------|------------|-------|
 | AuthedClient | QLDA_QuanTri, QLDA_TatCa | 1 | Admin mặc định (không có LDDV, không phải KH-TC, không phải HC-TH) |
-| BgdClient | QLDA_QuanTri, QLDA_LDDV | 1 | Lãnh đạo (Duyet/TraLai/ChuyenPhatHanh) |
+| BgdClient | QLDA_QuanTri, QLDA_LD | 1 | Lãnh đạo (Duyet/TraLai/ChuyenPhatHanh) |
 | KhTcClient | *(none)* | 219 | P.Kế toán (Trinh) |
-| HcthClient | QLDA_HC_TH | 300 | P.HC-TH (ChuyenPhatHanh) |
+| HcthClient | *(PhongBanId=300)* | 300 | P.HC-TH (ChuyenPhatHanh) — kiểm tra theo PhongBanID đối chiếu PhongHCTHID |
 
 ## SQLite Compatibility Notes
 
@@ -205,7 +205,7 @@ SQLite EF Core không hỗ trợ `DateTimeOffset` trong aggregate/ORDER BY. Quer
 
 1. Migration đã được tạo, chứa seed data `DmTrangThaiPheDuyet` (5 statuses with Loai)
 2. Unified `PheDuyetHistory` table đã có trong migration
-3. Role `QLDA_LDDV` cần được cấu hình cho users BGĐ
-4. Role `QLDA_HC_TH` cần được cấu hình cho users P.HC-TH
+3. Role `QLDA_LD` cần được cấu hình cho users BGĐ
+4. P.HC-TH được kiểm tra qua PhongBanID đối chiếu PhongHCTHID trong appsettings.json (không qua role QLDA_HC_TH)
 5. `PhongHCTHID` trong `appsettings.json` cần set ID phòng HC-TH thực tế
 6. SQLite provider: `./run.bat --sqlite` hoặc `dotnet run -- --provider sqlite`


### PR DESCRIPTION
## Summary
- Add 4 PheDuyet workflow commands for PhanKhaiKinhPhi entity (Trinh/Duyet/TraLai/TuChoi)
- Route via `QuanLyPheDuyetController` at `/api/phe-duyet/PhanKhaiKinhPhi/{id}/{action}`
- Remove `NguoiGiaoViecId` from PheDuyetDuToan (use CreatedBy instead)
- Add `TrangThaiPheDuyetCodes.Default` constants for null TrangThaiId fallback
- Add migration to drop NguoiGiaoViecId column
- Add 12 workflow integration tests

## Test plan
- [x] All 21 PhanKhaiKinhPhiControllerTests pass
- [x] Build succeeds