### PR TITLE
fix: junction DeXuatTrinhKinhPhiNam và API tổng hợp kinh phí năm

### DIFF
--- a/QLDA.Application/DeXuatChuTruongMoi/Queries/DeXuatChuTruongMoiGetDanhSachQuery.cs
+++ b/QLDA.Application/DeXuatChuTruongMoi/Queries/DeXuatChuTruongMoiGetDanhSachQuery.cs
@@ -9,11 +9,6 @@ using QLDA.Domain.Enums;
 
 namespace QLDA.Application.DeXuatChuTruongMois.Queries;
 
-public class DanhMucDonViCbo {
-    public string? TenDonVi { get; set; }
-    public long Id { get; set; }
-}
-
 public record DeXuatChuTruongMoiQuery : AggregateRootPagination, IMayHaveGlobalFilter, IFromDateToDate, IRequest<PaginatedList<DeXuatChuTruongMoiDto>> {
     public int? BuocId { get; set; }
     public Guid? DuAnId { get; set; }

--- a/QLDA.Application/DeXuatKinhPhiNam/Commands/DeXuatKinhPhiNamInsertCommand.cs
+++ b/QLDA.Application/DeXuatKinhPhiNam/Commands/DeXuatKinhPhiNamInsertCommand.cs
@@ -7,34 +7,25 @@ using QLDA.Domain.Entities.DanhMuc;
 
 namespace QLDA.Application.DeXuatNhuCauKinhPhiNams.Commands;
 
-public record DeXuatNhuCauKinhPhiNamInsertCommand(DeXuatNhuCauKinhPhiNam Dto) : IRequest<DeXuatNhuCauKinhPhiNam>;
+public record DeXuatNhuCauKinhPhiNamInsertCommand(DeXuatNhuCauKinhPhiNamInsertDto Dto) : IRequest<DeXuatNhuCauKinhPhiNam>;
 
-internal class DeXuatNhuCauKinhPhiNamInsertCommandHandler : IRequestHandler<DeXuatNhuCauKinhPhiNamInsertCommand, DeXuatNhuCauKinhPhiNam>
-{
+internal class DeXuatNhuCauKinhPhiNamInsertCommandHandler : IRequestHandler<DeXuatNhuCauKinhPhiNamInsertCommand, DeXuatNhuCauKinhPhiNam> {
     private readonly IRepository<DeXuatNhuCauKinhPhiNam, Guid> _repo;
-    private readonly IRepository<DeXuatTrinhKinhPhiNam, Guid> _repoDeXuat;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepo;
     private readonly IUnitOfWork _unitOfWork;
 
-    public DeXuatNhuCauKinhPhiNamInsertCommandHandler(IServiceProvider serviceProvider)
-    {
+    public DeXuatNhuCauKinhPhiNamInsertCommandHandler(IServiceProvider serviceProvider) {
         _repo = serviceProvider.GetRequiredService<IRepository<DeXuatNhuCauKinhPhiNam, Guid>>();
         _statusRepo = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _unitOfWork = _repo.UnitOfWork;
     }
 
-    public async Task<DeXuatNhuCauKinhPhiNam> Handle(DeXuatNhuCauKinhPhiNamInsertCommand request, CancellationToken cancellationToken = default)
-    {
-        // Auto-assign Dự thảo status
+    public async Task<DeXuatNhuCauKinhPhiNam> Handle(DeXuatNhuCauKinhPhiNamInsertCommand request,
+        CancellationToken cancellationToken = default) {
         var trangThaiDuThao = await _statusRepo.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
             .FirstOrDefaultAsync(s => s.Ma == "DT" && s.Loai == PheDuyetEntityNames.DeXuatMacDinhStt, cancellationToken);
-        var deXuatIds = request.Dto.DeXuats?
-           .Select(x => x.RightId)
-           .ToList();
 
-        var entity = new DeXuatNhuCauKinhPhiNam
-        {
-         
+        var entity = new DeXuatNhuCauKinhPhiNam {
             So = request.Dto.So,
             NgayKeHoach = request.Dto.NgayKeHoach,
             TrichYeu = request.Dto.TrichYeu,
@@ -46,9 +37,7 @@ internal class DeXuatNhuCauKinhPhiNamInsertCommandHandler : IRequestHandler<DeXu
         using var tx = await _unitOfWork.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         await _repo.AddAsync(entity, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
-        await _unitOfWork.CommitTransactionAsync(cancellationToken);
-        // save danh sách đề xuất được trình
-        entity.SyncDeXuatIds(deXuatIds);
+        entity.SyncDeXuatIds(request.Dto.DanhSachDeXuat);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
         await _unitOfWork.CommitTransactionAsync(cancellationToken);
         return entity;

--- a/QLDA.Application/DeXuatKinhPhiNam/Commands/DeXuatKinhPhiNamUpdateCommand.cs
+++ b/QLDA.Application/DeXuatKinhPhiNam/Commands/DeXuatKinhPhiNamUpdateCommand.cs
@@ -1,5 +1,6 @@
 using System.Data;
 using Microsoft.EntityFrameworkCore;
+using QLDA.Application.DeXuatNhuCauKinhPhiNamMappings;
 using QLDA.Application.DeXuatNhuCauKinhPhiNams.DTOs;
 using QLDA.Domain.Constants;
 
@@ -7,39 +8,38 @@ namespace QLDA.Application.DeXuatNhuCauKinhPhiNams.Commands;
 
 public record DeXuatNhuCauKinhPhiNamUpdateCommand(DeXuatNhuCauKinhPhiNamInsertDto Dto) : IRequest<DeXuatNhuCauKinhPhiNam>;
 
-internal class DeXuatNhuCauKinhPhiNamUpdateCommandHandler : IRequestHandler<DeXuatNhuCauKinhPhiNamUpdateCommand, DeXuatNhuCauKinhPhiNam>
-{
+internal class DeXuatNhuCauKinhPhiNamUpdateCommandHandler : IRequestHandler<DeXuatNhuCauKinhPhiNamUpdateCommand, DeXuatNhuCauKinhPhiNam> {
     private readonly IRepository<DeXuatNhuCauKinhPhiNam, Guid> _repo;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepo;
     private readonly IUnitOfWork _unitOfWork;
 
-    public DeXuatNhuCauKinhPhiNamUpdateCommandHandler(IServiceProvider serviceProvider)
-    {
+    public DeXuatNhuCauKinhPhiNamUpdateCommandHandler(IServiceProvider serviceProvider) {
         _repo = serviceProvider.GetRequiredService<IRepository<DeXuatNhuCauKinhPhiNam, Guid>>();
         _statusRepo = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _unitOfWork = _repo.UnitOfWork;
     }
 
-    public async Task<DeXuatNhuCauKinhPhiNam> Handle(DeXuatNhuCauKinhPhiNamUpdateCommand request, CancellationToken cancellationToken = default)
-    {
+    public async Task<DeXuatNhuCauKinhPhiNam> Handle(DeXuatNhuCauKinhPhiNamUpdateCommand request,
+        CancellationToken cancellationToken = default) {
         var trangThaiDuThao = await _statusRepo.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
             .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DeXuatMacDinh.DuThao && s.Loai == PheDuyetEntityNames.DeXuatMacDinhStt, cancellationToken);
 
         var entity = await _repo.GetQueryableSet()
+            .Include(e => e.DeXuats)
+            .Include(e => e.TrangThai)
             .FirstOrDefaultAsync(e => e.Id == request.Dto.Id, cancellationToken);
         ManagedException.ThrowIf(entity == null, "Không tìm thấy dữ liệu.");
 
-        // Validate current status must be null (legacy), Dự thảo, or Migrated (LEG)
-        if (entity.TrangThaiId != null && entity.TrangThaiId != trangThaiDuThao?.Id && entity.TrangThai?.Ma != "LEG")
-        {
+        if (entity.TrangThaiId != null && entity.TrangThaiId != trangThaiDuThao?.Id && entity.TrangThai?.Ma != "LEG") {
             throw new ManagedException("Chỉ có thể cập nhật khi trạng thái là dự thảo");
         }
+
         entity.GhiChu = request.Dto.GhiChu;
         entity.So = request.Dto.So;
         entity.NgayKeHoach = request.Dto.NgayKeHoach;
         entity.TrichYeu = request.Dto.TrichYeu;
         entity.TongKinhPhiDeXuat = request.Dto.TongKinhPhiDeXuat;
-        
+        entity.SyncDeXuatIds(request.Dto.DanhSachDeXuat);
 
         using var tx = await _unitOfWork.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         await _repo.UpdateAsync(entity, cancellationToken);
@@ -49,4 +49,3 @@ internal class DeXuatNhuCauKinhPhiNamUpdateCommandHandler : IRequestHandler<DeXu
         return entity;
     }
 }
-

--- a/QLDA.Application/DeXuatKinhPhiNam/DTOs/DeXuatKinhPhiNamDto.cs
+++ b/QLDA.Application/DeXuatKinhPhiNam/DTOs/DeXuatKinhPhiNamDto.cs
@@ -1,11 +1,10 @@
 using QLDA.Application.Common.Interfaces;
 using QLDA.Application.TepDinhKems.DTOs;
-using QLDA.Domain.Interfaces;
 using SequentialGuid;
 
 namespace QLDA.Application.DeXuatNhuCauKinhPhiNams.DTOs;
 
-public class DeXuatNhuCauKinhPhiNamDto : IHasKey<Guid?>, IMustHaveId<Guid>,  IMayHaveTepDinhKemDto {
+public class DeXuatNhuCauKinhPhiNamDto : IHasKey<Guid?>, IMustHaveId<Guid>, IMayHaveTepDinhKemDto {
     [DefaultValue(null)] public Guid? Id { get; set; }
 
     public Guid GetId() {
@@ -21,6 +20,6 @@ public class DeXuatNhuCauKinhPhiNamDto : IHasKey<Guid?>, IMustHaveId<Guid>,  IMa
     public string? MaTrangThai { get; set; }
     public int? TrangThaiId { get; set; }
     public string? TenTrangThai { get; set; }
-    public List<DeXuatNhuCauKinhPhi>? DanhSachDeXuat { get; set; }
+    public List<Guid>? DanhSachDeXuat { get; set; }
     public List<TepDinhKemDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/DeXuatKinhPhiNam/DeXuatNhuCauKinhPhiMappings.cs
+++ b/QLDA.Application/DeXuatKinhPhiNam/DeXuatNhuCauKinhPhiMappings.cs
@@ -1,48 +1,27 @@
-using Azure.Core;
 using QLDA.Application.DeXuatNhuCauKinhPhiNams.DTOs;
 using QLDA.Application.TepDinhKems.DTOs;
 
 namespace QLDA.Application.DeXuatNhuCauKinhPhiNamMappings;
 
-public static class DeXuatNhuCauKinhPhiNamMappings
-{
-    public static DeXuatNhuCauKinhPhiNam ToEntity(this DeXuatNhuCauKinhPhiNamInsertDto dto) {
-        Guid id = dto.Id ?? Guid.NewGuid();
-        return new DeXuatNhuCauKinhPhiNam {
-            Id = id,
-            So = dto.So,
-            GhiChu = dto.GhiChu,
-            NgayKeHoach = dto.NgayKeHoach,
-            TrichYeu = dto.TrichYeu,
-            TongKinhPhiDeXuat = dto.TongKinhPhiDeXuat,
-            DeXuats = [..dto.DanhSachDeXuat?.Select(dx => new DeXuatTrinhKinhPhiNam {
-                LeftId = id,
-                RightId =dx
-            }) ?? []]
-        };
-    }
-    public static void SyncDeXuatIds(this DeXuatNhuCauKinhPhiNam entity, List<Guid>? deXuatIds)
-    {
-        if (deXuatIds is null)
-        {
+public static class DeXuatNhuCauKinhPhiNamMappings {
+    public static void SyncDeXuatIds(this DeXuatNhuCauKinhPhiNam entity, List<Guid>? deXuatIds) {
+        if (deXuatIds is null) {
             entity.DeXuats = [];
             return;
         }
 
         entity.DeXuats ??= [];
         entity.DeXuats.Clear();
-        foreach (var deXuatId in deXuatIds)
-        {
-            entity.DeXuats.Add(new DeXuatTrinhKinhPhiNam
-            {
+        foreach (var deXuatId in deXuatIds) {
+            entity.DeXuats.Add(new DeXuatTrinhKinhPhiNam {
                 LeftId = entity.Id,
                 RightId = deXuatId,
             });
         }
     }
 
-    public static DeXuatNhuCauKinhPhiNamDto ToDto(this DeXuatNhuCauKinhPhiNam entity, List<TepDinhKem>? files = null) {
-        return new DeXuatNhuCauKinhPhiNamDto {
+    public static DeXuatNhuCauKinhPhiNamDto ToDto(this DeXuatNhuCauKinhPhiNam entity, List<TepDinhKem>? files = null) =>
+        new() {
             Id = entity.Id,
             So = entity.So,
             GhiChu = entity.GhiChu,
@@ -51,10 +30,6 @@ public static class DeXuatNhuCauKinhPhiNamMappings
             TongKinhPhiDeXuat = entity.TongKinhPhiDeXuat,
             TrangThaiId = entity.TrangThaiId,
             DanhSachTepDinhKem = files?.Select(x => x.ToDto()).ToList(),
-            DanhSachDeXuat = [..entity.DeXuats? .Select(xuLy => new DeXuatNhuCauKinhPhi
-                                                                {
-                                                                    Id= xuLy.RightId
-                                                                }) ?? []]
+            DanhSachDeXuat = entity.DeXuats?.Select(x => x.RightId).ToList(),
         };
-    }
 }

--- a/QLDA.Application/DeXuatKinhPhiNam/Queries/DeXuatNhuCauKinhPhiGetQuery.cs
+++ b/QLDA.Application/DeXuatKinhPhiNam/Queries/DeXuatNhuCauKinhPhiGetQuery.cs
@@ -20,6 +20,7 @@ internal class DeXuatNhuCauKinhPhiNamGetQueryHandler(IServiceProvider servicePro
     public async Task<DeXuatNhuCauKinhPhiNam> Handle(DeXuatNhuCauKinhPhiNamGetQuery request,
         CancellationToken cancellationToken = default) {
         var queryable = DeXuatNhuCauKinhPhiNam.GetOrderedSet()
+            .Include(e => e.DeXuats)
             .Where(e => e.Id == request.Id);
 
         if (request.IsNoTracking)

--- a/QLDA.Application/DeXuatNhuCauKinhPhi/Queries/DeXuatNhuCauKinhPhiGetDanhSachQuery.cs
+++ b/QLDA.Application/DeXuatNhuCauKinhPhi/Queries/DeXuatNhuCauKinhPhiGetDanhSachQuery.cs
@@ -24,7 +24,6 @@ internal class
     DeXuatNhuCauKinhPhiQueryHandler(IServiceProvider ServiceProvider)
     : IRequestHandler<DeXuatNhuCauKinhPhiQuery, PaginatedList<DeXuatNhuCauKinhPhiDto>> {
     private readonly IRepository<DeXuatNhuCauKinhPhi, Guid> DeXuatNhuCauKinhPhi = ServiceProvider.GetRequiredService<IRepository<DeXuatNhuCauKinhPhi, Guid>>();
-    private readonly IRepository<DeXuatTrinhKinhPhiNam, Guid> DeXuatTrinhKinhPhiNam = ServiceProvider.GetRequiredService<IRepository<DeXuatTrinhKinhPhiNam, Guid>>();
     private readonly IRepository<TepDinhKem, Guid> TepDinhKem =
         ServiceProvider.GetRequiredService<IRepository<TepDinhKem, Guid>>();
 

--- a/QLDA.Domain/Entities/DeXuatTrinhKinhPhiNam.cs
+++ b/QLDA.Domain/Entities/DeXuatTrinhKinhPhiNam.cs
@@ -1,16 +1,17 @@
-using QLDA.Domain.Enums;
 using QLDA.Domain.Interfaces;
 
 namespace QLDA.Domain.Entities;
 
-public class DeXuatTrinhKinhPhiNam : Entity<Guid>, IAggregateRoot {
+/// <summary>
+/// Junction: Tổng hợp KP năm ↔ Đề xuất nhu cầu kinh phí được trình
+/// </summary>
+public class DeXuatTrinhKinhPhiNam : IJunctionEntity<Guid, Guid>, IAggregateRoot {
     public Guid LeftId { get; set; }
-  
     public Guid RightId { get; set; }
 
     #region Navigation Properties
 
-    public DeXuatNhuCauKinhPhiNam? DeXuatNhuCauKinhPhi { get; set; }
+    public DeXuatNhuCauKinhPhiNam? DeXuatNhuCauKinhPhiNam { get; set; }
 
     #endregion
 }

--- a/QLDA.Migrator/Migrations/20260525100208_FixDeXuatTrinhJunctionAndDropDanhMucDonViCbo.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260525100208_FixDeXuatTrinhJunctionAndDropDanhMucDonViCbo.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260525100208_FixDeXuatTrinhJunctionAndDropDanhMucDonViCbo")]
+    partial class FixDeXuatTrinhJunctionAndDropDanhMucDonViCbo
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260525100208_FixDeXuatTrinhJunctionAndDropDanhMucDonViCbo.cs
+++ b/QLDA.Migrator/Migrations/20260525100208_FixDeXuatTrinhJunctionAndDropDanhMucDonViCbo.cs
@@ -1,0 +1,168 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations;
+
+/// <inheritdoc />
+public partial class FixDeXuatTrinhJunctionAndDropDanhMucDonViCbo : Migration {
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder) {
+        // 1. DeXuatTrinhKinhPhiNam — junction chỉ 2 cột: drop constraint trước, rồi mới drop cột dư
+        migrationBuilder.Sql("""
+            IF OBJECT_ID(N'DeXuatTrinhKinhPhiNam', N'U') IS NOT NULL
+            BEGIN
+            DECLARE @TableId INT = OBJECT_ID(N'DeXuatTrinhKinhPhiNam');
+            DECLARE @Sql NVARCHAR(MAX);
+
+            IF EXISTS (
+                SELECT 1 FROM sys.foreign_keys
+                WHERE name = N'FK_DeXuatTrinhKinhPhiNam_DeXuatNhuCauKinhPhiNam_DeXuatKinhPhiNamId'
+            )
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP CONSTRAINT [FK_DeXuatTrinhKinhPhiNam_DeXuatNhuCauKinhPhiNam_DeXuatKinhPhiNamId];
+
+            SET @Sql = N'';
+            SELECT @Sql = @Sql + N'ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP CONSTRAINT [' + fk.name + N'];' + CHAR(13)
+            FROM sys.foreign_keys fk
+            WHERE fk.parent_object_id = @TableId
+              AND fk.name <> N'FK_DeXuatTrinhKinhPhiNam_DeXuatNhuCauKinhPhiNam_DeXuatKinhPhiNamId';
+            IF LEN(@Sql) > 0 EXEC sp_executesql @Sql;
+
+            SET @Sql = N'';
+            SELECT @Sql = @Sql + N'ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP CONSTRAINT [' + kc.name + N'];' + CHAR(13)
+            FROM sys.key_constraints kc
+            WHERE kc.parent_object_id = @TableId AND kc.type IN (N'PK', N'UQ');
+            IF LEN(@Sql) > 0 EXEC sp_executesql @Sql;
+
+            SET @Sql = N'';
+            SELECT @Sql = @Sql + N'ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP CONSTRAINT [' + dc.name + N'];' + CHAR(13)
+            FROM sys.default_constraints dc
+            WHERE dc.parent_object_id = @TableId;
+            IF LEN(@Sql) > 0 EXEC sp_executesql @Sql;
+
+            SET @Sql = N'';
+            SELECT @Sql = @Sql + N'DROP INDEX [' + i.name + N'] ON [DeXuatTrinhKinhPhiNam];' + CHAR(13)
+            FROM sys.indexes i
+            WHERE i.object_id = @TableId
+              AND i.name IS NOT NULL
+              AND i.is_primary_key = 0
+              AND i.is_unique_constraint = 0;
+            IF LEN(@Sql) > 0 EXEC sp_executesql @Sql;
+
+            IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @TableId AND name = N'Id')
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP COLUMN [Id];
+            IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @TableId AND name = N'CreatedAt')
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP COLUMN [CreatedAt];
+            IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @TableId AND name = N'CreatedBy')
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP COLUMN [CreatedBy];
+            IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @TableId AND name = N'UpdatedAt')
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP COLUMN [UpdatedAt];
+            IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @TableId AND name = N'UpdatedBy')
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP COLUMN [UpdatedBy];
+            IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @TableId AND name = N'IsDeleted')
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP COLUMN [IsDeleted];
+            IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @TableId AND name = N'Index')
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] DROP COLUMN [Index];
+
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.key_constraints
+                WHERE parent_object_id = @TableId AND name = N'PK_DeXuatTrinhKinhPhiNam'
+            )
+            AND EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @TableId AND name = N'DeXuatKinhPhiNamId')
+            AND EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @TableId AND name = N'DeXuatNhuCauKinhPhiId')
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] ADD CONSTRAINT [PK_DeXuatTrinhKinhPhiNam]
+                    PRIMARY KEY ([DeXuatKinhPhiNamId], [DeXuatNhuCauKinhPhiId]);
+
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.foreign_keys
+                WHERE name = N'FK_DeXuatTrinhKinhPhiNam_DeXuatNhuCauKinhPhiNam_DeXuatKinhPhiNamId'
+            )
+                ALTER TABLE [DeXuatTrinhKinhPhiNam] ADD CONSTRAINT [FK_DeXuatTrinhKinhPhiNam_DeXuatNhuCauKinhPhiNam_DeXuatKinhPhiNamId]
+                    FOREIGN KEY ([DeXuatKinhPhiNamId]) REFERENCES [DeXuatNhuCauKinhPhiNam] ([Id]) ON DELETE CASCADE;
+            END
+            """);
+
+        // DeXuatNhuCauKinhPhiNam — bỏ DuAnId (không thuộc aggregate tổng hợp KP năm)
+        migrationBuilder.Sql("""
+            IF EXISTS (
+                SELECT 1 FROM sys.foreign_keys
+                WHERE name = N'FK_DeXuatNhuCauKinhPhiNam_DuAn_DuAnId'
+            )
+                ALTER TABLE [DeXuatNhuCauKinhPhiNam] DROP CONSTRAINT [FK_DeXuatNhuCauKinhPhiNam_DuAn_DuAnId];
+            """);
+
+        migrationBuilder.Sql("""
+            IF EXISTS (
+                SELECT 1 FROM sys.indexes i
+                INNER JOIN sys.tables t ON i.object_id = t.object_id
+                WHERE t.name = N'DeXuatNhuCauKinhPhiNam' AND i.name = N'IX_DeXuatNhuCauKinhPhiNam_DuAnId'
+            )
+                DROP INDEX [IX_DeXuatNhuCauKinhPhiNam_DuAnId] ON [DeXuatNhuCauKinhPhiNam];
+            """);
+
+        migrationBuilder.Sql("""
+            IF EXISTS (
+                SELECT 1 FROM sys.columns
+                WHERE object_id = OBJECT_ID(N'DeXuatNhuCauKinhPhiNam') AND name = N'DuAnId'
+            )
+                ALTER TABLE [DeXuatNhuCauKinhPhiNam] DROP COLUMN [DuAnId];
+            """);
+
+        // 2. DanhMucDonViCbo — chỉ DTO/query (DmDonVi + DeXuatDonViXuLy); drop bảng thừa trên DB dev nếu có
+        migrationBuilder.Sql("""
+            DECLARE @RefTableId INT = OBJECT_ID(N'[dbo].[DanhMucDonViCbo]');
+            IF @RefTableId IS NOT NULL
+            BEGIN
+                DECLARE @DropFkSql NVARCHAR(MAX) = N'';
+
+                SELECT @DropFkSql = @DropFkSql
+                    + N'ALTER TABLE [' + OBJECT_SCHEMA_NAME(fk.parent_object_id) + N'].['
+                    + OBJECT_NAME(fk.parent_object_id) + N'] DROP CONSTRAINT [' + fk.name + N'];' + CHAR(13)
+                FROM sys.foreign_keys fk
+                WHERE fk.referenced_object_id = @RefTableId;
+
+                IF LEN(@DropFkSql) > 0
+                    EXEC sp_executesql @DropFkSql;
+
+                DROP TABLE [dbo].[DanhMucDonViCbo];
+            END
+            """);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder) {
+        migrationBuilder.Sql("""
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.columns
+                WHERE object_id = OBJECT_ID(N'DeXuatNhuCauKinhPhiNam') AND name = N'DuAnId'
+            )
+                ALTER TABLE [DeXuatNhuCauKinhPhiNam] ADD [DuAnId] uniqueidentifier NULL;
+            """);
+
+        migrationBuilder.Sql("""
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.indexes i
+                INNER JOIN sys.tables t ON i.object_id = t.object_id
+                WHERE t.name = N'DeXuatNhuCauKinhPhiNam' AND i.name = N'IX_DeXuatNhuCauKinhPhiNam_DuAnId'
+            )
+            AND EXISTS (
+                SELECT 1 FROM sys.columns
+                WHERE object_id = OBJECT_ID(N'DeXuatNhuCauKinhPhiNam') AND name = N'DuAnId'
+            )
+                CREATE INDEX [IX_DeXuatNhuCauKinhPhiNam_DuAnId] ON [DeXuatNhuCauKinhPhiNam] ([DuAnId]);
+            """);
+
+        migrationBuilder.Sql("""
+            IF NOT EXISTS (
+                SELECT 1 FROM sys.foreign_keys
+                WHERE name = N'FK_DeXuatNhuCauKinhPhiNam_DuAn_DuAnId'
+            )
+            AND EXISTS (
+                SELECT 1 FROM sys.columns
+                WHERE object_id = OBJECT_ID(N'DeXuatNhuCauKinhPhiNam') AND name = N'DuAnId'
+            )
+                ALTER TABLE [DeXuatNhuCauKinhPhiNam] ADD CONSTRAINT [FK_DeXuatNhuCauKinhPhiNam_DuAn_DuAnId]
+                    FOREIGN KEY ([DuAnId]) REFERENCES [DuAn] ([Id]);
+            """);
+    }
+}

--- a/QLDA.Persistence/Configurations/DeXuatTrinhKinhPhiNamConfiguration.cs
+++ b/QLDA.Persistence/Configurations/DeXuatTrinhKinhPhiNamConfiguration.cs
@@ -1,14 +1,10 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using QLDA.Domain.Entities.DanhMuc;
 
 namespace QLDA.Persistence.Configurations;
 
-public class DeXuatTrinhKinhPhiNamConfiguration : AggregateRootConfiguration<DeXuatTrinhKinhPhiNam>
-{
-    public override void Configure(EntityTypeBuilder<DeXuatTrinhKinhPhiNam> builder)
-    {
-
+public class DeXuatTrinhKinhPhiNamConfiguration : AggregateRootConfiguration<DeXuatTrinhKinhPhiNam> {
+    public override void Configure(EntityTypeBuilder<DeXuatTrinhKinhPhiNam> builder) {
         builder.ToTable(nameof(DeXuatTrinhKinhPhiNam));
 
         builder.HasKey(e => new { e.LeftId, e.RightId });
@@ -16,8 +12,8 @@ public class DeXuatTrinhKinhPhiNamConfiguration : AggregateRootConfiguration<DeX
         builder.Property(e => e.LeftId).HasColumnName("DeXuatKinhPhiNamId");
         builder.Property(e => e.RightId).HasColumnName("DeXuatNhuCauKinhPhiId");
 
-        builder.HasOne(e => e.DeXuatNhuCauKinhPhi) 
-            .WithMany(e => e.DeXuats) 
+        builder.HasOne(e => e.DeXuatNhuCauKinhPhiNam)
+            .WithMany(e => e.DeXuats)
             .HasForeignKey(e => e.LeftId)
             .OnDelete(DeleteBehavior.Cascade);
     }

--- a/QLDA.WebApi/Controllers/DeXuatNhuCauKinhPhiNamController.cs
+++ b/QLDA.WebApi/Controllers/DeXuatNhuCauKinhPhiNamController.cs
@@ -1,31 +1,18 @@
-using Azure.Core;
+using System.Net.Mime;
 using QLDA.Application.DeXuatNhuCauKinhPhiNams.Commands;
 using QLDA.Application.DeXuatNhuCauKinhPhiNams.DTOs;
 using QLDA.Application.DeXuatNhuCauKinhPhiNams.Queries;
-using QLDA.Application.DuAns.Commands;
-using QLDA.Application.PhanKhaiKinhPhis.Commands;
 using QLDA.Application.TepDinhKems.Commands;
 using QLDA.Application.TepDinhKems.Queries;
 using QLDA.Domain.Constants;
 using QLDA.WebApi.Models.DeXuatNhuCauKinhPhiNams;
-using QLDA.WebApi.Models.PhanKhaiKinhPhis;
 using QLDA.WebApi.Models.TepDinhKems;
-using System.Net.Mime;
 
 namespace QLDA.WebApi.Controllers;
 
 [Tags("Đề xuất kế hoạch kinh phí năm")]
 [Route("api/tong-hop-kinh-phi")]
-public class DeXuatNhuCauKinhPhiNamController : AggregateRootController {
-    // GET
-    public DeXuatNhuCauKinhPhiNamController(IServiceProvider serviceProvider) : base(serviceProvider) {
-    }
-
-    /// <summary>
-    /// Chi tiết
-    /// </summary>
-    /// <param name="id"></param>
-    /// <returns></returns>
+public class DeXuatNhuCauKinhPhiNamController(IServiceProvider serviceProvider) : AggregateRootController(serviceProvider) {
     [ProducesResponseType<ResultApi<DeXuatNhuCauKinhPhiNamModel>>(StatusCodes.Status200OK)]
     [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
     [HttpGet("{id}/chi-tiet")]
@@ -42,7 +29,6 @@ public class DeXuatNhuCauKinhPhiNamController : AggregateRootController {
         return ResultApi.Ok(entity.ToModel(danhSachTepDinhKem));
     }
 
-
     [HttpDelete("{id}/xoa")]
     public async Task<ResultApi> Delete(Guid id) {
         var res = await Mediator.Send(new DeXuatNhuCauKinhPhiNamDeleteCommand(id));
@@ -54,11 +40,7 @@ public class DeXuatNhuCauKinhPhiNamController : AggregateRootController {
     [ProducesResponseType<ResultApi<Guid>>(StatusCodes.Status200OK)]
     [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
     public async Task<ResultApi> Create([FromBody] DeXuatNhuCauKinhPhiNamModel model) {
-        //Cập nhật bước hiện tại của dự án
-        
-      
-        var entity = model.ToEntity();
-        var savedEntity = await Mediator.Send(new DeXuatNhuCauKinhPhiNamInsertCommand(entity));
+        var savedEntity = await Mediator.Send(new DeXuatNhuCauKinhPhiNamInsertCommand(model.ToInsertDto()));
 
         List<TepDinhKem> files = [.. model.DanhSachTepDinhKem?.ToEntities(savedEntity.Id, GroupTypeConstants.NhuCauKinhPhi) ?? []];
 
@@ -70,45 +52,32 @@ public class DeXuatNhuCauKinhPhiNamController : AggregateRootController {
         return ResultApi.Ok(savedEntity.Id);
     }
 
-   
     [HttpPut("cap-nhat")]
     [Consumes(MediaTypeNames.Application.Json)]
-    [ProducesResponseType<ResultApi<DeXuatNhuCauKinhPhiNam>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ResultApi<DeXuatNhuCauKinhPhiNamModel>>(StatusCodes.Status200OK)]
     [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
     public async Task<ResultApi> Update(
         [FromBody] DeXuatNhuCauKinhPhiNamModel model,
         [FromServices] IUnitOfWork unitOfWork,
-        CancellationToken cancellationToken = default)
-    {
-        var entity = await Mediator.Send(new DeXuatNhuCauKinhPhiNamUpdateCommand(
-            new()
-            {
-                Id = model.GetId(),
-                So = model.So,
-                NgayKeHoach = model.NgayKeHoach,
-                TrichYeu = model.TrichYeu,
-                GhiChu = model.GhiChu,
-                TongKinhPhiDeXuat = model.TongKinhPhiDeXuat
-            }
-        ), cancellationToken);
+        CancellationToken cancellationToken = default) {
+        var insertDto = model.ToInsertDto();
+        insertDto.Id = model.GetId();
 
-        List<TepDinhKem> files = [.. model.DanhSachTepDinhKem?.ToEntities(entity.Id,GroupTypeConstants.NhuCauKinhPhi) ?? []];
-        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand
-        {
+        var entity = await Mediator.Send(new DeXuatNhuCauKinhPhiNamUpdateCommand(insertDto), cancellationToken);
+
+        List<TepDinhKem> files = [.. model.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.NhuCauKinhPhi) ?? []];
+        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
             GroupId = entity.Id.ToString(),
             Entities = files
         }, cancellationToken);
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
 
-        var danhSachTepDinhKem = await Mediator.Send(new GetDanhSachTepDinhKemQuery
-        {
+        var danhSachTepDinhKem = await Mediator.Send(new GetDanhSachTepDinhKemQuery {
             GroupId = [entity.Id.ToString()]
         }, cancellationToken);
         return ResultApi.Ok(entity.ToModel(danhSachTepDinhKem));
     }
-
-
 
     [HttpGet("danh-sach-tien-do")]
     [ProducesResponseType<ResultApi<PaginatedList<DeXuatNhuCauKinhPhiNamDto>>>(StatusCodes.Status200OK)]
@@ -121,10 +90,9 @@ public class DeXuatNhuCauKinhPhiNamController : AggregateRootController {
             NguoiDeXuatId = req.NguoiDeXuatId,
             PhongBanDeXuatId = req.PhongBanDeXuatId,
             GlobalFilter = req.GlobalFilter,
-            PageIndex = req.PageIndex??1,
-            PageSize = req.PageSize??1000000,
+            PageIndex = req.PageIndex ?? 1,
+            PageSize = req.PageSize ?? 1000000,
             IsNoTracking = true,
-            
         });
         return ResultApi.Ok(res);
     }

--- a/QLDA.WebApi/Controllers/ThuyetMinhDuAnController.cs
+++ b/QLDA.WebApi/Controllers/ThuyetMinhDuAnController.cs
@@ -1,32 +1,23 @@
 using System.Net.Mime;
+using QLDA.Application.BaoCaoTienDos.Commands;
+using QLDA.Application.BaoCaoTienDos.DTOs;
+using QLDA.Application.BaoCaoTienDos.Queries;
 using QLDA.Application.DuAns.Commands;
 using QLDA.Application.TepDinhKems.Commands;
 using QLDA.Application.TepDinhKems.Queries;
-using QLDA.Application.ThuyetMinhDuAns.Commands;
-using QLDA.Application.ThuyetMinhDuAns.DTOs;
-using QLDA.Application.ThuyetMinhDuAns.Queries;
+using QLDA.WebApi.Models.BaoCaoTienDos;
 using QLDA.WebApi.Models.TepDinhKems;
-using QLDA.WebApi.Models.ThuyetMinhDuAns;
 
 namespace QLDA.WebApi.Controllers;
 
 [Tags("Thuyết minh dự án")]
 [Route("api/thuyet-minh-du-an")]
-public class ThuyetMinhDuAnController : AggregateRootController {
-    // GET
-    public ThuyetMinhDuAnController(IServiceProvider serviceProvider) : base(serviceProvider) {
-    }
-
-    /// <summary>
-    /// Chi tiết
-    /// </summary>
-    /// <param name="id"></param>
-    /// <returns></returns>
-    [ProducesResponseType<ResultApi<ThuyetMinhDuAnModel>>(StatusCodes.Status200OK)]
+public class ThuyetMinhDuAnController(IServiceProvider serviceProvider) : AggregateRootController(serviceProvider) {
+    [ProducesResponseType<ResultApi<BaoCaoTienDoModel>>(StatusCodes.Status200OK)]
     [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
     [HttpGet("{id}/chi-tiet")]
     public async Task<ResultApi> Get(Guid id) {
-        var entity = await Mediator.Send(new ThuyetMinhDuAnGetQuery() {
+        var entity = await Mediator.Send(new BaoCaoTienDoGetQuery() {
             Id = id,
             ThrowIfNull = true,
             IsNoTracking = true,
@@ -38,33 +29,23 @@ public class ThuyetMinhDuAnController : AggregateRootController {
         return ResultApi.Ok(entity.ToModel(danhSachTepDinhKem));
     }
 
-
     [HttpDelete("{id}/xoa")]
     public async Task<ResultApi> Delete(Guid id) {
-        var res = await Mediator.Send(new ThuyetMinhDuAnDeleteCommand(id));
+        var res = await Mediator.Send(new BaoCaoTienDoDeleteCommand(id));
         return ResultApi.Ok(res);
     }
 
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <remarks>
-    ///du an id la bac buoc
-    /// </remarks>
-    /// <param name="model"></param>
-    /// <returns></returns>
+    /// <remarks>du an id la bac buoc</remarks>
     [HttpPost("them-moi")]
     [Consumes(MediaTypeNames.Application.Json)]
     [ProducesResponseType<ResultApi<Guid>>(StatusCodes.Status200OK)]
     [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
-    public async Task<ResultApi> Create([FromBody] ThuyetMinhDuAnModel model) {
-        //Cập nhật bước hiện tại của dự án
-        
+    public async Task<ResultApi> Create([FromBody] BaoCaoTienDoModel model) {
         var step = await Mediator.Send(new DuAnUpdateStepCommand(model.DuAnId, model.BuocId));
         await Mediator.Send(new DuAnUpdatePhaseCommand(model.DuAnId, step));
 
         var entity = model.ToEntity();
-        await Mediator.Send(new ThuyetMinhDuAnInsertOrUpdateCommand(entity));
+        await Mediator.Send(new BaoCaoTienDoInsertOrUpdateCommand(entity));
 
         var danhSachTepDinhKem = model.GetDanhSachTepDinhKem(entity.Id).ToList();
 
@@ -76,25 +57,19 @@ public class ThuyetMinhDuAnController : AggregateRootController {
         return ResultApi.Ok(entity.Id);
     }
 
-    /// <summary>
-    /// Cập nhật
-    /// </summary>
-    /// <param name="model"></param>
-    /// <returns></returns>
     [HttpPut("cap-nhat")]
     [Consumes(MediaTypeNames.Application.Json)]
-    [ProducesResponseType<ResultApi<ThuyetMinhDuAnModel>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ResultApi<BaoCaoTienDoModel>>(StatusCodes.Status200OK)]
     [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
-    public async Task<ResultApi> Update([FromBody] ThuyetMinhDuAnModel model) {
+    public async Task<ResultApi> Update([FromBody] BaoCaoTienDoModel model) {
         var entity =
-            await Mediator.Send(new ThuyetMinhDuAnGetQuery { Id = model.GetId(), ThrowIfNull = true });
+            await Mediator.Send(new BaoCaoTienDoGetQuery { Id = model.GetId(), ThrowIfNull = true });
         entity.Update(model);
 
-        await Mediator.Send(new ThuyetMinhDuAnInsertOrUpdateCommand(entity));
+        await Mediator.Send(new BaoCaoTienDoInsertOrUpdateCommand(entity));
 
         var danhSachTepDinhKem = model.GetDanhSachTepDinhKem(entity.Id);
 
-        //Thêm file mới
         await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand {
             GroupId = entity.Id.ToString(),
             Entities = danhSachTepDinhKem
@@ -102,20 +77,12 @@ public class ThuyetMinhDuAnController : AggregateRootController {
         return ResultApi.Ok(entity.ToModel(danhSachTepDinhKem));
     }
 
-    /// <summary>
-    /// Văn bản trong tiến độ dự án lấy theo từng bước
-    /// </summary>
-    /// <param name="duAnId"></param>
-    /// <param name="buocId"></param>
-    /// <param name="globalFilter"></param>
-    /// <param name="pageIndex"></param>
-    /// <param name="pageSize"></param>
-    /// <returns></returns>
     [HttpGet("danh-sach-tien-do")]
-    [ProducesResponseType<ResultApi<PaginatedList<ThuyetMinhDuAnDto>>>(StatusCodes.Status200OK)]
+    [ProducesResponseType<ResultApi<PaginatedList<BaoCaoTienDoDto>>>(StatusCodes.Status200OK)]
     [ProducesResponseType<ResultApi>(StatusCodes.Status400BadRequest)]
-    public async Task<ResultApi> Get([FromQuery] Guid? duAnId, int? buocId, string? globalFilter = null, int pageIndex = 0, int pageSize = 0) {
-        var res = await Mediator.Send(new ThuyetMinhDuAnGetDanhSachQuery() {
+    public async Task<ResultApi> GetDanhSach([FromQuery] Guid? duAnId, int? buocId, string? globalFilter = null,
+        int pageIndex = 0, int pageSize = 0) {
+        var res = await Mediator.Send(new BaoCaoTienDoGetDanhSachQuery() {
             DuAnId = duAnId,
             BuocId = buocId,
             GlobalFilter = globalFilter,

--- a/QLDA.WebApi/Models/DeXuatNhuCauKinhPhiNams/DeXuatNhuCauKinhPhiNamMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/DeXuatNhuCauKinhPhiNams/DeXuatNhuCauKinhPhiNamMappingConfiguration.cs
@@ -1,13 +1,11 @@
-using BuildingBlocks.Domain.Entities.Abstractions;
-using QLDA.Domain.Interfaces;
+using QLDA.Application.DeXuatNhuCauKinhPhiNams.DTOs;
 using QLDA.WebApi.Models.TepDinhKems;
-using static Dapper.SqlMapper;
 
 namespace QLDA.WebApi.Models.DeXuatNhuCauKinhPhiNams;
 
-public static class DeXuatNhuCauKinhPhiNamMappingConfiguration
-{
-    public static DeXuatNhuCauKinhPhiNamModel ToModel(this DeXuatNhuCauKinhPhiNam entity, List<TepDinhKem>? danhSachTepDinhKem = null) =>
+public static class DeXuatNhuCauKinhPhiNamMappingConfiguration {
+    public static DeXuatNhuCauKinhPhiNamModel ToModel(this DeXuatNhuCauKinhPhiNam entity,
+        List<TepDinhKem>? danhSachTepDinhKem = null) =>
         new() {
             Id = entity.Id,
             So = entity.So,
@@ -16,22 +14,19 @@ public static class DeXuatNhuCauKinhPhiNamMappingConfiguration
             GhiChu = entity.GhiChu,
             TongKinhPhiDeXuat = entity.TongKinhPhiDeXuat,
             TrangThaiId = entity.TrangThaiId,
+            DanhSachDeXuat = entity.DeXuats?.Select(x => x.RightId).ToList(),
             DanhSachTepDinhKem = danhSachTepDinhKem?.Select(o => o.ToModel()).ToList()
         };
 
-
-    public static DeXuatNhuCauKinhPhiNam ToEntity(this DeXuatNhuCauKinhPhiNamModel model)
-        => new() {
-            Id = model.GetId(),
+    public static DeXuatNhuCauKinhPhiNamInsertDto ToInsertDto(this DeXuatNhuCauKinhPhiNamModel model) =>
+        new() {
+            Id = model.Id,
             So = model.So,
             NgayKeHoach = model.NgayKeHoach,
             TrichYeu = model.TrichYeu,
             GhiChu = model.GhiChu,
-            TongKinhPhiDeXuat = model.TongKinhPhiDeXuat
+            TongKinhPhiDeXuat = model.TongKinhPhiDeXuat,
+            TrangThaiId = model.TrangThaiId,
+            DanhSachDeXuat = model.DanhSachDeXuat,
         };
-
-    //public static void Update(this DeXuatNhuCauKinhPhiNam entity, DeXuatNhuCauKinhPhiNamModel model) {
-    //    entity.BuocId = model.BuocId;
-    //    entity.DuAnId = model.DuAnId;
-    //}
 }

--- a/QLDA.WebApi/Models/DeXuatNhuCauKinhPhiNams/DeXuatNhuCauKinhPhiNamModel.cs
+++ b/QLDA.WebApi/Models/DeXuatNhuCauKinhPhiNams/DeXuatNhuCauKinhPhiNamModel.cs
@@ -1,27 +1,18 @@
 using System.ComponentModel;
 using QLDA.Domain.Interfaces;
-using QLDA.WebApi.Models.DeXuatNhuCauKinhPhis;
 using QLDA.WebApi.Models.TepDinhKems;
 using SequentialGuid;
 
 namespace QLDA.WebApi.Models.DeXuatNhuCauKinhPhiNams;
 
-public class DeXuatNhuCauKinhPhiNamModel : IHasKey<Guid?>, IMustHaveId<Guid>, IMayHaveTepDinhKemModel{
+public class DeXuatNhuCauKinhPhiNamModel : IHasKey<Guid?>, IMustHaveId<Guid>, IMayHaveTepDinhKemModel {
     [DefaultValue(null)] public Guid? Id { get; set; }
 
-    /// <summary>
-    /// Nếu có id => cập nhật, ngược lại là tạo mới
-    /// </summary>
-    /// <returns></returns>
     public Guid GetId() {
         Id ??= SequentialGuidGenerator.Instance.NewGuid();
         return (Guid)Id;
     }
 
-    public Guid SetId() {
-        
-        return SequentialGuidGenerator.Instance.NewGuid();
-    }
     public string? So { get; set; }
     public DateTimeOffset? NgayKeHoach { get; set; }
     public string? TrichYeu { get; set; }
@@ -30,7 +21,9 @@ public class DeXuatNhuCauKinhPhiNamModel : IHasKey<Guid?>, IMustHaveId<Guid>, IM
     public string? MaTrangThai { get; set; }
     public int? TrangThaiId { get; set; }
     public string? TenTrangThai { get; set; }
-    public List<DeXuatTrinhKinhPhiNam>? DeXuats { get; set; }
-    public List<TepDinhKemModel>? DanhSachTepDinhKem { get; set; }
 
+    /// <summary>Danh sách Id DeXuatNhuCauKinhPhi được trình trong tổng hợp KP năm</summary>
+    public List<Guid>? DanhSachDeXuat { get; set; }
+
+    public List<TepDinhKemModel>? DanhSachTepDinhKem { get; set; }
 }

--- a/docs/feature/DeXuatKinhPhiNam/task-fix-de-xuat-trinh-junction-swagger.md
+++ b/docs/feature/DeXuatKinhPhiNam/task-fix-de-xuat-trinh-junction-swagger.md
@@ -1,0 +1,522 @@
+# Task – Fix junction `DeXuatTrinhKinhPhiNam`, `DanhMucDonViCbo`, Swagger `POST /api/tong-hop-kinh-phi/them-moi`
+
+> Tham chiếu format: [`task-9460-ky-so-crud.md`](../KySo/task-9460-ky-so-crud.md), pattern junction: [`task-fix-don-vi-phoi-hop-ids.md`](../DeXuatChuTruongMoi/task-fix-don-vi-phoi-hop-ids.md)
+
+---
+
+## 1. Phân tích yêu cầu
+
+### 1.1 Việc cần làm
+
+| # | Phần | Mục | Ghi chú |
+|---|------|-----|---------|
+| 1 | **PHẦN 1** | Sửa entity + EF `DeXuatTrinhKinhPhiNam` | Chỉ junction 2 cột; composite PK |
+| 2 | **PHẦN 1** | Migration (nếu DB có cột dư) | Drop column, **không** drop cả bảng |
+| 3 | **PHẦN 2** | `DanhMucDonViCbo` không sinh table | Keyless / không DbSet; drop table nếu đã tồn tại |
+| 4 | **PHẦN 3** | Request body API `them-moi` | Mảng `Guid`, không nested full entity |
+| 5 | Chung | Build + test Swagger/Postman | Không đổi route, không đổi `ResultApi` wrapper |
+
+### 1.2 API bị ảnh hưởng
+
+| Method | Endpoint | Sau fix |
+|--------|----------|---------|
+| POST | `/api/tong-hop-kinh-phi/them-moi` | Body gọn; lưu junction qua list Guid |
+| PUT | `/api/tong-hop-kinh-phi/cap-nhat` | *(Ngoài scope tối thiểu — chỉ sửa nếu còn dùng `DeXuats` full object)* |
+| GET | `/api/tong-hop-kinh-phi/{id}/chi-tiet` | Có thể bổ sung `danhSachDeXuatIds` response *(tùy product)* |
+
+> **Không đổi** route, tag controller, wrapper `ResultApi`.
+
+### 1.3 Payload mong muốn (POST `them-moi`)
+
+Tên field theo convention dự án (ưu tiên khớp `DeXuatNhuCauKinhPhiNamInsertDto.DanhSachDeXuat`):
+
+```json
+{
+  "so": "string",
+  "ngayKeHoach": "2026-05-25T00:00:00.000Z",
+  "trichYeu": "string",
+  "ghiChu": "string",
+  "tongKinhPhiDeXuat": 0,
+  "maTrangThai": "string",
+  "trangThaiId": 0,
+  "tenTrangThai": "string",
+  "danhSachDeXuat": [
+    "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+  ],
+  "danhSachTepDinhKem": []
+}
+```
+
+| Field | Kiểu | Map DB / nghiệp vụ |
+|-------|------|---------------------|
+| `danhSachDeXuat` | `List<Guid>?` | `DeXuatTrinhKinhPhiNam.RightId` (`DeXuatNhuCauKinhPhiId`) |
+| — | — | `DeXuatTrinhKinhPhiNam.LeftId` = `DeXuatNhuCauKinhPhiNam.Id` sau insert |
+| `maTrangThai`, `tenTrangThai` | string | **Read-only / display** — insert gán trạng thái DT server-side (handler hiện tại) |
+| `danhSachTepDinhKem` | list | `TepDinhKem` group `NhuCauKinhPhi` |
+
+> **Không** nhận `deXuats: [{ id, createdAt, deXuatNhuCauKinhPhi: { ... } }]`.
+
+### 1.4 Bảng junction mục tiêu
+
+| Cột DB | Property entity | Ghi chú |
+|--------|-----------------|--------|
+| `DeXuatKinhPhiNamId` | `LeftId` | FK → `DeXuatNhuCauKinhPhiNam.Id` |
+| `DeXuatNhuCauKinhPhiId` | `RightId` | Id bản ghi `DeXuatNhuCauKinhPhi` được trình |
+
+**Không có:** `Id`, `CreatedAt`, `CreatedBy`, `UpdatedAt`, `UpdatedBy`, `IsDeleted`, `Index`.
+
+---
+
+## 2. Phân tích hiện trạng
+
+### 2.1 `DeXuatTrinhKinhPhiNam` – Domain / EF / DB
+
+| Layer | Hiện trạng | Vấn đề |
+|-------|------------|--------|
+| **Domain** | `DeXuatTrinhKinhPhiNam : Entity<Guid>, IAggregateRoot` | Kế thừa base → Swagger/EF có thể expose `Id`, audit… dù config đã composite key |
+| **Persistence** | `DeXuatTrinhKinhPhiNamConfiguration`: `HasKey(LeftId, RightId)`, rename cột | Đúng hướng junction; base class `AggregateRootConfiguration` không phù hợp entity đơn giản |
+| **Migration Init** | Bảng **chỉ 2 cột** + composite PK | Khớp nghiệp vụ trong repo hiện tại |
+| **Snapshot** | Chỉ `LeftId`, `RightId` | Không có cột audit trong model |
+| **WebApi Model** | `DeXuatNhuCauKinhPhiNamModel.DeXuats` = `List<DeXuatTrinhKinhPhiNam>?` | **Nguyên nhân Swagger phức tạp** — client thấy full entity + navigation |
+
+**File liên quan:**
+
+- `QLDA.Domain/Entities/DeXuatTrinhKinhPhiNam.cs`
+- `QLDA.Persistence/Configurations/DeXuatTrinhKinhPhiNamConfiguration.cs`
+- `QLDA.Domain/Entities/DeXuatNhuCauKinhPhiNam.cs` — `ICollection<DeXuatTrinhKinhPhiNam>? DeXuats`
+- `QLDA.WebApi/Models/DeXuatNhuCauKinhPhiNams/DeXuatNhuCauKinhPhiNamModel.cs`
+- `QLDA.WebApi/Controllers/DeXuatNhuCauKinhPhiNamController.cs` — `POST them-moi` dùng `DeXuatNhuCauKinhPhiNamModel`
+
+### 2.2 Application – đã có DTO list Guid (chưa dùng ở WebApi)
+
+| File | Ghi chú |
+|------|---------|
+| `QLDA.Application/DeXuatKinhPhiNam/DTOs/DeXuatKinhPhiNamInsertDto.cs` | Đã có `List<Guid>? DanhSachDeXuat` |
+| `QLDA.Application/DeXuatKinhPhiNam/DeXuatNhuCauKinhPhiMappings.cs` | `ToEntity(dto)` map junction; `SyncDeXuatIds(entity, ids)` |
+| `QLDA.Application/DeXuatKinhPhiNam/Commands/DeXuatKinhPhiNamInsertCommand.cs` | Insert parent → `SyncDeXuatIds` sau `SaveChanges`; đọc `request.Dto.DeXuats?.Select(x => x.RightId)` |
+
+**Gap:** Controller gọi `model.ToEntity()` **không** map `DeXuats` / `DanhSachDeXuat` → junction không lưu khi POST qua WebApi model.
+
+### 2.3 `DanhMucDonViCbo`
+
+| Vị trí | Hiện trạng trong repo |
+|--------|----------------------|
+| `QLDA.Application/DeXuatChuTruongMoi/DTOs/DeXuatChuTruongMoiDto.cs` | Class `DanhMucDonViCbo` (DTO thuần) |
+| `QLDA.Application/DeXuatChuTruongMoi/Queries/DeXuatChuTruongMoiGetDanhSachQuery.cs` | **Trùng** class `DanhMucDonViCbo` trong file Query |
+| `QLDA.Domain` / `QLDA.Persistence` / `QLDA.Migrator` | **Không** có entity `DanhMucDonViCbo`, **không** có table trong migration |
+
+**Đọc dữ liệu:** Join `DmDonVi` + `DeXuatDonViXuLy` trong LINQ (`Select` → `DTOs.DanhMucDonViCbo`).
+
+> Nếu môi trường dev **có** table `DanhMucDonViCbo` trên SQL Server: có thể do branch khác / entity từng được thêm vào `DbContext`. Bước implement phải **grep toàn solution** trước khi quyết định migration drop.
+
+### 2.4 Pattern tham chiếu (bắt buộc bám)
+
+| Pattern | File |
+|---------|------|
+| Junction entity | `DeXuatDonViXuLy : IJunctionEntity<Guid, long>` |
+| Junction EF config | `DeXuatDonViXuLyConfiguration` |
+| API list id | `DeXuatChuTruongMoiModel.DonViPhoiHopIds` |
+| Sync junction | `DeXuatChuTruongMoiMappings.SyncDonViPhoiHopIds` |
+| POST không full object | `task-fix-don-vi-phoi-hop-ids.md` |
+
+---
+
+## 3. Thứ tự thực hiện
+
+```
+Bước 1:  Domain – DeXuatTrinhKinhPhiNam → IJunctionEntity<Guid, Guid>
+Bước 2:  Persistence – DeXuatTrinhKinhPhiNamConfiguration (bỏ audit base nếu có)
+Bước 3:  Kiểm tra DB thực tế → ef.bat QLDA add (chỉ khi có cột/table dư)
+Bước 4:  Application – dọn repository/handler (bỏ IRepository<DeXuatTrinhKinhPhiNam, Guid> thừa)
+Bước 5:  WebApi – Model + Mapping + Controller POST (danhSachDeXuat)
+Bước 6:  DanhMucDonViCbo – audit entity/DbSet; keyless hoặc DTO-only; migration drop table (nếu có)
+Bước 7:  dotnet build solution
+Bước 8:  Test Swagger / Postman
+```
+
+**Commit group (nếu có migration):** Domain + Persistence.Configuration + Migrator **cùng một commit** (theo `CLAUDE.md`).
+
+---
+
+## 4. Chi tiết từng bước
+
+---
+
+### Bước 1 – Domain: `DeXuatTrinhKinhPhiNam`
+
+**File:** `QLDA.Domain/Entities/DeXuatTrinhKinhPhiNam.cs`
+
+**Trước:**
+
+```csharp
+public class DeXuatTrinhKinhPhiNam : Entity<Guid>, IAggregateRoot {
+    public Guid LeftId { get; set; }
+    public Guid RightId { get; set; }
+    public DeXuatNhuCauKinhPhiNam? DeXuatNhuCauKinhPhi { get; set; }
+}
+```
+
+**Sau (theo `DeXuatDonViXuLy`):**
+
+```csharp
+using QLDA.Domain.Interfaces;
+
+namespace QLDA.Domain.Entities;
+
+/// <summary>
+/// Junction: Tổng hợp KP năm ↔ Đề xuất nhu cầu kinh phí được trình
+/// </summary>
+public class DeXuatTrinhKinhPhiNam : IJunctionEntity<Guid, Guid>, IAggregateRoot {
+    public Guid LeftId { get; set; }
+    public Guid RightId { get; set; }
+
+    #region Navigation Properties
+    public DeXuatNhuCauKinhPhiNam? DeXuatNhuCauKinhPhiNam { get; set; }
+    #endregion
+}
+```
+
+| Thay đổi | Lý do |
+|----------|-------|
+| Bỏ `Entity<Guid>` | Không còn `Id` / audit trên junction |
+| Giữ `IAggregateRoot` | Khớp pattern `DeXuatDonViXuLy`, repository hiện tại |
+| Đổi tên navigation (tùy chọn) | Tránh nhầm với entity `DeXuatNhuCauKinhPhi`; cập nhật Configuration `WithMany` |
+
+---
+
+### Bước 2 – Persistence: `DeXuatTrinhKinhPhiNamConfiguration`
+
+**File:** `QLDA.Persistence/Configurations/DeXuatTrinhKinhPhiNamConfiguration.cs`
+
+```csharp
+public class DeXuatTrinhKinhPhiNamConfiguration : AggregateRootConfiguration<DeXuatTrinhKinhPhiNam> {
+    public override void Configure(EntityTypeBuilder<DeXuatTrinhKinhPhiNam> builder) {
+        builder.ToTable(nameof(DeXuatTrinhKinhPhiNam));
+
+        builder.HasKey(e => new { e.LeftId, e.RightId });
+
+        builder.Property(e => e.LeftId).HasColumnName("DeXuatKinhPhiNamId");
+        builder.Property(e => e.RightId).HasColumnName("DeXuatNhuCauKinhPhiId");
+
+        // Không gọi ConfigureForBase() — junction không có audit columns
+
+        builder.HasOne(e => e.DeXuatNhuCauKinhPhiNam)
+            .WithMany(e => e.DeXuats)
+            .HasForeignKey(e => e.LeftId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}
+```
+
+**Kiểm tra sau khi sửa entity:**
+
+```bash
+cd QLDA.Migrator
+dotnet ef migrations add FixDeXuatTrinhKinhPhiNamJunction --startup-project ../QLDA.Migrator
+```
+
+| Kết quả migration | Hành động |
+|-------------------|-----------|
+| **Empty** / no-op | DB đã đúng 2 cột (Init) → có thể `ef.bat QLDA remove` migration vừa add |
+| **DropColumn** `Id`, `CreatedAt`, … | Apply lên DB dev đang có cột dư (ảnh screenshot task) |
+| **DropTable** `DanhMucDonViCbo` | Chỉ khi bước 6 xác nhận table tồn tại |
+
+```bash
+# Từ root repo
+ef.bat QLDA add FixDeXuatTrinhKinhPhiNamAndDanhMucDonViCbo
+ef.bat QLDA update
+# hoặc local: ef.bat QLDA update --sqlite
+```
+
+> **KHÔNG** sửa tay file migration `.cs` sau khi generate. **KHÔNG** sửa snapshot cũ.
+
+---
+
+### Bước 3 – Migration: cột cần remove (nếu DB có)
+
+Chỉ chạy khi SSMS / `INFORMATION_SCHEMA.COLUMNS` xác nhận bảng `DeXuatTrinhKinhPhiNam` **có** các cột:
+
+| Cột drop | Ghi chú |
+|----------|---------|
+| `Id` | PK cũ single-column (nếu từng tạo nhầm) |
+| `CreatedAt` | Audit |
+| `CreatedBy` | Audit |
+| `UpdatedAt` | Audit |
+| `UpdatedBy` | Audit |
+| `IsDeleted` | Soft delete — không dùng cho junction |
+| `Index` | STT / ordering base |
+
+**Không làm:** `DropTable("DeXuatTrinhKinhPhiNam")` khi chỉ cần drop column.
+
+---
+
+### Bước 4 – Application: Insert / Update / Repository
+
+#### 4.1 `DeXuatNhuCauKinhPhiNamInsertCommand`
+
+**File:** `QLDA.Application/DeXuatKinhPhiNam/Commands/DeXuatKinhPhiNamInsertCommand.cs`
+
+- Đổi command nhận `DeXuatNhuCauKinhPhiNamInsertDto` (hoặc record kèm `List<Guid>? DanhSachDeXuat`) thay vì entity từ WebApi map thiếu field.
+- Lấy ids: `request.Dto.DanhSachDeXuat` thay vì `request.Dto.DeXuats?.Select(x => x.RightId)`.
+- **Xóa** field `_repoDeXuat` nếu không dùng (dead code hiện tại).
+
+**Luồng giữ nguyên:**
+
+1. Insert `DeXuatNhuCauKinhPhiNam` (trạng thái DT server-side).
+2. `SaveChanges` → có `entity.Id`.
+3. `entity.SyncDeXuatIds(danhSachDeXuat)`.
+4. `SaveChanges` lần 2.
+
+#### 4.2 `DeXuatNhuCauKinhPhiNamUpdateCommand` *(nếu PUT cần sync junction)*
+
+- `Include(e => e.DeXuats)`.
+- Gọi `SyncDeXuatIds` từ list Guid trong DTO.
+
+#### 4.3 Repository
+
+- Junction **không** có `Guid Id` → tránh `IRepository<DeXuatTrinhKinhPhiNam, Guid>` cho thao tác đơn lẻ; sync qua navigation collection parent (pattern `DeXuatDonViXuLy`).
+
+---
+
+### Bước 5 – WebApi: Model + Mapping + Controller
+
+#### 5.1 `DeXuatNhuCauKinhPhiNamModel`
+
+**File:** `QLDA.WebApi/Models/DeXuatNhuCauKinhPhiNams/DeXuatNhuCauKinhPhiNamModel.cs`
+
+**Xóa:**
+
+```csharp
+public List<DeXuatTrinhKinhPhiNam>? DeXuats { get; set; }
+```
+
+**Thêm:**
+
+```csharp
+/// <summary>Danh sách Id DeXuatNhuCauKinhPhi được trình trong tổng hợp KP năm</summary>
+public List<Guid>? DanhSachDeXuat { get; set; }
+```
+
+> Có thể alias JSON `deXuatNhuCauKinhPhiIds` bằng `[JsonPropertyName("deXuatNhuCauKinhPhiIds")]` **chỉ khi** FE đã chốt tên — ưu tiên `danhSachDeXuat` khớp InsertDto.
+
+#### 5.2 `DeXuatNhuCauKinhPhiNamMappingConfiguration`
+
+**File:** `QLDA.WebApi/Models/DeXuatNhuCauKinhPhiNams/DeXuatNhuCauKinhPhiNamMappingConfiguration.cs`
+
+Thêm:
+
+```csharp
+public static DeXuatNhuCauKinhPhiNamInsertDto ToInsertDto(this DeXuatNhuCauKinhPhiNamModel model) =>
+    new() {
+        So = model.So,
+        NgayKeHoach = model.NgayKeHoach,
+        TrichYeu = model.TrichYeu,
+        GhiChu = model.GhiChu,
+        TongKinhPhiDeXuat = model.TongKinhPhiDeXuat,
+        TrangThaiId = model.TrangThaiId,
+        DanhSachDeXuat = model.DanhSachDeXuat,
+        DanhSachTepDinhKem = model.DanhSachTepDinhKem?.Select(...).ToList(),
+    };
+```
+
+`ToModel` (GET): map `DanhSachDeXuat = entity.DeXuats?.Select(x => x.RightId).ToList()` nếu product cần trả ids.
+
+#### 5.3 Controller `POST them-moi`
+
+**File:** `QLDA.WebApi/Controllers/DeXuatNhuCauKinhPhiNamController.cs`
+
+**Trước:**
+
+```csharp
+var entity = model.ToEntity();
+var savedEntity = await Mediator.Send(new DeXuatNhuCauKinhPhiNamInsertCommand(entity));
+```
+
+**Sau:**
+
+```csharp
+var savedEntity = await Mediator.Send(
+    new DeXuatNhuCauKinhPhiNamInsertCommand(model.ToInsertDto()));
+```
+
+- POST **không** gọi `model.GetId()` trên parent (để DB sinh `Id`) — align `task-fix-don-vi-phoi-hop-ids`.
+- `TepDinhKem` dùng `savedEntity.Id` sau insert.
+
+#### 5.4 `[ProducesResponseType]`
+
+Đổi request type Swagger sang `DeXuatNhuCauKinhPhiNamModel` (đã gọn) hoặc `DeXuatNhuCauKinhPhiNamInsertDto` nếu controller bind trực tiếp DTO Application (ưu tiên **một** model cho Swagger).
+
+---
+
+### Bước 6 – `DanhMucDonViCbo`
+
+#### 6.1 Audit (bắt buộc trước code)
+
+```bash
+# Tìm entity/DbSet/configuration
+rg "DanhMucDonViCbo" --glob "*.cs"
+rg "DbSet.*DanhMucDonViCbo" 
+```
+
+| Kết quả audit | Hành động |
+|---------------|-----------|
+| Chỉ có class trong **Application DTO/Query** (repo hiện tại) | **Không** migration; gom class trùng → một file DTO |
+| Có `QLDA.Domain` entity + `DbSet` | Xem 6.2 |
+| Table có trên DB, không có trong code | Migration `DropTable` |
+
+#### 6.2 Nếu tồn tại Domain entity (môi trường lỗi)
+
+**Option A – Chỉ DTO (khuyến nghị cho UC Đề xuất chủ trương):**
+
+- Xóa entity Domain / DbSet / Configuration.
+- Giữ `QLDA.Application/DeXuatChuTruongMoi/DTOs/DanhMucDonViCbo.cs`.
+- Xóa class trùng trong `DeXuatChuTruongMoiGetDanhSachQuery.cs` → `using DTOs`.
+
+**Option B – Keyless đọc view/table ngoài (chỉ khi bắt buộc map SQL view):**
+
+```csharp
+// Domain
+[Keyless]
+public class DanhMucDonViCbo { public long Id { get; set; } public string? TenDonVi { get; set; } }
+
+// Persistence
+builder.Entity<DanhMucDonViCbo>().HasNoKey().ToView("vw_DanhMucDonViCbo"); // hoặc ToTable nếu đọc bảng có sẵn, không insert
+```
+
+> Với list **Đề xuất chủ trương mới**, hiện **không cần** Option B — join `DmDonVi` đã đủ.
+
+#### 6.3 Migration drop table
+
+Chỉ khi `DanhMucDonViCbo` tồn tại trong DB:
+
+```sql
+-- Kiểm tra
+SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 'DanhMucDonViCbo';
+```
+
+EF migration generate: `migrationBuilder.DropTable(name: "DanhMucDonViCbo");`
+
+#### 6.4 Đảm bảo API list vẫn chạy
+
+`DeXuatChuTruongMoiGetDanhSachQuery` — không đổi logic join; chỉ đổi namespace DTO sau khi gom class.
+
+---
+
+## 5. Checklist hoàn thành
+
+```
+[ ] 1. DeXuatTrinhKinhPhiNam → IJunctionEntity<Guid, Guid> (bỏ Entity<Guid>)
+[ ] 2. EF Configuration: composite key, không ConfigureForBase
+[ ] 3. Migration: drop cột dư (nếu DB có) — không drop bảng junction
+[ ] 4. WebApi Model: DanhSachDeXuat thay DeXuats
+[ ] 5. Controller POST: InsertDto + command handler
+[ ] 6. Insert handler: DanhSachDeXuat + SyncDeXuatIds
+[ ] 7. DanhMucDonViCbo: audit + gom DTO / drop table nếu có
+[ ] 8. dotnet build (0 error)
+[ ] 9. Swagger POST them-moi: body không còn nested DeXuatNhuCauKinhPhi
+[ ] 10. Postman: insert + verify bảng DeXuatTrinhKinhPhiNam
+```
+
+---
+
+## 6. Lưu ý kỹ thuật
+
+- **DTO mapping** nằm **Application** (`DeXuatNhuCauKinhPhiNamMappings`) — không tạo WebApi model map entity phức tạp (`CLAUDE.md`).
+- **RightId** = `DeXuatNhuCauKinhPhi.Id` (module đề xuất nhu cầu KP), **LeftId** = `DeXuatNhuCauKinhPhiNam.Id` (tổng hợp KP năm). Tên cột `DeXuatNhuCauKinhPhiId` giữ nguyên theo migration Init.
+- Init migration **đã** đúng 2 cột — dev DB có thêm cột thường do apply schema cũ hoặc entity `Entity<Guid>` từng được scaffold. Luôn **đối chiếu DB thật** trước khi commit migration.
+- `maTrangThai`, `tenTrangThai` trên request có thể bỏ qua khi insert — handler gán `TrangThaiId` từ `DanhMucTrangThaiPheDuyet` mã `DT`.
+- **Không** push `bin/`, `obj/`, `logs/`, `publish/`.
+
+---
+
+## 7. Kịch bản test (Swagger / Postman)
+
+### 7.1 POST `/api/tong-hop-kinh-phi/them-moi`
+
+**Request:**
+
+```http
+POST /api/tong-hop-kinh-phi/them-moi
+Content-Type: application/json
+
+{
+  "so": "TH-2026-001",
+  "ngayKeHoach": "2026-05-25T00:00:00Z",
+  "trichYeu": "Tổng hợp KP năm test",
+  "tongKinhPhiDeXuat": 1000000,
+  "danhSachDeXuat": [
+    "<guid-de-xuat-nhu-cau-kinh-phi-1>",
+    "<guid-de-xuat-nhu-cau-kinh-phi-2>"
+  ],
+  "danhSachTepDinhKem": []
+}
+```
+
+| Kiểm tra | Kỳ vọng |
+|----------|---------|
+| Status | `200`, `data` = `Guid` parent mới |
+| Swagger schema | Không có object `deXuats` lồng audit |
+| DB `DeXuatTrinhKinhPhiNam` | 2 row / 2 id; chỉ 2 cột + PK composite |
+| DB không có cột `Id` trên junction | SSMS confirm |
+
+### 7.2 SQL verify junction
+
+```sql
+SELECT DeXuatKinhPhiNamId, DeXuatNhuCauKinhPhiId
+FROM DeXuatTrinhKinhPhiNam
+WHERE DeXuatKinhPhiNamId = '<parent-id-vua-tao>';
+```
+
+### 7.3 GET list Đề xuất chủ trương (DanhMucDonViCbo)
+
+```http
+GET /api/de-xuat-chu-truong-moi/danh-sach?duAnId=<guid>
+```
+
+| Kiểm tra | Kỳ vọng |
+|----------|---------|
+| `danhSachDonViPhoiHop` | Vẫn có `id`, `tenDonVi` sau khi gom DTO |
+| Table `DanhMucDonViCbo` | Không tồn tại (hoặc đã drop) |
+
+### 7.4 Build
+
+```bash
+dotnet build QLDA.sln
+```
+
+---
+
+## 8. Mẫu báo cáo sau khi implement (trả lời 7 câu hỏi)
+
+> Dev điền sau khi xong task — copy section này vào PR / comment.
+
+| # | Câu hỏi | Điền khi xong |
+|---|---------|---------------|
+| 1 | Đã sửa những file nào? | *(list path)* |
+| 2 | Entity `DeXuatTrinhKinhPhiNam` đã sửa ra sao? | `IJunctionEntity<Guid, Guid>`, chỉ `LeftId`/`RightId` |
+| 3 | Migration mới tên gì? | `FixDeXuatTrinhKinhPhiNam...` / hoặc *Không có* |
+| 4 | Đã remove những cột nào khỏi `DeXuatTrinhKinhPhiNam`? | `Id`, `CreatedAt`, … hoặc *Không có trên DB* |
+| 5 | `DanhMucDonViCbo` xử lý thế nào? | DTO-only / keyless / drop table |
+| 6 | Request body `them-moi` sau sửa? | JSON mẫu §1.3 |
+| 7 | Cách test lại? | §7 Swagger + SQL |
+
+---
+
+## 9. Phụ lục – File map nhanh
+
+| Layer | File | Thao tác |
+|-------|------|----------|
+| Domain | `Entities/DeXuatTrinhKinhPhiNam.cs` | Sửa junction |
+| Persistence | `Configurations/DeXuatTrinhKinhPhiNamConfiguration.cs` | Sửa EF |
+| Migrator | `ef.bat QLDA add ...` | Có điều kiện |
+| Application | `DeXuatKinhPhiNam/DeXuatNhuCauKinhPhiMappings.cs` | Giữ / tinh chỉnh |
+| Application | `DeXuatKinhPhiNam/DTOs/DeXuatKinhPhiNamInsertDto.cs` | Đã có `DanhSachDeXuat` |
+| Application | `DeXuatKinhPhiNam/Commands/DeXuatKinhPhiNamInsertCommand.cs` | Dùng DTO + dọn repo |
+| WebApi | `Models/.../DeXuatNhuCauKinhPhiNamModel.cs` | List Guid |
+| WebApi | `Models/.../DeXuatNhuCauKinhPhiNamMappingConfiguration.cs` | `ToInsertDto` |
+| WebApi | `Controllers/DeXuatNhuCauKinhPhiNamController.cs` | POST |
+| Application | `DeXuatChuTruongMoi/DTOs/...` + Query | Gom `DanhMucDonViCbo` |
+
+---
+
+*Task doc – chưa implement code. Tạo từ phân tích codebase + yêu cầu user.*


### PR DESCRIPTION
## Summary
- Chuẩn hóa bảng junction `DeXuatTrinhKinhPhiNam` chỉ còn 2 cột (`DeXuatKinhPhiNamId`, `DeXuatNhuCauKinhPhiId`), bỏ cột audit/`Id` trên DB dev lệch schema.
- Xóa bảng thừa `DanhMucDonViCbo` (chỉ dùng DTO query qua `DmDonVi` + `DeXuatDonViXuLy`).
- API `POST/PUT /api/tong-hop-kinh-phi` nhận `danhSachDeXuat: Guid[]`, sync junction qua Application (`SyncDeXuatIds`).

## DB
- Migration: `FixDeXuatTrinhJunctionAndDropDanhMucDonViCbo`
- Drop FK/default/PK cũ → drop cột dư → composite PK 2 cột
- Drop FK tham chiếu → `DROP TABLE DanhMucDonViCbo` (nếu tồn tại)

## API
- Swagger không còn nested `deXuats` / full entity junction
- Insert/Update dùng `DeXuatNhuCauKinhPhiNamInsertDto` + `ToInsertDto()`

## Test plan
- [x] `dotnet ef database update` thành công
- [x] `dotnet build` pass
- [x] POST `/api/tong-hop-kinh-phi/them-moi` với `danhSachDeXuat: [guid,...]`
- [x] Verify SQL: `DeXuatTrinhKinhPhiNam` chỉ 2 cột; không còn bảng `DanhMucDonViCbo`
- [x] GET `/api/de-xuat-chu-truong-moi/danh-sach` — `danhSachDonViPhoiHop` vẫn có `id`, `tenDonVi`

## Hình Ảnh
<img width="1730" height="650" alt="image" src="https://github.com/user-attachments/assets/7bf9227c-443e-4a5a-8c8f-2854d4930cff" />
