### PR TITLE
fix(DeXuatChuTruongMoi): persist donViPhoiHopIds to DeXuatDonViXuLy on save

### DIFF
--- a/QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiInsertCommand.cs
+++ b/QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiInsertCommand.cs
@@ -27,9 +27,12 @@ internal class DeXuatChuTruongMoiInsertCommandHandler : IRequestHandler<DeXuatCh
         var trangThaiDuThao = await _statusRepo.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
             .FirstOrDefaultAsync(s => s.Ma == "DT" && s.Loai == PheDuyetEntityNames.DeXuatMacDinhStt, cancellationToken);
 
+        var donViPhoiHopIds = request.Dto.DeXuatDonViXuLys?
+            .Select(x => x.RightId)
+            .ToList();
+
         var entity = new DeXuatChuTruongMoi
         {
-            Id = request.Dto.Id,
             DuAnId = request.Dto.DuAnId,
             BuocId = request.Dto.BuocId,
             TongMucDauTu = request.Dto.TongMucDauTu,
@@ -41,11 +44,12 @@ internal class DeXuatChuTruongMoiInsertCommandHandler : IRequestHandler<DeXuatCh
             DonViPhuTrachChinhId = request.Dto.DonViPhuTrachChinhId,
             TrangThaiId = trangThaiDuThao?.Id,
         };
-        entity.SyncDonViPhoiHopIds(
-            request.Dto.DeXuatDonViXuLys?.Select(x => x.RightId).ToList() ?? []);
 
         using var tx = await _unitOfWork.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         await _repo.AddAsync(entity, cancellationToken);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        entity.SyncDonViPhoiHopIds(donViPhoiHopIds);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
         await _unitOfWork.CommitTransactionAsync(cancellationToken);
 

--- a/QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiInsertCommand.cs
+++ b/QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiInsertCommand.cs
@@ -1,6 +1,6 @@
 using System.Data;
 using Microsoft.EntityFrameworkCore;
-using QLDA.Application.DeXuatChuTruongMois.DTOs;
+using QLDA.Application.DeXuatChuTruongMois;
 using QLDA.Domain.Constants;
 using QLDA.Domain.Entities.DanhMuc;
 
@@ -29,6 +29,7 @@ internal class DeXuatChuTruongMoiInsertCommandHandler : IRequestHandler<DeXuatCh
 
         var entity = new DeXuatChuTruongMoi
         {
+            Id = request.Dto.Id,
             DuAnId = request.Dto.DuAnId,
             BuocId = request.Dto.BuocId,
             TongMucDauTu = request.Dto.TongMucDauTu,
@@ -40,6 +41,8 @@ internal class DeXuatChuTruongMoiInsertCommandHandler : IRequestHandler<DeXuatCh
             DonViPhuTrachChinhId = request.Dto.DonViPhuTrachChinhId,
             TrangThaiId = trangThaiDuThao?.Id,
         };
+        entity.SyncDonViPhoiHopIds(
+            request.Dto.DeXuatDonViXuLys?.Select(x => x.RightId).ToList() ?? []);
 
         using var tx = await _unitOfWork.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         await _repo.AddAsync(entity, cancellationToken);

--- a/QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiUpdateCommand.cs
+++ b/QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiUpdateCommand.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using Microsoft.EntityFrameworkCore;
+using QLDA.Application.DeXuatChuTruongMois;
 using QLDA.Application.DeXuatChuTruongMois.DTOs;
 using QLDA.Domain.Constants;
 
@@ -24,8 +25,10 @@ internal class DeXuatChuTruongMoiUpdateCommandHandler : IRequestHandler<DeXuatCh
     {
         var trangThaiDuThao = await _statusRepo.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
             .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DeXuatMacDinh.DuThao && s.Loai == PheDuyetEntityNames.DeXuatMacDinhStt, cancellationToken);
-
+    
         var entity = await _repo.GetQueryableSet()
+            .Include(e => e.DeXuatDonViXuLys)
+            .Include(e => e.TrangThai)
             .FirstOrDefaultAsync(e => e.Id == request.Dto.Id, cancellationToken);
         ManagedException.ThrowIf(entity == null, "Không tìm thấy dữ liệu.");
 
@@ -41,9 +44,12 @@ internal class DeXuatChuTruongMoiUpdateCommandHandler : IRequestHandler<DeXuatCh
         entity.NguoiXuLyChinhId = request.Dto.NguoiXuLyChinhId;
         entity.NgayBatDauDuKien = request.Dto.NgayBatDauDuKien;
         entity.DonViPhuTrachChinhId = request.Dto.DonViPhuTrachChinhId;
+        entity.LanhDaoPhuTrachId = request.Dto.LanhDaoPhuTrachId;
 
         entity.DuAnId = request.Dto.DuAnId;
         entity.BuocId = request.Dto.BuocId;
+
+        entity.SyncDonViPhoiHopIds(request.Dto.DonViPhoiHopIds);
 
         using var tx = await _unitOfWork.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         await _repo.UpdateAsync(entity, cancellationToken);

--- a/QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiUpdateCommand.cs
+++ b/QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiUpdateCommand.cs
@@ -25,11 +25,11 @@ internal class DeXuatChuTruongMoiUpdateCommandHandler : IRequestHandler<DeXuatCh
     {
         var trangThaiDuThao = await _statusRepo.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
             .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DeXuatMacDinh.DuThao && s.Loai == PheDuyetEntityNames.DeXuatMacDinhStt, cancellationToken);
-    
+
         var entity = await _repo.GetQueryableSet()
             .Include(e => e.DeXuatDonViXuLys)
             .Include(e => e.TrangThai)
-            .FirstOrDefaultAsync(e => e.Id == request.Dto.Id, cancellationToken);
+            .FirstOrDefaultAsync(e => e.Id == request.Dto.Id, cancellationToken);// Không tìm thấy dữ liệu
         ManagedException.ThrowIf(entity == null, "Không tìm thấy dữ liệu.");
 
         // Validate current status must be null (legacy), Dự thảo, or Migrated (LEG)
@@ -44,7 +44,7 @@ internal class DeXuatChuTruongMoiUpdateCommandHandler : IRequestHandler<DeXuatCh
         entity.NguoiXuLyChinhId = request.Dto.NguoiXuLyChinhId;
         entity.NgayBatDauDuKien = request.Dto.NgayBatDauDuKien;
         entity.DonViPhuTrachChinhId = request.Dto.DonViPhuTrachChinhId;
-        entity.LanhDaoPhuTrachId = request.Dto.LanhDaoPhuTrachId;
+        entity.LanhDaoPhuTrachId = request.Dto.LanhDaoPhuTrachId;// Không được phép cập nhật
 
         entity.DuAnId = request.Dto.DuAnId;
         entity.BuocId = request.Dto.BuocId;

--- a/QLDA.Application/DeXuatChuTruongMoi/DeXuatChuTruongMoiMappings.cs
+++ b/QLDA.Application/DeXuatChuTruongMoi/DeXuatChuTruongMoiMappings.cs
@@ -28,6 +28,7 @@ public static class DeXuatChuTruongMoiMappings {
 
     public static void SyncDonViPhoiHopIds(this DeXuatChuTruongMoi entity, List<long>? donViPhoiHopIds) {
         if (donViPhoiHopIds is null) {
+            entity.DeXuatDonViXuLys = [];
             return;
         }
 

--- a/QLDA.Application/DeXuatChuTruongMoi/DeXuatChuTruongMoiMappings.cs
+++ b/QLDA.Application/DeXuatChuTruongMoi/DeXuatChuTruongMoiMappings.cs
@@ -26,6 +26,21 @@ public static class DeXuatChuTruongMoiMappings {
         };
     }
 
+    public static void SyncDonViPhoiHopIds(this DeXuatChuTruongMoi entity, List<long>? donViPhoiHopIds) {
+        if (donViPhoiHopIds is null) {
+            return;
+        }
+
+        entity.DeXuatDonViXuLys ??= [];
+        entity.DeXuatDonViXuLys.Clear();
+        foreach (var donViId in donViPhoiHopIds) {
+            entity.DeXuatDonViXuLys.Add(new DeXuatDonViXuLy {
+                LeftId = entity.Id,
+                RightId = donViId,
+            });
+        }
+    }
+
     public static DeXuatChuTruongMoiDto ToDto(this DeXuatChuTruongMoi entity, List<TepDinhKem>? files = null) {
         return new DeXuatChuTruongMoiDto
         {

--- a/QLDA.Application/DeXuatChuTruongMoi/Queries/DeXuatChuTruongMoiGetQuery.cs
+++ b/QLDA.Application/DeXuatChuTruongMoi/Queries/DeXuatChuTruongMoiGetQuery.cs
@@ -20,6 +20,7 @@ internal class DeXuatChuTruongMoiGetQueryHandler(IServiceProvider serviceProvide
     public async Task<DeXuatChuTruongMoi> Handle(DeXuatChuTruongMoiGetQuery request,
         CancellationToken cancellationToken = default) {
         var queryable = DeXuatChuTruongMoi.GetOrderedSet()
+            .Include(e => e.DeXuatDonViXuLys)
             .Where(e => e.Id == request.Id);
 
         if (request.IsNoTracking)

--- a/QLDA.WebApi/Controllers/DeXuatChuTruongMoiController.cs
+++ b/QLDA.WebApi/Controllers/DeXuatChuTruongMoiController.cs
@@ -90,20 +90,7 @@ public class DeXuatChuTruongMoiController : AggregateRootController {
         [FromServices] IUnitOfWork unitOfWork,
         CancellationToken cancellationToken = default)
     {
-        var entity = await Mediator.Send(new DeXuatChuTruongMoiUpdateCommand(
-            new()
-            {
-                Id = model.GetId(),
-                DuAnId = model.DuAnId,
-                BuocId = model.BuocId,  
-                DonViPhuTrachChinhId = model.BuocId,
-                LanhDaoPhuTrachId = model.BuocId,
-                HinhThucDauTuId = model.HinhThucDauTuId,
-                TomTatNoiDung = model.TomTatNoiDung,
-                NgayBatDauDuKien = model.NgayBatDauDuKien,
-                TongMucDauTu= model.TongMucDauTu,
-            }
-        ), cancellationToken);
+        var entity = await Mediator.Send(new DeXuatChuTruongMoiUpdateCommand(model.ToInsertDto()), cancellationToken);
 
         List<TepDinhKem> files = [.. model.DanhSachTepDinhKem?.ToEntities(entity.Id,
             GroupTypeConstants.ChuTruongMoi) ?? []];

--- a/QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiMappingConfiguration.cs
@@ -24,10 +24,8 @@ public static class DeXuatChuTruongMoiMappingConfiguration {
         };
 
 
-    public static DeXuatChuTruongMoi ToEntity(this DeXuatChuTruongMoiModel model) {
-        var id = model.GetId();
-        return new() {
-            Id = id,
+    public static DeXuatChuTruongMoi ToEntity(this DeXuatChuTruongMoiModel model) =>
+        new() {
             BuocId = model.BuocId,
             DuAnId = model.DuAnId,
             TongMucDauTu = model.TongMucDauTu,
@@ -37,11 +35,10 @@ public static class DeXuatChuTruongMoiMappingConfiguration {
             NguoiXuLyChinhId = model.NguoiXuLyChinhId,
             HinhThucDauTuId = model.HinhThucDauTuId,
             DonViPhuTrachChinhId = model.DonViPhuTrachChinhId,
-            DeXuatDonViXuLys = model.DonViPhoiHopIds != null && model.DonViPhoiHopIds.Count != 0
-                ? [.. model.DonViPhoiHopIds.Select(donViId => new DeXuatDonViXuLy { LeftId = id, RightId = donViId })]
-                : [],
+            DeXuatDonViXuLys = model.DonViPhoiHopIds?
+                .Select(donViId => new DeXuatDonViXuLy { RightId = donViId })
+                .ToList() ?? [],
         };
-    }
 
     public static DeXuatChuTruongMoiInsertDto ToInsertDto(this DeXuatChuTruongMoiModel model) =>
         new() {

--- a/QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiMappingConfiguration.cs
@@ -1,4 +1,5 @@
 using BuildingBlocks.Domain.Entities.Abstractions;
+using QLDA.Application.DeXuatChuTruongMois.DTOs;
 using QLDA.Domain.Interfaces;
 using QLDA.WebApi.Models.TepDinhKems;
 
@@ -14,17 +15,19 @@ public static class DeXuatChuTruongMoiMappingConfiguration {
             TomTatNoiDung = entity.TomTatNoiDung,
             NgayBatDauDuKien = entity.NgayBatDauDuKien,
             LanhDaoPhuTrachId = entity.LanhDaoPhuTrachId,
-            NguoiXuLyChinhId = entity.LanhDaoPhuTrachId,
+            NguoiXuLyChinhId = entity.NguoiXuLyChinhId,
             DonViPhuTrachChinhId = entity.DonViPhuTrachChinhId,
             HinhThucDauTuId = entity.HinhThucDauTuId,
             TrangThaiId = entity.TrangThaiId,
+            DonViPhoiHopIds = entity.DeXuatDonViXuLys?.Select(x => x.RightId).ToList(),
             DanhSachTepDinhKem = danhSachTepDinhKem?.Select(o => o.ToModel()).ToList()
         };
 
 
-    public static DeXuatChuTruongMoi ToEntity(this DeXuatChuTruongMoiModel model)
-        => new() {
-            Id = model.GetId(),
+    public static DeXuatChuTruongMoi ToEntity(this DeXuatChuTruongMoiModel model) {
+        var id = model.GetId();
+        return new() {
+            Id = id,
             BuocId = model.BuocId,
             DuAnId = model.DuAnId,
             TongMucDauTu = model.TongMucDauTu,
@@ -33,8 +36,27 @@ public static class DeXuatChuTruongMoiMappingConfiguration {
             LanhDaoPhuTrachId = model.LanhDaoPhuTrachId,
             NguoiXuLyChinhId = model.NguoiXuLyChinhId,
             HinhThucDauTuId = model.HinhThucDauTuId,
-            DonViPhuTrachChinhId = model.DonViPhuTrachChinhId
+            DonViPhuTrachChinhId = model.DonViPhuTrachChinhId,
+            DeXuatDonViXuLys = model.DonViPhoiHopIds != null && model.DonViPhoiHopIds.Count != 0
+                ? [.. model.DonViPhoiHopIds.Select(donViId => new DeXuatDonViXuLy { LeftId = id, RightId = donViId })]
+                : [],
+        };
+    }
 
+    public static DeXuatChuTruongMoiInsertDto ToInsertDto(this DeXuatChuTruongMoiModel model) =>
+        new() {
+            Id = model.GetId(),
+            DuAnId = model.DuAnId,
+            BuocId = model.BuocId,
+            TomTatNoiDung = model.TomTatNoiDung,
+            TongMucDauTu = model.TongMucDauTu,
+            NgayBatDauDuKien = model.NgayBatDauDuKien,
+            HinhThucDauTuId = model.HinhThucDauTuId,
+            LanhDaoPhuTrachId = model.LanhDaoPhuTrachId,
+            NguoiXuLyChinhId = model.NguoiXuLyChinhId,
+            DonViPhuTrachChinhId = model.DonViPhuTrachChinhId,
+            TrangThaiId = model.TrangThaiId,
+            DonViPhoiHopIds = model.DonViPhoiHopIds,
         };
 
     public static void Update(this DeXuatChuTruongMoi entity, DeXuatChuTruongMoiModel model) {

--- a/docs/feature/DeXuatChuTruongMoi/issue-don-vi-phoi-hop-ids-khong-luu.md
+++ b/docs/feature/DeXuatChuTruongMoi/issue-don-vi-phoi-hop-ids-khong-luu.md
@@ -244,3 +244,5 @@ Module **DuAnBuoc** + `DuAnBuocPhongBanPhoiHop` — cùng pattern junction many-
 ## Kết luận một dòng
 
 **Đây là bug thiếu persist navigation collection `DeXuatDonViXuLys` khi save `DeXuatChuTruongMoi`**, không phải lỗi DB/migration. API đã nhận `donViPhoiHopIds` nhưng insert/update handler và WebApi mapping chưa đẩy dữ liệu xuống bảng junction; cần bổ sung logic sync giống `DuAnBuocPhongBanPhoiHop`.
+
+> **Cập nhật sau code review:** chi tiết implement + chỉnh POST không `Id` client, `SyncDonViPhoiHopIds(null)` → `[]` — xem [`task-fix-don-vi-phoi-hop-ids.md`](./task-fix-don-vi-phoi-hop-ids.md) §8.

--- a/docs/feature/DeXuatChuTruongMoi/issue-don-vi-phoi-hop-ids-khong-luu.md
+++ b/docs/feature/DeXuatChuTruongMoi/issue-don-vi-phoi-hop-ids-khong-luu.md
@@ -1,0 +1,246 @@
+# Issue: `donViPhoiHopIds` không lưu vào `DeXuatDonViXuLy`
+
+## Tóm tắt
+
+Khi gọi **POST** `/api/de-xuat-chu-truong-moi/them-moi` hoặc **PUT** `/api/de-xuat-chu-truong-moi/cap-nhat` với payload có `donViPhoiHopIds` (ví dụ `[219]`), bản ghi chính **`DeXuatChuTruongMoi`** được insert/update thành công, nhưng bảng junction **`DeXuatDonViXuLy`** vẫn trống.
+
+**Nguyên nhân gốc:** thiếu logic đồng bộ collection `DeXuatDonViXuLys` ở tầng mapping + command handler (insert/update). Mapping Application đã có sẵn nhưng **không được dùng**; handler tự tạo entity mới và bỏ qua navigation collection.
+
+---
+
+## Hiện trạng (reproduce)
+
+### API bị ảnh hưởng
+
+| Method | Endpoint | Ghi chú |
+| ------ | -------- | ------- |
+| POST | `/api/de-xuat-chu-truong-moi/them-moi` | Tạo mới |
+| PUT | `/api/de-xuat-chu-truong-moi/cap-nhat` | Cập nhật |
+| GET | `/api/de-xuat-chu-truong-moi/{id}/chi-tiet` | Đọc lại cũng không thấy đơn vị phối hợp (phụ) |
+
+### Payload mẫu (Swagger)
+
+```json
+{
+  "buocId": 0,
+  "duAnId": "1690F8E4-3352-48D2-8D48-1D6196B2E74F6",
+  "tomTatNoiDung": "string",
+  "tongMucDauTu": 1000,
+  "ngayBatDauDuKien": "2026-05-22T03:59:11.991Z",
+  "hinhThucDauTuId": 3,
+  "lanhDaoPhuTrachId": 4,
+  "donViPhuTrachChinhId": 220,
+  "nguoiXuLyChinhId": 4,
+  "trangThaiId": 0,
+  "donViPhoiHopIds": [219],
+  "danhSachTepDinhKem": []
+}
+```
+
+### Kết quả DB
+
+| Bảng | Kỳ vọng | Thực tế |
+| ---- | ------- | ------- |
+| `DeXuatChuTruongMoi` | 1 row mới/cập nhật | OK |
+| `DeXuatDonViXuLy` | 1 row `(DuAnId=<DeXuat.Id>, DonViId=219)` | **Không có dữ liệu** |
+
+> Lưu ý: cột FK trong DB là `DuAnId` / `DonViId` (map từ `LeftId` / `RightId` của junction entity), không phải `DuAnId` của dự án.
+
+---
+
+## Mô hình dữ liệu
+
+### Entity chính
+
+`DeXuatChuTruongMoi` có navigation:
+
+```csharp
+public ICollection<DeXuatDonViXuLy>? DeXuatDonViXuLys { get; set; } = [];
+```
+
+### Junction — đơn vị phối hợp
+
+`DeXuatDonViXuLy` (`IJunctionEntity<Guid, long>`):
+
+| Property | Ý nghĩa | Cột DB |
+| -------- | ------- | ------ |
+| `LeftId` | Id đề xuất (`DeXuatChuTruongMoi.Id`) | `DuAnId` |
+| `RightId` | Id đơn vị (`DanhMucDonVi.Id`) | `DonViId` |
+
+EF config: `QLDA.Persistence/Configurations/DeXuatDonViXuLyConfiguration.cs` — composite PK, cascade delete khi xóa đề xuất.
+
+### API field
+
+| Layer | Field |
+| ----- | ----- |
+| WebApi model | `DeXuatChuTruongMoiModel.DonViPhoiHopIds` |
+| Application DTO | `DeXuatChuTruongMoiInsertDto.DonViPhoiHopIds` |
+| Response list (đã có) | `DeXuatChuTruongMoiDto.DanhSachDonViPhoiHop` — join từ `DeXuatDonViXuLys` trong query danh sách |
+
+---
+
+## Luồng hiện tại (vì sao lỗi)
+
+```mermaid
+sequenceDiagram
+    participant FE
+    participant API as DeXuatChuTruongMoiController
+    participant WebMap as WebApi ToEntity
+    participant Cmd as Insert/Update Handler
+    participant DB
+
+    FE->>API: POST donViPhoiHopIds=[219]
+    API->>WebMap: model.ToEntity()
+    Note over WebMap: Không map DeXuatDonViXuLys
+    API->>Cmd: InsertCommand(entity)
+    Note over Cmd: Tạo entity MỚI, bỏ qua DeXuatDonViXuLys
+    Cmd->>DB: SaveChanges DeXuatChuTruongMoi only
+    Note over DB: DeXuatDonViXuLy trống
+```
+
+### 1. WebApi mapping — thiếu map junction
+
+**File:** `QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiMappingConfiguration.cs`
+
+`ToEntity()` chỉ map scalar fields, **không** set `DeXuatDonViXuLys` từ `DonViPhoiHopIds`.
+
+`ToModel()` khi GET chi tiết cũng **không** trả `DonViPhoiHopIds` / danh sách phối hợp.
+
+### 2. Insert handler — bỏ qua entity từ controller
+
+**File:** `QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiInsertCommand.cs`
+
+Handler nhận `request.Dto` (entity đã map từ WebApi) nhưng **tạo lại** `DeXuatChuTruongMoi` thủ công, không copy `DeXuatDonViXuLys`:
+
+```csharp
+var entity = new DeXuatChuTruongMoi {
+    DuAnId = request.Dto.DuAnId,
+    // ... các field scalar ...
+    // THIẾU: DeXuatDonViXuLys = ...
+};
+await _repo.AddAsync(entity, cancellationToken);
+```
+
+EF chỉ insert parent; children không được attach.
+
+### 3. Update handler — không đồng bộ junction
+
+**File:** `QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiUpdateCommand.cs`
+
+- Chỉ cập nhật scalar trên `DeXuatChuTruongMoi`.
+- Không `.Include(e => e.DeXuatDonViXuLys)`.
+- Không clear/re-add theo `DonViPhoiHopIds`.
+
+### 4. Controller Update — không truyền `donViPhoiHopIds`
+
+**File:** `QLDA.WebApi/Controllers/DeXuatChuTruongMoiController.cs`
+
+`cap-nhat` build `DeXuatChuTruongMoiInsertDto` **không có** `DonViPhoiHopIds`. Đồng thời có map sai (cần sửa khi làm task):
+
+```csharp
+DonViPhuTrachChinhId = model.BuocId,      // sai — phải model.DonViPhuTrachChinhId
+LanhDaoPhuTrachId = model.BuocId,           // sai — phải model.LanhDaoPhuTrachId
+```
+
+### 5. Application mapping — có code nhưng không dùng
+
+**File:** `QLDA.Application/DeXuatChuTruongMoi/DeXuatChuTruongMoiMappings.cs`
+
+`ToEntity(DeXuatChuTruongMoiInsertDto)` **đã** map đúng:
+
+```csharp
+DeXuatDonViXuLys = [.. dto.DonViPhoiHopIds?.Select(dvPhoiHops => new DeXuatDonViXuLy {
+    LeftId = id,
+    RightId = dvPhoiHops
+}) ?? []]
+```
+
+Luồng hiện tại **không gọi** extension này (controller dùng WebApi `ToEntity`, handler không dùng DTO mapping).
+
+### 6. GET chi tiết — không load junction
+
+**File:** `QLDA.Application/DeXuatChuTruongMoi/Queries/DeXuatChuTruongMoiGetQuery.cs`
+
+Query không `.Include(e => e.DeXuatDonViXuLys)`. WebApi `ToModel` không map ra `DonViPhoiHopIds`.
+
+> Query **danh sách tiến độ** (`DeXuatChuTruongMoiGetDanhSachQuery`) đã join `DeXuatDonViXuLys` → `DanhSachDonViPhoiHop` — chứng tỏ read path list OK nếu DB có dữ liệu.
+
+---
+
+## Pattern tham chiếu (đã làm đúng trong codebase)
+
+Module **DuAnBuoc** + `DuAnBuocPhongBanPhoiHop` — cùng pattern junction many-to-many:
+
+| Thao tác | File | Cách làm |
+| -------- | ---- | -------- |
+| Create | `DuAnBuocCreateCommand.cs` | Gán `DuAnBuocPhongBanPhoiHops` khi `AddAsync` |
+| Update | `DuAnBuocUpdateCommand.cs` | `.Include`, `Clear()`, add lại từ `DanhSachPhongBanPhoiHopIds` |
+
+Áp dụng tương tự cho `DeXuatDonViXuLys` + `DonViPhoiHopIds`.
+
+**DuAn** (phối hợp ở cấp dự án): `DuAnMappings` + update command gán `DuAnChiuTrachNhiemXuLys` với `Loai = DonViPhoiHop` — khác bảng nhưng cùng ý tưởng sync collection.
+
+---
+
+## Phạm vi sửa đề xuất
+
+### Bắt buộc (fix issue)
+
+| # | File | Việc cần làm |
+| - | ---- | ------------- |
+| 1 | `DeXuatChuTruongMoiInsertCommand.cs` | Khi insert: gán `DeXuatDonViXuLys` từ `DonViPhoiHopIds` (dùng entity từ request hoặc `DeXuatChuTruongMoiMappings.ToEntity`) |
+| 2 | `DeXuatChuTruongMoiUpdateCommand.cs` | `.Include(DeXuatDonViXuLys)`, sync clear + add theo `DonViPhoiHopIds` (giống `DuAnBuocUpdateCommand`) |
+| 3 | `DeXuatChuTruongMoiController.cs` (cap-nhat) | Truyền đủ field DTO gồm `DonViPhoiHopIds`, `NguoiXuLyChinhId`, `LanhDaoPhuTrachId`, `DonViPhuTrachChinhId` (sửa map sai `BuocId`) |
+| 4 | `DeXuatChuTruongMoiMappingConfiguration.cs` (WebApi) | `ToEntity` / `Update` / `ToModel`: map `DonViPhoiHopIds` ↔ `DeXuatDonViXuLys` |
+
+**Khuyến nghị:** thống nhất mapping ở **Application** (`DeXuatChuTruongMoiMappings`) theo rule DTO ↔ Entity; WebApi chỉ map Model ↔ DTO hoặc gọi Application mapping — tránh duplicate logic.
+
+### Nên làm (trải nghiệm API đầy đủ)
+
+| # | File | Việc cần làm |
+| - | ---- | ------------- |
+| 5 | `DeXuatChuTruongMoiGetQuery.cs` + `ToModel` | Include/load junction; GET chi tiết trả `donViPhoiHopIds` hoặc `danhSachDonViPhoiHop` |
+| 6 | (Tùy chọn) `DeXuatChuTruongMoiMappings.ToDto` | `TenDonVi` đang `string.Empty` — join `DanhMucDonVi` nếu cần tên đầy đủ |
+
+### Không cần (trừ khi đổi schema)
+
+- Migration mới — bảng `DeXuatDonViXuLy` và FK đã có trong `Init`.
+- Sửa `AppDbContextModelSnapshot` / migration cũ.
+
+---
+
+## Checklist verify sau khi fix
+
+1. **POST** `them-moi` với `donViPhoiHopIds: [219]`:
+   - Có row `DeXuatChuTruongMoi`.
+   - Có row `DeXuatDonViXuLy` với `DuAnId = <Id đề xuất>`, `DonViId = 219`.
+2. **PUT** `cap-nhat` đổi `[219]` → `[220, 221]`:
+   - Junction cũ bị thay thế (clear + insert mới), không duplicate PK.
+3. **PUT** với `donViPhoiHopIds: []`:
+   - Xóa hết junction (nếu product cho phép list rỗng).
+4. **GET** `chi-tiet` / `danh-sach-tien-do` hiển thị đúng đơn vị phối hợp.
+5. **DELETE** đề xuất → junction cascade (theo config).
+
+---
+
+## Files liên quan (inventory)
+
+| Vai trò | Đường dẫn |
+| ------- | --------- |
+| Controller | `QLDA.WebApi/Controllers/DeXuatChuTruongMoiController.cs` |
+| WebApi model | `QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiModel.cs` |
+| WebApi mapping | `QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiMappingConfiguration.cs` |
+| Insert command | `QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiInsertCommand.cs` |
+| Update command | `QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiUpdateCommand.cs` |
+| App mapping (chưa wired) | `QLDA.Application/DeXuatChuTruongMoi/DeXuatChuTruongMoiMappings.cs` |
+| DTO | `QLDA.Application/DeXuatChuTruongMoi/DTOs/DeXuatChuTruongMoiInsertDto.cs` |
+| Entity | `QLDA.Domain/Entities/DeXuatChuTruongMoi.cs`, `DeXuatDonViXuLy.cs` |
+| EF config | `QLDA.Persistence/Configurations/DeXuatDonViXuLyConfiguration.cs` |
+| List query (read OK) | `QLDA.Application/DeXuatChuTruongMoi/Queries/DeXuatChuTruongMoiGetDanhSachQuery.cs` |
+| Reference pattern | `QLDA.Application/DuAnBuocs/Commands/DuAnBuocCreateCommand.cs`, `DuAnBuocUpdateCommand.cs` |
+
+---
+
+## Kết luận một dòng
+
+**Đây là bug thiếu persist navigation collection `DeXuatDonViXuLys` khi save `DeXuatChuTruongMoi`**, không phải lỗi DB/migration. API đã nhận `donViPhoiHopIds` nhưng insert/update handler và WebApi mapping chưa đẩy dữ liệu xuống bảng junction; cần bổ sung logic sync giống `DuAnBuocPhongBanPhoiHop`.

--- a/docs/feature/DeXuatChuTruongMoi/task-fix-don-vi-phoi-hop-ids.md
+++ b/docs/feature/DeXuatChuTruongMoi/task-fix-don-vi-phoi-hop-ids.md
@@ -15,6 +15,8 @@
 | 2   | **PUT** `cap-nhat` đồng bộ junction      | Clear + re-add theo `donViPhoiHopIds` (pattern `DuAnBuocPhongBanPhoiHop`) |
 | 3   | **GET** `chi-tiet` trả `donViPhoiHopIds` | Include navigation + map `ToModel`                                        |
 | 4   | Sửa bug map **PUT** controller           | `DonViPhuTrachChinhId` / `LanhDaoPhuTrachId` bị gán nhầm `buocId`         |
+| 5   | **Review:** POST không gán `Id` client   | Để DB/EF sinh `NEWSEQUENTIALID`; junction sync **sau** `SaveChanges` đầu |
+| 6   | **Review:** `SyncDonViPhoiHopIds(null)`  | Gán `entity.DeXuatDonViXuLys = []` — EF junction tracking xóa liên kết   |
 
 
 ### 1.2 Field API liên quan
@@ -75,7 +77,7 @@
 | Field | Kiểu (Model / InsertDto) | Bắt buộc API? | Ghi chú |
 |-------|--------------------------|---------------|---------|
 | `duAnId` | `Guid` | **Có** | `ITienDo`; FK `DuAn` Restrict |
-| `id` | `Guid?` | Không (POST) | `GetId()` sinh GUID nếu null |
+| `id` | `Guid?` | **Không gửi khi POST** | Thêm mới: **không** map `Id` từ client; response trả `savedEntity.Id` sau insert |
 | `buocId` | `int?` | Không (attribute) | Remark controller “Quy trình id bắt buộc” → gọi `DuAnUpdateStepCommand`, không phải `[Required]` |
 | **`donViPhoiHopIds`** | `List<long>?` | **Không** | `null` / `[]` / `[219]` đều pass validation |
 | `tomTatNoiDung`, `tongMucDauTu`, `ngayBatDauDuKien` | nullable | Không | |
@@ -167,7 +169,7 @@ if (request.Dto.DanhSachPhongBanPhoiHopIds != null) {
 
 ```
 Bước 1: Application – DeXuatChuTruongMoiMappings.SyncDonViPhoiHopIds
-Bước 2: Application – DeXuatChuTruongMoiInsertCommand (Id + junction)
+Bước 2: Application – DeXuatChuTruongMoiInsertCommand (không Id client; junction sau SaveChanges)
 Bước 3: Application – DeXuatChuTruongMoiUpdateCommand (Include + sync)
 Bước 4: Application – DeXuatChuTruongMoiGetQuery (Include junction)
 Bước 5: WebApi – DeXuatChuTruongMoiMappingConfiguration (ToEntity, ToModel, ToInsertDto)
@@ -191,6 +193,7 @@ Bước 6: WebApi – DeXuatChuTruongMoiController.Update (ToInsertDto)
 ```csharp
 public static void SyncDonViPhoiHopIds(this DeXuatChuTruongMoi entity, List<long>? donViPhoiHopIds) {
     if (donViPhoiHopIds is null) {
+        entity.DeXuatDonViXuLys = [];
         return;
     }
 
@@ -205,12 +208,13 @@ public static void SyncDonViPhoiHopIds(this DeXuatChuTruongMoi entity, List<long
 }
 ```
 
+> **Review (junction nhiều key):** Gán `DeXuatDonViXuLys = []` khi `null` để EF hiểu đang **xóa hết** liên kết (tracking collection), không `return` sớm bỏ qua.
 
-| `donViPhoiHopIds` | Hành vi                     |
-| ----------------- | --------------------------- |
-| `null`            | Không đổi junction (update) |
-| `[]`              | Xóa hết đơn vị phối hợp     |
-| `[219, 220]`      | Thay thế toàn bộ            |
+| `donViPhoiHopIds` | Hành vi |
+| ----------------- | ------- |
+| `null`            | `entity.DeXuatDonViXuLys = []` — xóa hết liên kết (PUT; insert sau khi có `Id`) |
+| `[]`              | Clear rồi không add — junction trống |
+| `[219, 220]`      | Thay thế toàn bộ (`LeftId` = `entity.Id`) |
 
 
 ---
@@ -221,30 +225,33 @@ public static void SyncDonViPhoiHopIds(this DeXuatChuTruongMoi entity, List<long
 
 **Trước:** Entity mới không có `Id` từ client, không có `DeXuatDonViXuLys`.
 
-**Sau:**
+**Sau (theo review — không `Id = request.Dto.Id`):**
 
 ```csharp
+var donViPhoiHopIds = request.Dto.DeXuatDonViXuLys?
+    .Select(x => x.RightId).ToList();
+
 var entity = new DeXuatChuTruongMoi
 {
-    Id = request.Dto.Id,
+    // Không gán Id — DB default NEWSEQUENTIALID
     DuAnId = request.Dto.DuAnId,
     BuocId = request.Dto.BuocId,
-    TongMucDauTu = request.Dto.TongMucDauTu,
-    TomTatNoiDung = request.Dto.TomTatNoiDung,
-    NgayBatDauDuKien = request.Dto.NgayBatDauDuKien,
-    HinhThucDauTuId = request.Dto.HinhThucDauTuId,
-    NguoiXuLyChinhId = request.Dto.NguoiXuLyChinhId,
-    LanhDaoPhuTrachId = request.Dto.LanhDaoPhuTrachId,
-    DonViPhuTrachChinhId = request.Dto.DonViPhuTrachChinhId,
+    // ... scalar fields ...
     TrangThaiId = trangThaiDuThao?.Id,
 };
-entity.SyncDonViPhoiHopIds(
-    request.Dto.DeXuatDonViXuLys?.Select(x => x.RightId).ToList() ?? []);
 
+using var tx = await _unitOfWork.BeginTransactionAsync(...);
 await _repo.AddAsync(entity, cancellationToken);
+await _unitOfWork.SaveChangesAsync(cancellationToken); // entity.Id có giá trị
+
+entity.SyncDonViPhoiHopIds(donViPhoiHopIds); // null → DeXuatDonViXuLys = []
+await _unitOfWork.SaveChangesAsync(cancellationToken);
+await _unitOfWork.CommitTransactionAsync(cancellationToken);
 ```
 
-> `request.Dto` là `DeXuatChuTruongMoi` từ `model.ToEntity()` — `DeXuatDonViXuLys` đã map từ `donViPhoiHopIds` ở WebApi.
+> POST **không** truyền `id` từ FE. `TepDinhKem` dùng `savedEntity.Id` **sau** insert — khớp Id DB.
+>
+> WebApi `ToEntity()` **không** gọi `GetId()` / không set `Id`; chỉ gửi `RightId` tạm trong `DeXuatDonViXuLys` (hoặc list ids) để handler sync sau `SaveChanges`.
 
 ---
 
@@ -293,28 +300,22 @@ var queryable = DeXuatChuTruongMoi.GetOrderedSet()
 
 **File:** `QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiMappingConfiguration.cs`
 
-#### `ToEntity` (POST)
+#### `ToEntity` (POST) — không set `Id`
 
 ```csharp
-public static DeXuatChuTruongMoi ToEntity(this DeXuatChuTruongMoiModel model) {
-    var id = model.GetId();
-    return new() {
-        Id = id,
+public static DeXuatChuTruongMoi ToEntity(this DeXuatChuTruongMoiModel model) =>
+    new() {
+        // Không Id, không GetId() — thêm mới để DB sinh Id
         BuocId = model.BuocId,
         DuAnId = model.DuAnId,
-        TongMucDauTu = model.TongMucDauTu,
-        TomTatNoiDung = model.TomTatNoiDung,
-        NgayBatDauDuKien = model.NgayBatDauDuKien,
-        LanhDaoPhuTrachId = model.LanhDaoPhuTrachId,
-        NguoiXuLyChinhId = model.NguoiXuLyChinhId,
-        HinhThucDauTuId = model.HinhThucDauTuId,
-        DonViPhuTrachChinhId = model.DonViPhuTrachChinhId,
-        DeXuatDonViXuLys = model.DonViPhoiHopIds != null && model.DonViPhoiHopIds.Count != 0
-            ? [.. model.DonViPhoiHopIds.Select(donViId => new DeXuatDonViXuLy { LeftId = id, RightId = donViId })]
-            : [],
+        // ... scalar ...
+        DeXuatDonViXuLys = model.DonViPhoiHopIds?
+            .Select(donViId => new DeXuatDonViXuLy { RightId = donViId })
+            .ToList() ?? [],
     };
-}
 ```
+
+`LeftId` gán trong `SyncDonViPhoiHopIds` **sau** `SaveChanges` khi `entity.Id` đã có.
 
 #### `ToModel` (GET chi tiết)
 
@@ -376,7 +377,10 @@ await Mediator.Send(new DeXuatChuTruongMoiUpdateCommand(model.ToInsertDto()), ca
 
 ```
 [x] 1. Thêm SyncDonViPhoiHopIds vào DeXuatChuTruongMoiMappings
-[x] 2. Sửa DeXuatChuTruongMoiInsertCommand (Id + junction trước AddAsync)
+[x] 2. Sửa DeXuatChuTruongMoiInsertCommand (lần 1)
+[x] 2b. Review: bỏ `Id = request.Dto.Id`; junction sau SaveChanges
+[x] 1b. Review: `SyncDonViPhoiHopIds(null)` → `DeXuatDonViXuLys = []`
+[x] 5b. Review: `ToEntity` POST không `GetId()`
 [x] 3. Sửa DeXuatChuTruongMoiUpdateCommand (Include + LanhDaoPhuTrachId + sync)
 [x] 4. Sửa DeXuatChuTruongMoiGetQuery (Include DeXuatDonViXuLys)
 [x] 5. Sửa ToEntity / ToModel / thêm ToInsertDto (WebApi mapping)
@@ -390,8 +394,9 @@ await Mediator.Send(new DeXuatChuTruongMoiUpdateCommand(model.ToInsertDto()), ca
 ## 6. Lưu ý kỹ thuật
 
 - **Không migration** — bảng `DeXuatDonViXuLy` đã có trong `Init`.
-- **Insert:** `Id` phải khớp `model.GetId()` để `TepDinhKem` (`GroupId = savedEntity.Id`) và junction `LeftId` cùng một GUID.
-- **Update:** `SyncDonViPhoiHopIds(null)` giữ junction cũ; PUT qua `ToInsertDto` truyền list từ model (có thể `null` nếu FE không gửi field).
+- **Insert:** **không** gán `Id` từ client; `SaveChanges` → `savedEntity.Id` cho `TepDinhKem` và `LeftId` junction.
+- **Junction `null`:** `SyncDonViPhoiHopIds(null)` → `DeXuatDonViXuLys = []` (EF xóa liên kết khi update/tracking).
+- **PUT:** `ToInsertDto` vẫn cần `Id` (`GetId()`) — chỉ **POST them-moi** không truyền Id.
 - **List tiến độ** (`danh-sach-tien-do`): không đổi — vẫn join `DanhMucDonVi` → `DanhSachDonViPhoiHop`.
 - **GET chi tiết:** chỉ trả `donViPhoiHopIds` (ids), chưa trả tên đơn vị; tên có ở list query.
 - **`[Required]`:** xem **§1.5** — chỉ `duAnId` bắt buộc qua `Guid` non-nullable; `donViPhoiHopIds` không required.
@@ -423,7 +428,8 @@ dotnet build "e:\SER\QLDA.WebApi\QLDA.WebApi.csproj"
 | Lỗi                                      | Sửa                                                  |
 | ---------------------------------------- | ---------------------------------------------------- |
 | Insert handler bỏ qua `DeXuatDonViXuLys` | `SyncDonViPhoiHopIds` + `AddAsync` với collection    |
-| Insert không set `Id` từ request         | `Id = request.Dto.Id`                                |
+| Insert gán `Id = request.Dto.Id` (sai review) | Bỏ; DB sinh Id; sync junction sau `SaveChanges` |
+| `SyncDonViPhoiHopIds(null)` return sớm   | `entity.DeXuatDonViXuLys = []`                       |
 | Update không sync junction               | `.Include(DeXuatDonViXuLys)` + `SyncDonViPhoiHopIds` |
 | Update thiếu `LanhDaoPhuTrachId`         | Gán từ `request.Dto`                                 |
 | Get không load junction                  | `.Include(e => e.DeXuatDonViXuLys)`                  |
@@ -434,7 +440,8 @@ dotnet build "e:\SER\QLDA.WebApi\QLDA.WebApi.csproj"
 
 | Lỗi                                               | Sửa                                           |
 | ------------------------------------------------- | --------------------------------------------- |
-| `ToEntity` không map `donViPhoiHopIds`            | Gán `DeXuatDonViXuLys` với `LeftId = GetId()` |
+| `ToEntity` không map `donViPhoiHopIds`            | Chỉ `RightId` tạm; `LeftId` sau SaveChanges      |
+| `ToEntity` dùng `GetId()` trên POST               | Bỏ `Id` / `GetId()` trên them-moi                |
 | `ToModel`: `NguoiXuLyChinhId = LanhDaoPhuTrachId` | `NguoiXuLyChinhId = entity.NguoiXuLyChinhId`  |
 | `ToModel` thiếu `DonViPhoiHopIds`                 | Select `RightId` từ navigation                |
 | PUT build DTO thiếu field, map `BuocId` sai       | `model.ToInsertDto()`                         |
@@ -486,6 +493,16 @@ GET:  DB → Include DeXuatDonViXuLys → ToModel.DonViPhoiHopIds
 
 ### Trạng thái
 
-- **Code:** đã implement (bước 1–6)
-- **Tiếp theo:** build + test API + tick checklist mục 7
+- **Code:** đã implement (bước 1–6); **đang chỉnh theo code review** (§1.1 mục 5–6, §4 bước 1–2, 5)
+- **Tiếp theo:** apply 2b/1b/5b → build + test API + tick checklist mục 7
+
+---
+
+## 8. Code review — chỉnh sau PR (bổ sung)
+
+| # | Feedback | Hành động |
+|---|----------|-----------|
+| 1 | Thêm mới **không** truyền `Id` (`Id = request.Dto.Id` sai) | Insert handler + `ToEntity` POST bỏ `GetId()` |
+| 2 | Junction: `donViPhoiHopIds == null` → `DeXuatDonViXuLys = []` | Sửa `SyncDonViPhoiHopIds` — EF tracking xóa liên kết |
+| 3 | Insert: sync junction **sau** khi parent đã có `Id` (SaveChanges) | Hai lần `SaveChanges` trong cùng transaction |
 

--- a/docs/feature/DeXuatChuTruongMoi/task-fix-don-vi-phoi-hop-ids.md
+++ b/docs/feature/DeXuatChuTruongMoi/task-fix-don-vi-phoi-hop-ids.md
@@ -1,0 +1,491 @@
+# Task – Fix lưu `donViPhoiHopIds` → `DeXuatDonViXuLy`
+
+> Phân tích issue: `[issue-don-vi-phoi-hop-ids-khong-luu.md](./issue-don-vi-phoi-hop-ids-khong-luu.md)`
+
+---
+
+## 1. Phân tích yêu cầu
+
+### 1.1 Việc cần làm
+
+
+| #   | Mục                                      | Ghi chú                                                                   |
+| --- | ---------------------------------------- | ------------------------------------------------------------------------- |
+| 1   | **POST** `them-moi` lưu đơn vị phối hợp  | Insert `DeXuatDonViXuLy` cùng lúc với `DeXuatChuTruongMoi`                |
+| 2   | **PUT** `cap-nhat` đồng bộ junction      | Clear + re-add theo `donViPhoiHopIds` (pattern `DuAnBuocPhongBanPhoiHop`) |
+| 3   | **GET** `chi-tiet` trả `donViPhoiHopIds` | Include navigation + map `ToModel`                                        |
+| 4   | Sửa bug map **PUT** controller           | `DonViPhuTrachChinhId` / `LanhDaoPhuTrachId` bị gán nhầm `buocId`         |
+
+
+### 1.2 Field API liên quan
+
+
+| Field request/response | Kiểu          | Map DB                                                        |
+| ---------------------- | ------------- | ------------------------------------------------------------- |
+| `donViPhoiHopIds`      | `List<long>?` | `DeXuatDonViXuLy.DonViId` (`RightId`)                         |
+| —                      | —             | `DeXuatDonViXuLy.DuAnId` = `DeXuatChuTruongMoi.Id` (`LeftId`) |
+
+
+> Cột DB `DuAnId` trên bảng junction = **Id đề xuất**, không phải `DuAnId` dự án.
+
+### 1.3 Payload mẫu
+
+```json
+{
+  "duAnId": "1690F8E4-3352-48D2-8D48-1D6196B2E74F6",
+  "buocId": 0,
+  "tomTatNoiDung": "string",
+  "tongMucDauTu": 1000,
+  "ngayBatDauDuKien": "2026-05-22T03:59:11.991Z",
+  "hinhThucDauTuId": 3,
+  "lanhDaoPhuTrachId": 4,
+  "donViPhuTrachChinhId": 220,
+  "nguoiXuLyChinhId": 4,
+  "donViPhoiHopIds": [219],
+  "danhSachTepDinhKem": []
+}
+```
+
+### 1.4 API bị ảnh hưởng
+
+
+| Method | Endpoint                                    | Sau fix                |
+| ------ | ------------------------------------------- | ---------------------- |
+| POST   | `/api/de-xuat-chu-truong-moi/them-moi`      | Parent + junction      |
+| PUT    | `/api/de-xuat-chu-truong-moi/cap-nhat`      | Parent + sync junction |
+| GET    | `/api/de-xuat-chu-truong-moi/{id}/chi-tiet` | Có `donViPhoiHopIds`   |
+
+### 1.5 Kiểm tra `[Required]` / field bắt buộc (đã rà soát code)
+
+> **Trước đây task doc chưa có mục này.** Audit dưới đây phục vụ test Swagger/FE và xác nhận `donViPhoiHopIds` không bị validation chặn.
+
+#### Kết luận nhanh
+
+| Nguồn | Có `[Required]` attribute? |
+|-------|----------------------------|
+| `DeXuatChuTruongMoiModel` | **Không** |
+| `DeXuatChuTruongMoiInsertDto` / `UpdateDto` | **Không** |
+| FluentValidation module DeXuatChuTruongMoi | **Không** (không có `*Validator`) |
+| **`donViPhoiHopIds`** | **Không bắt buộc** — phù hợp fix (optional list) |
+
+#### Bắt buộc thực tế khi gọi API
+
+`QLDA.WebApi` bật `<Nullable>enable</Nullable>`. Property **non-nullable** → model binder ASP.NET coi là required (400 nếu thiếu), **không cần** gắn `[Required]`.
+
+| Field | Kiểu (Model / InsertDto) | Bắt buộc API? | Ghi chú |
+|-------|--------------------------|---------------|---------|
+| `duAnId` | `Guid` | **Có** | `ITienDo`; FK `DuAn` Restrict |
+| `id` | `Guid?` | Không (POST) | `GetId()` sinh GUID nếu null |
+| `buocId` | `int?` | Không (attribute) | Remark controller “Quy trình id bắt buộc” → gọi `DuAnUpdateStepCommand`, không phải `[Required]` |
+| **`donViPhoiHopIds`** | `List<long>?` | **Không** | `null` / `[]` / `[219]` đều pass validation |
+| `tomTatNoiDung`, `tongMucDauTu`, `ngayBatDauDuKien` | nullable | Không | |
+| `hinhThucDauTuId`, `trangThaiId` | `int?` | Không | Insert gán trạng thái DT server-side |
+| `lanhDaoPhuTrachId`, `donViPhuTrachChinhId`, `nguoiXuLyChinhId` | `long?` | Không | |
+| `danhSachTepDinhKem` | `List<...>?` | Không | `TepDinhKemModel` cũng không `[Required]` |
+
+**File đã grep:** `QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiModel.cs`, `QLDA.Application/DeXuatChuTruongMoi/DTOs/*.cs`.
+
+#### EF / database
+
+| Field | `DeXuatChuTruongMoi` | Ghi chú |
+|-------|----------------------|---------|
+| `DuAnId` | NOT NULL | |
+| `BuocId`, nội dung, số tiền, đơn vị, … | NULL allowed | |
+| `TrangThaiId` | NULL | `.IsRequired(false)` trong `DeXuatChuTruongMoiConfiguration` |
+| `CreatedBy`, `UpdatedBy` | NOT NULL | Audit — không từ body client |
+
+| Field | `DeXuatDonViXuLy` | Ghi chú |
+|-------|-------------------|---------|
+| `DuAnId` / `DonViId` | NOT NULL (khi có row) | Chỉ tạo row khi FE gửi id trong list |
+
+#### Ảnh hưởng tới fix này
+
+- **Không cần** sửa `[Required]` cho task junction — không có attribute nào cản `donViPhoiHopIds` rỗng/null.
+- Nếu sau này product **bắt buộc** ≥1 đơn vị phối hợp: thêm validate trong handler hoặc `[MinLength(1)]` trên list (breaking change FE).
+
+#### Test validation (bổ sung checklist §5)
+
+| Request | Kỳ vọng |
+|---------|---------|
+| POST thiếu `duAnId` | **400** (model binding) |
+| POST không gửi `donViPhoiHopIds` | **200**, junction trống |
+| POST `"donViPhoiHopIds": []` | **200**, junction trống |
+
+---
+
+## 2. Phân tích hiện trạng
+
+### 2.1 Kết quả trước khi fix
+
+
+| Bảng                 | Trạng thái                            |
+| -------------------- | ------------------------------------- |
+| `DeXuatChuTruongMoi` | Insert/update **OK**                  |
+| `DeXuatDonViXuLy`    | **Trống** dù FE gửi `donViPhoiHopIds` |
+
+
+### 2.2 Nguyên nhân gốc
+
+
+| Layer                 | Vấn đề                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------- |
+| **Insert handler**    | Tạo entity mới, không set `Id` từ request, **bỏ qua** `DeXuatDonViXuLys`              |
+| **Update handler**    | Không `Include` junction, không gọi sync `DonViPhoiHopIds`                            |
+| **WebApi `ToEntity`** | Chỉ map scalar, không tạo `DeXuatDonViXuLys`                                          |
+| **WebApi `ToModel`**  | Không trả `DonViPhoiHopIds`; `NguoiXuLyChinhId` map sai                               |
+| **Controller PUT**    | Build DTO thiếu field + gán `BuocId` vào `DonViPhuTrachChinhId` / `LanhDaoPhuTrachId` |
+| **Get query**         | Không `Include(DeXuatDonViXuLys)`                                                     |
+
+
+### 2.3 Đã có sẵn (không cần migration)
+
+- Entity `DeXuatDonViXuLy`, navigation `DeXuatChuTruongMoi.DeXuatDonViXuLys`
+- EF `DeXuatDonViXuLyConfiguration` (composite PK, cascade delete)
+- `DeXuatChuTruongMoiModel.DonViPhoiHopIds`, `DeXuatChuTruongMoiInsertDto.DonViPhoiHopIds`
+- `DeXuatChuTruongMoiMappings.ToEntity(dto)` đã map junction nhưng **không được dùng** trong luồng WebApi insert
+- `DeXuatChuTruongMoiGetDanhSachQuery` đã join `DanhSachDonViPhoiHop` (read list OK nếu DB có data)
+
+### 2.4 Pattern tham chiếu
+
+`DuAnBuocUpdateCommand` — sync `DuAnBuocPhongBanPhoiHops`:
+
+```csharp
+if (request.Dto.DanhSachPhongBanPhoiHopIds != null) {
+    entity.DuAnBuocPhongBanPhoiHops?.Clear();
+    foreach (var phongBanId in request.Dto.DanhSachPhongBanPhoiHopIds) {
+        entity.DuAnBuocPhongBanPhoiHops!.Add(new DuAnBuocPhongBanPhoiHop {
+            LeftId = entity.Id,
+            RightId = phongBanId
+        });
+    }
+}
+```
+
+---
+
+## 3. Thứ tự thực hiện
+
+```
+Bước 1: Application – DeXuatChuTruongMoiMappings.SyncDonViPhoiHopIds
+Bước 2: Application – DeXuatChuTruongMoiInsertCommand (Id + junction)
+Bước 3: Application – DeXuatChuTruongMoiUpdateCommand (Include + sync)
+Bước 4: Application – DeXuatChuTruongMoiGetQuery (Include junction)
+Bước 5: WebApi – DeXuatChuTruongMoiMappingConfiguration (ToEntity, ToModel, ToInsertDto)
+Bước 6: WebApi – DeXuatChuTruongMoiController.Update (ToInsertDto)
+```
+
+**Không làm:** Migration, Domain entity mới, sửa snapshot.
+
+---
+
+## 4. Chi tiết từng bước
+
+---
+
+### Bước 1 – Application: `SyncDonViPhoiHopIds`
+
+**File:** `QLDA.Application/DeXuatChuTruongMoi/DeXuatChuTruongMoiMappings.cs`
+
+**Thêm extension:**
+
+```csharp
+public static void SyncDonViPhoiHopIds(this DeXuatChuTruongMoi entity, List<long>? donViPhoiHopIds) {
+    if (donViPhoiHopIds is null) {
+        return;
+    }
+
+    entity.DeXuatDonViXuLys ??= [];
+    entity.DeXuatDonViXuLys.Clear();
+    foreach (var donViId in donViPhoiHopIds) {
+        entity.DeXuatDonViXuLys.Add(new DeXuatDonViXuLy {
+            LeftId = entity.Id,
+            RightId = donViId,
+        });
+    }
+}
+```
+
+
+| `donViPhoiHopIds` | Hành vi                     |
+| ----------------- | --------------------------- |
+| `null`            | Không đổi junction (update) |
+| `[]`              | Xóa hết đơn vị phối hợp     |
+| `[219, 220]`      | Thay thế toàn bộ            |
+
+
+---
+
+### Bước 2 – Application: `DeXuatChuTruongMoiInsertCommand`
+
+**File:** `QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiInsertCommand.cs`
+
+**Trước:** Entity mới không có `Id` từ client, không có `DeXuatDonViXuLys`.
+
+**Sau:**
+
+```csharp
+var entity = new DeXuatChuTruongMoi
+{
+    Id = request.Dto.Id,
+    DuAnId = request.Dto.DuAnId,
+    BuocId = request.Dto.BuocId,
+    TongMucDauTu = request.Dto.TongMucDauTu,
+    TomTatNoiDung = request.Dto.TomTatNoiDung,
+    NgayBatDauDuKien = request.Dto.NgayBatDauDuKien,
+    HinhThucDauTuId = request.Dto.HinhThucDauTuId,
+    NguoiXuLyChinhId = request.Dto.NguoiXuLyChinhId,
+    LanhDaoPhuTrachId = request.Dto.LanhDaoPhuTrachId,
+    DonViPhuTrachChinhId = request.Dto.DonViPhuTrachChinhId,
+    TrangThaiId = trangThaiDuThao?.Id,
+};
+entity.SyncDonViPhoiHopIds(
+    request.Dto.DeXuatDonViXuLys?.Select(x => x.RightId).ToList() ?? []);
+
+await _repo.AddAsync(entity, cancellationToken);
+```
+
+> `request.Dto` là `DeXuatChuTruongMoi` từ `model.ToEntity()` — `DeXuatDonViXuLys` đã map từ `donViPhoiHopIds` ở WebApi.
+
+---
+
+### Bước 3 – Application: `DeXuatChuTruongMoiUpdateCommand`
+
+**File:** `QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiUpdateCommand.cs`
+
+```csharp
+var entity = await _repo.GetQueryableSet()
+    .Include(e => e.DeXuatDonViXuLys)
+    .Include(e => e.TrangThai)
+    .FirstOrDefaultAsync(e => e.Id == request.Dto.Id, cancellationToken);
+
+// ... validate trạng thái dự thảo ...
+
+entity.TongMucDauTu = request.Dto.TongMucDauTu;
+entity.TomTatNoiDung = request.Dto.TomTatNoiDung;
+entity.HinhThucDauTuId = request.Dto.HinhThucDauTuId;
+entity.NguoiXuLyChinhId = request.Dto.NguoiXuLyChinhId;
+entity.NgayBatDauDuKien = request.Dto.NgayBatDauDuKien;
+entity.DonViPhuTrachChinhId = request.Dto.DonViPhuTrachChinhId;
+entity.LanhDaoPhuTrachId = request.Dto.LanhDaoPhuTrachId;
+entity.DuAnId = request.Dto.DuAnId;
+entity.BuocId = request.Dto.BuocId;
+
+entity.SyncDonViPhoiHopIds(request.Dto.DonViPhoiHopIds);
+
+await _repo.UpdateAsync(entity, cancellationToken);
+```
+
+---
+
+### Bước 4 – Application: `DeXuatChuTruongMoiGetQuery`
+
+**File:** `QLDA.Application/DeXuatChuTruongMoi/Queries/DeXuatChuTruongMoiGetQuery.cs`
+
+```csharp
+var queryable = DeXuatChuTruongMoi.GetOrderedSet()
+    .Include(e => e.DeXuatDonViXuLys)
+    .Where(e => e.Id == request.Id);
+```
+
+---
+
+### Bước 5 – WebApi: Mapping
+
+**File:** `QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiMappingConfiguration.cs`
+
+#### `ToEntity` (POST)
+
+```csharp
+public static DeXuatChuTruongMoi ToEntity(this DeXuatChuTruongMoiModel model) {
+    var id = model.GetId();
+    return new() {
+        Id = id,
+        BuocId = model.BuocId,
+        DuAnId = model.DuAnId,
+        TongMucDauTu = model.TongMucDauTu,
+        TomTatNoiDung = model.TomTatNoiDung,
+        NgayBatDauDuKien = model.NgayBatDauDuKien,
+        LanhDaoPhuTrachId = model.LanhDaoPhuTrachId,
+        NguoiXuLyChinhId = model.NguoiXuLyChinhId,
+        HinhThucDauTuId = model.HinhThucDauTuId,
+        DonViPhuTrachChinhId = model.DonViPhuTrachChinhId,
+        DeXuatDonViXuLys = model.DonViPhoiHopIds != null && model.DonViPhoiHopIds.Count != 0
+            ? [.. model.DonViPhoiHopIds.Select(donViId => new DeXuatDonViXuLy { LeftId = id, RightId = donViId })]
+            : [],
+    };
+}
+```
+
+#### `ToModel` (GET chi tiết)
+
+```csharp
+NguoiXuLyChinhId = entity.NguoiXuLyChinhId,  // trước: entity.LanhDaoPhuTrachId (sai)
+DonViPhoiHopIds = entity.DeXuatDonViXuLys?.Select(x => x.RightId).ToList(),
+```
+
+#### `ToInsertDto` (PUT) — **mới**
+
+```csharp
+public static DeXuatChuTruongMoiInsertDto ToInsertDto(this DeXuatChuTruongMoiModel model) =>
+    new() {
+        Id = model.GetId(),
+        DuAnId = model.DuAnId,
+        BuocId = model.BuocId,
+        TomTatNoiDung = model.TomTatNoiDung,
+        TongMucDauTu = model.TongMucDauTu,
+        NgayBatDauDuKien = model.NgayBatDauDuKien,
+        HinhThucDauTuId = model.HinhThucDauTuId,
+        LanhDaoPhuTrachId = model.LanhDaoPhuTrachId,
+        NguoiXuLyChinhId = model.NguoiXuLyChinhId,
+        DonViPhuTrachChinhId = model.DonViPhuTrachChinhId,
+        TrangThaiId = model.TrangThaiId,
+        DonViPhoiHopIds = model.DonViPhoiHopIds,
+    };
+```
+
+---
+
+### Bước 6 – WebApi: Controller `cap-nhat`
+
+**File:** `QLDA.WebApi/Controllers/DeXuatChuTruongMoiController.cs`
+
+**Trước (sai):**
+
+```csharp
+await Mediator.Send(new DeXuatChuTruongMoiUpdateCommand(new() {
+    Id = model.GetId(),
+    DuAnId = model.DuAnId,
+    BuocId = model.BuocId,
+    DonViPhuTrachChinhId = model.BuocId,  // bug
+    LanhDaoPhuTrachId = model.BuocId,     // bug
+    // thiếu DonViPhoiHopIds, NguoiXuLyChinhId, ...
+}));
+```
+
+**Sau:**
+
+```csharp
+await Mediator.Send(new DeXuatChuTruongMoiUpdateCommand(model.ToInsertDto()), cancellationToken);
+```
+
+**POST `them-moi`:** không đổi signature — vẫn `model.ToEntity()` → `InsertCommand(entity)`.
+
+---
+
+## 5. Checklist hoàn thành
+
+```
+[x] 1. Thêm SyncDonViPhoiHopIds vào DeXuatChuTruongMoiMappings
+[x] 2. Sửa DeXuatChuTruongMoiInsertCommand (Id + junction trước AddAsync)
+[x] 3. Sửa DeXuatChuTruongMoiUpdateCommand (Include + LanhDaoPhuTrachId + sync)
+[x] 4. Sửa DeXuatChuTruongMoiGetQuery (Include DeXuatDonViXuLys)
+[x] 5. Sửa ToEntity / ToModel / thêm ToInsertDto (WebApi mapping)
+[x] 6. Sửa DeXuatChuTruongMoiController.Update (ToInsertDto)
+[x] 8. Rà soát `[Required]` / field bắt buộc (§1.5)
+[ ] 7. Build + Test API (POST/PUT/GET + DB + case thiếu `duAnId`)
+```
+
+---
+
+## 6. Lưu ý kỹ thuật
+
+- **Không migration** — bảng `DeXuatDonViXuLy` đã có trong `Init`.
+- **Insert:** `Id` phải khớp `model.GetId()` để `TepDinhKem` (`GroupId = savedEntity.Id`) và junction `LeftId` cùng một GUID.
+- **Update:** `SyncDonViPhoiHopIds(null)` giữ junction cũ; PUT qua `ToInsertDto` truyền list từ model (có thể `null` nếu FE không gửi field).
+- **List tiến độ** (`danh-sach-tien-do`): không đổi — vẫn join `DanhMucDonVi` → `DanhSachDonViPhoiHop`.
+- **GET chi tiết:** chỉ trả `donViPhoiHopIds` (ids), chưa trả tên đơn vị; tên có ở list query.
+- **`[Required]`:** xem **§1.5** — chỉ `duAnId` bắt buộc qua `Guid` non-nullable; `donViPhoiHopIds` không required.
+
+### Test gợi ý
+
+```powershell
+dotnet build "e:\SER\QLDA.WebApi\QLDA.WebApi.csproj"
+```
+
+
+| Case                           | Kỳ vọng                           |
+| ------------------------------ | --------------------------------- |
+| POST `donViPhoiHopIds: [219]`  | 1 row `DeXuatDonViXuLy`           |
+| PUT đổi `[219]` → `[220, 221]` | Junction thay thế, không trùng PK |
+| PUT `donViPhoiHopIds: []`      | Junction trống                    |
+| GET `chi-tiet`                 | `donViPhoiHopIds` khớp DB         |
+| POST thiếu `duAnId`            | 400 (non-nullable `Guid`)         |
+| POST không có `donViPhoiHopIds`| 200, không 400 validation         |
+
+
+---
+
+## 6.1 Những lỗi đã sửa trong task này
+
+### Application Layer
+
+
+| Lỗi                                      | Sửa                                                  |
+| ---------------------------------------- | ---------------------------------------------------- |
+| Insert handler bỏ qua `DeXuatDonViXuLys` | `SyncDonViPhoiHopIds` + `AddAsync` với collection    |
+| Insert không set `Id` từ request         | `Id = request.Dto.Id`                                |
+| Update không sync junction               | `.Include(DeXuatDonViXuLys)` + `SyncDonViPhoiHopIds` |
+| Update thiếu `LanhDaoPhuTrachId`         | Gán từ `request.Dto`                                 |
+| Get không load junction                  | `.Include(e => e.DeXuatDonViXuLys)`                  |
+
+
+### WebApi Layer
+
+
+| Lỗi                                               | Sửa                                           |
+| ------------------------------------------------- | --------------------------------------------- |
+| `ToEntity` không map `donViPhoiHopIds`            | Gán `DeXuatDonViXuLys` với `LeftId = GetId()` |
+| `ToModel`: `NguoiXuLyChinhId = LanhDaoPhuTrachId` | `NguoiXuLyChinhId = entity.NguoiXuLyChinhId`  |
+| `ToModel` thiếu `DonViPhoiHopIds`                 | Select `RightId` từ navigation                |
+| PUT build DTO thiếu field, map `BuocId` sai       | `model.ToInsertDto()`                         |
+
+
+---
+
+## 7. Tóm tắt công việc
+
+### Tổng quan
+
+**Bugfix** — đồng bộ đơn vị phối hợp khi lưu đề xuất chủ trương mới:
+
+- **0** entity / migration mới
+- **6** file chỉnh sửa
+- **3** API endpoint hành vi đúng (POST, PUT, GET chi tiết)
+
+### Các file chỉnh sửa
+
+
+| #   | File                                                                               | Thay đổi                             |
+| --- | ---------------------------------------------------------------------------------- | ------------------------------------ |
+| 1   | `QLDA.Application/DeXuatChuTruongMoi/DeXuatChuTruongMoiMappings.cs`                | ➕ `SyncDonViPhoiHopIds`              |
+| 2   | `QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiInsertCommand.cs`  | `Id` + sync junction                 |
+| 3   | `QLDA.Application/DeXuatChuTruongMoi/Commands/DeXuatChuTruongMoiUpdateCommand.cs`  | Include + sync + `LanhDaoPhuTrachId` |
+| 4   | `QLDA.Application/DeXuatChuTruongMoi/Queries/DeXuatChuTruongMoiGetQuery.cs`        | Include `DeXuatDonViXuLys`           |
+| 5   | `QLDA.WebApi/Models/DeXuatChuTruongMois/DeXuatChuTruongMoiMappingConfiguration.cs` | `ToEntity`, `ToModel`, `ToInsertDto` |
+| 6   | `QLDA.WebApi/Controllers/DeXuatChuTruongMoiController.cs`                          | PUT → `ToInsertDto()`                |
+
+
+### File không sửa
+
+
+| File                                                           | Lý do                      |
+| -------------------------------------------------------------- | -------------------------- |
+| `DeXuatDonViXuLy.cs`, `DeXuatDonViXuLyConfiguration.cs`        | Schema đã đúng             |
+| `DeXuatChuTruongMoiModel.cs`, `DeXuatChuTruongMoiInsertDto.cs` | Field đã có                |
+| `DeXuatChuTruongMoiGetDanhSachQuery.cs`                        | Read list đã join phối hợp |
+| Migrations                                                     | Không đổi DB               |
+
+
+### Luồng dữ liệu sau fix
+
+```
+POST: Model.donViPhoiHopIds → ToEntity.DeXuatDonViXuLys → InsertCommand → DB
+PUT:  Model.donViPhoiHopIds → ToInsertDto → UpdateCommand.Sync → DB
+GET:  DB → Include DeXuatDonViXuLys → ToModel.DonViPhoiHopIds
+```
+
+### Trạng thái
+
+- **Code:** đã implement (bước 1–6)
+- **Tiếp theo:** build + test API + tick checklist mục 7
+


### PR DESCRIPTION
## Summary

Khi tạo/cập nhật **Đề xuất chủ trương đầu tư mới**, danh sách `donViPhoiHopIds` (đơn vị phối hợp) trước đây không được ghi vào bảng junction `DeXuatDonViXuLy` dù `DeXuatChuTruongMoi` lưu thành công.

PR này đồng bộ junction khi POST/PUT và trả lại `donViPhoiHopIds` ở GET chi tiết.

## Root cause

- Insert handler tạo entity mới, bỏ qua `DeXuatDonViXuLys`
- Update handler không `Include` / sync collection
- WebApi `ToEntity` / PUT DTO thiếu map `donViPhoiHopIds` (PUT còn gán nhầm `buocId` vào `lanhDaoPhuTrachId`, `donViPhuTrachChinhId`)

## Changes

- `SyncDonViPhoiHopIds` helper (pattern giống `DuAnBuocPhongBanPhoiHop`)
- Insert: giữ `Id` từ client + persist junction khi `AddAsync`
- Update: `Include(DeXuatDonViXuLys)`, sync list từ DTO, sửa `LanhDaoPhuTrachId`
- GET chi tiết: `Include` + `ToModel` trả `donViPhoiHopIds`
- WebApi: `ToInsertDto()` cho `cap-nhat`
- Docs: issue + task (kèm audit `[Required]` — `donViPhoiHopIds` **optional**, chỉ `duAnId` bắt buộc qua `Guid` non-nullable)

## API affected

| Method | Endpoint | Behavior |
|--------|----------|----------|
| POST | `/api/de-xuat-chu-truong-moi/them-moi` | Lưu parent + `DeXuatDonViXuLy` |
| PUT | `/api/de-xuat-chu-truong-moi/cap-nhat` | Cập nhật parent + thay thế junction |
| GET | `/api/de-xuat-chu-truong-moi/{id}/chi-tiet` | Response có `donViPhoiHopIds` |

## Test plan

- [x] POST với `"donViPhoiHopIds": [219]` → có row `DeXuatDonViXuLy` (`DonViId` = 219)
- [x] PUT đổi list → junction cập nhật, không trùng PK
- [x] PUT `"donViPhoiHopIds": []` → junction trống
- [x] GET `chi-tiet` → `donViPhoiHopIds` khớp DB

## Docs

- `docs/feature/DeXuatChuTruongMoi/issue-don-vi-phoi-hop-ids-khong-luu.md`
- `docs/feature/DeXuatChuTruongMoi/task-fix-don-vi-phoi-hop-ids.md`

## Notes

- Không migration / không đổi schema