### PR TITLE
fix(qlda): search filters and trien khai ke hoach lcnt update fixes

### DIFF
--- a/QLDA.Application/DuAns/DTOs/TheoDoiDuAnPhongPhanCongSearchDto.cs
+++ b/QLDA.Application/DuAns/DTOs/TheoDoiDuAnPhongPhanCongSearchDto.cs
@@ -17,6 +17,12 @@ public record TheoDoiDuAnPhongPhanCongSearchDto : CommonSearchDto
     /// <summary>Mã dự án (contains)</summary>
     public string? MaDuAn { get; set; }
 
+    /// <summary>Lãnh đạo phụ trách — UserMaster.Id. Gửi -1 để lọc dự án chưa gán.</summary>
+    public long? LanhDaoPhuTrachId { get; set; }
+
+    /// <summary>Trạng thái dự án — DanhMucTrangThaiDuAn (KHÔNG phải trạng thái phê duyệt)</summary>
+    public int? TrangThaiDuAnId { get; set; }
+
     /// <summary>Panel/tab đang chọn</summary>
     public ETheoDoiDuAnPhongPhanCongLoai Loai { get; set; } = ETheoDoiDuAnPhongPhanCongLoai.TatCa;
 }

--- a/QLDA.Application/DuAns/Queries/TheoDoiDuAnPhongPhanCongQuery.cs
+++ b/QLDA.Application/DuAns/Queries/TheoDoiDuAnPhongPhanCongQuery.cs
@@ -116,6 +116,10 @@ internal class TheoDoiDuAnPhongPhanCongQueryHandler(
                 e => search.NamDuAn >= e.ThoiGianKhoiCong
                      && ((e.ThoiGianHoanThanh == null && e.ThoiGianKhoiCong == search.NamDuAn)
                          || search.NamDuAn <= e.ThoiGianHoanThanh))
+            .WhereFunc(search.LanhDaoPhuTrachId.HasValue, q => q
+                .WhereIf(search.LanhDaoPhuTrachId > 0, e => e.LanhDaoPhuTrachId == search.LanhDaoPhuTrachId)
+                .WhereIf(search.LanhDaoPhuTrachId == -1, e => e.LanhDaoPhuTrachId == null))
+            .WhereIf(search.TrangThaiDuAnId > 0, e => e.TrangThaiDuAnId == search.TrangThaiDuAnId)
             .WhereGlobalFilter(search, e => e.TenDuAn, e => e.MaDuAn);
 
         return loai switch

--- a/QLDA.Application/PhanKhaiKinhPhis/DTOs/PhanKhaiKinhPhiSearchDto.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/DTOs/PhanKhaiKinhPhiSearchDto.cs
@@ -1,0 +1,21 @@
+using QLDA.Application.Common.Interfaces;
+
+namespace QLDA.Application.PhanKhaiKinhPhis.DTOs;
+
+/// <summary>
+/// Search params cho danh sách phân khai kinh phí.
+/// Filter dự án (TenDuAn, DonViPhuTrachChinhId, LoaiDuAnTheoNamId) áp dụng qua navigation DuAn.
+/// </summary>
+public record PhanKhaiKinhPhiSearchDto : CommonSearchDto {
+    /// <summary>Tên dự án — contains, không phân biệt hoa thường</summary>
+    public string? TenDuAn { get; set; }
+
+    /// <summary>Đơn vị / phòng ban phụ trách chính của dự án</summary>
+    public long? DonViPhuTrachChinhId { get; set; }
+
+    /// <summary>Loại dự án theo năm tài chính (PMIS #9121) — KHÔNG phải LoaiDuAnId</summary>
+    public int? LoaiDuAnTheoNamId { get; set; }
+
+    /// <summary>Trạng thái phê duyệt phân khai — DanhMucTrangThaiPheDuyet</summary>
+    public int? TrangThaiId { get; set; }
+}

--- a/QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachExportQuery.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachExportQuery.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using QLDA.Application.Common.Mapping;
 using QLDA.Application.PhanKhaiKinhPhis.DTOs;
 using QLDA.Domain.Constants;
 
@@ -9,6 +10,9 @@ public record PhanKhaiKinhPhiGetDanhSachExportQuery : IMayHaveGlobalFilter,
     public Guid? DuAnId { get; set; }
     public Guid? Id { get; set; }
     public string? GlobalFilter { get; set; }
+    public string? TenDuAn { get; set; }
+    public long? DonViPhuTrachChinhId { get; set; }
+    public int? LoaiDuAnTheoNamId { get; set; }
     public int? TrangThaiId { get; set; }
 }
 
@@ -24,9 +28,19 @@ internal class PhanKhaiKinhPhiGetDanhSachExportQueryHandler(IServiceProvider ser
             .Include(e => e.TrangThai)
             .Include(e => e.DuAn)
             .Include(e => e.NguonVon)
+            .Where(e => e.DuAn != null && !e.DuAn.IsDeleted)
             .WhereIf(request.Id != null, e => e.Id == request.Id)
             .WhereIf(request.DuAnId != null, e => e.DuAnId == request.DuAnId)
             .WhereIf(request.TrangThaiId > 0, e => e.TrangThaiId == request.TrangThaiId)
+            .WhereIf(request.TenDuAn.IsNotNullOrWhitespace(),
+                e => e.DuAn!.TenDuAn!.ToLower().Contains(request.TenDuAn!.ToLower()))
+            .WhereFunc(request.DonViPhuTrachChinhId.HasValue, q => q
+                .WhereIf(request.DonViPhuTrachChinhId > 0,
+                    e => e.DuAn!.DonViPhuTrachChinhId == request.DonViPhuTrachChinhId)
+                .WhereIf(request.DonViPhuTrachChinhId == -1,
+                    e => e.DuAn!.DonViPhuTrachChinhId == null))
+            .WhereIf(request.LoaiDuAnTheoNamId > 0,
+                e => e.DuAn!.LoaiDuAnTheoNamId == request.LoaiDuAnTheoNamId)
             .WhereGlobalFilter(request,
                 e => e.SoToTrinh,
                 e => e.NguonVon != null ? e.NguonVon.Ten : null
@@ -35,27 +49,18 @@ internal class PhanKhaiKinhPhiGetDanhSachExportQueryHandler(IServiceProvider ser
         var rows = await queryable
             .OrderBy(e => e.SoToTrinh)
             .ToListAsync(cancellationToken);
-        try
-        {
-            return rows.Select((e, index) => new PhanKhaiKinhPhiDanhSachExportDto
-            {
-                Stt = index + 1,
-                TenDuAn = e.DuAn?.TenDuAn,
-                KinhPhiDeXuat = e.KinhPhiDeXuat,
-                KinhPhiPhanKhai = e.KinhPhiPhanKhai,
-                TongMucDauTu = e.DuAn?.TongMucDauTu,
-                SoToTrinh = e.SoToTrinh,
-                NgayToTrinh = e.NgayToTrinh,
-                TenTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG"
-              ? e.TrangThai.Ten
-              : TrangThaiPheDuyetCodes.Default.TenDuThao,
-            }).ToList();
-        }
-        catch (Exception ex)
-        {
 
-            throw;
-        }
-      
+        return rows.Select((e, index) => new PhanKhaiKinhPhiDanhSachExportDto {
+            Stt = index + 1,
+            TenDuAn = e.DuAn?.TenDuAn,
+            KinhPhiDeXuat = e.KinhPhiDeXuat,
+            KinhPhiPhanKhai = e.KinhPhiPhanKhai,
+            TongMucDauTu = e.DuAn?.TongMucDauTu,
+            SoToTrinh = e.SoToTrinh,
+            NgayToTrinh = e.NgayToTrinh,
+            TenTrangThai = e.TrangThai != null && e.TrangThai.Ma != "LEG"
+                ? e.TrangThai.Ten
+                : TrangThaiPheDuyetCodes.Default.TenDuThao,
+        }).ToList();
     }
 }

--- a/QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachQuery.cs
+++ b/QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachQuery.cs
@@ -6,10 +6,8 @@ using QLDA.Domain.Constants;
 
 namespace QLDA.Application.PhanKhaiKinhPhis.Queries;
 
-public record PhanKhaiKinhPhiGetDanhSachQuery : AggregateRootPagination, IMayHaveGlobalFilter, IRequest<PaginatedList<PhanKhaiKinhPhiDto>> {
-    public Guid? DuAnId { get; set; }
-    public string? GlobalFilter { get; set; }
-    public int? TrangThaiId { get; set; }
+public record PhanKhaiKinhPhiGetDanhSachQuery(PhanKhaiKinhPhiSearchDto SearchDto)
+    : AggregateRootPagination, IRequest<PaginatedList<PhanKhaiKinhPhiDto>> {
     public bool IsNoTracking { get; set; }
 }
 
@@ -23,12 +21,25 @@ internal class PhanKhaiKinhPhiGetDanhSachQueryHandler : IRequestHandler<PhanKhai
     }
 
     public async Task<PaginatedList<PhanKhaiKinhPhiDto>> Handle(PhanKhaiKinhPhiGetDanhSachQuery request, CancellationToken cancellationToken = default) {
+        var search = request.SearchDto;
+
         var queryable = _repo.GetQueryableSet().AsNoTracking()
             .Include(e => e.TrangThai)
             .Include(e => e.NguonVon)
-            .WhereIf(request.DuAnId != null, e => e.DuAnId == request.DuAnId)
-            .WhereIf(request.TrangThaiId > 0, e => e.TrangThaiId == request.TrangThaiId)
-            .WhereGlobalFilter(request,
+            .Include(e => e.DuAn)
+            .Where(e => e.DuAn != null && !e.DuAn.IsDeleted)
+            .WhereIf(search.DuAnId != null, e => e.DuAnId == search.DuAnId)
+            .WhereIf(search.TrangThaiId > 0, e => e.TrangThaiId == search.TrangThaiId)
+            .WhereIf(search.TenDuAn.IsNotNullOrWhitespace(),
+                e => e.DuAn!.TenDuAn!.ToLower().Contains(search.TenDuAn!.ToLower()))
+            .WhereFunc(search.DonViPhuTrachChinhId.HasValue, q => q
+                .WhereIf(search.DonViPhuTrachChinhId > 0,
+                    e => e.DuAn!.DonViPhuTrachChinhId == search.DonViPhuTrachChinhId)
+                .WhereIf(search.DonViPhuTrachChinhId == -1,
+                    e => e.DuAn!.DonViPhuTrachChinhId == null))
+            .WhereIf(search.LoaiDuAnTheoNamId > 0,
+                e => e.DuAn!.LoaiDuAnTheoNamId == search.LoaiDuAnTheoNamId)
+            .WhereGlobalFilter(search,
                 e => e.SoToTrinh,
                 e => e.NguonVon != null ? e.NguonVon.Ten : null
             );
@@ -52,6 +63,6 @@ internal class PhanKhaiKinhPhiGetDanhSachQueryHandler : IRequestHandler<PhanKhai
                     .Where(i => i.GroupId == e.Id.ToString())
                     .Select(i => i.ToDto()).ToList(),
             })
-            .PaginatedListAsync(request.Skip(), request.Take(), cancellationToken: cancellationToken);
+            .PaginatedListAsync(search.Skip(), search.Take(), cancellationToken: cancellationToken);
     }
 }

--- a/QLDA.Application/TrienKhaiKeHoachLCNT/Commands/TrienKhaiKeHoachLCNTUpdateCommand.cs
+++ b/QLDA.Application/TrienKhaiKeHoachLCNT/Commands/TrienKhaiKeHoachLCNTUpdateCommand.cs
@@ -40,8 +40,6 @@ internal class TrienKhaiKeHoachLCNTUpdateCommandHandler : IRequestHandler<TrienK
         .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DeXuatMacDinh.TraLai && s.Loai == PheDuyetEntityNames.DeXuatMacDinhStt, cancellationToken);
 
         var entity = await _repo.GetQueryableSet()
-            .Include(e => e.DonViTuVans)
-            .Include(e => e.TrangThai)
             .FirstOrDefaultAsync(e => e.Id == request.Dto.Id, cancellationToken);
         ManagedException.ThrowIf(entity == null, "Không tìm thấy dữ liệu.");
 
@@ -53,8 +51,8 @@ internal class TrienKhaiKeHoachLCNTUpdateCommandHandler : IRequestHandler<TrienK
         entity.DuAnId = request.Dto.DuAnId;
         entity.NgayTrinh = request.Dto.NgayTrinh;
         entity.TrichYeu = request.Dto.TrichYeu;
-        entity.So = request.Dto.TrichYeu;
-        
+        entity.So = request.Dto.So;
+
         entity.NoiDung = request.Dto.NoiDung;
         entity.YeuCau = request.Dto.YeuCau;
         entity.GiaTri = request.Dto.GiaTri;
@@ -62,9 +60,11 @@ internal class TrienKhaiKeHoachLCNTUpdateCommandHandler : IRequestHandler<TrienK
         entity.HinhThucLCNT = request.Dto.HinhThucLCNT;
         entity.TrangThaiDangTaiId = request.Dto.TrangThaiDangTaiId;
         entity.ThoiGianThucHien = request.Dto.ThoiGianThucHien;
-        
-        entity.DonViTuVans = request.Dto.DonViTuVans;
-        await _repo.UpdateAsync(entity, cancellationToken);
+
+        var dbContext = _unitOfWork as DbContext
+            ?? throw new InvalidOperationException("UnitOfWork must be a DbContext.");
+        await dbContext.SyncDonViTuVanAsync(entity.Id, request.Dto.DonViTuVans, cancellationToken);
+
         await _unitOfWork.SaveChangesAsync(cancellationToken);
 
         return entity;

--- a/QLDA.Application/TrienKhaiKeHoachLCNT/TrienKhaiKeHoachLCNTMappings.cs
+++ b/QLDA.Application/TrienKhaiKeHoachLCNT/TrienKhaiKeHoachLCNTMappings.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using QLDA.Application.TepDinhKems.DTOs;
 using QLDA.Application.ToTrinhThamDinhNhaThaus.DTOs;
 using QLDA.Application.TrienKhaiKeHoachLCNTs.DTOs;
@@ -5,20 +6,33 @@ using QLDA.Application.TrienKhaiKeHoachLCNTs.DTOs;
 namespace QLDA.Application.TrienKhaiKeHoachLCNTMappings;
 
 public static class TrienKhaiKeHoachLCNTMappings {
-    public static void SyncDonViTuVan(this TrienKhaiKeHoachLCNT entity, List<DonViTuVanKeHoach>? donVis) {
-        if (donVis is null) {
-            entity.DonViTuVans = [];
-            return;
-        }
+    public static async Task SyncDonViTuVanAsync(
+        this DbContext dbContext,
+        Guid keHoachId,
+        List<DonViTuVanKeHoach>? donVis,
+        CancellationToken cancellationToken = default) {
+        var requestList = donVis ?? [];
+        var requestIds = requestList.Select(d => d.Id).ToHashSet();
 
-        entity.DonViTuVans ??= [];
-        entity.DonViTuVans.Clear();
-        foreach (var item in donVis) {
-            entity.DonViTuVans.Add(new DonViTuVanKeHoach {
-                Id= item.Id,
-                KeHoachId = entity.Id,
-                TenDonVi = item.TenDonVi
-            });
+        var existingInDb = await dbContext.Set<DonViTuVanKeHoach>()
+            .Where(d => d.KeHoachId == keHoachId)
+            .ToListAsync(cancellationToken);
+
+        foreach (var toRemove in existingInDb.Where(d => !requestIds.Contains(d.Id)).ToList())
+            dbContext.Set<DonViTuVanKeHoach>().Remove(toRemove);
+
+        foreach (var item in requestList) {
+            var existing = existingInDb.FirstOrDefault(d => d.Id == item.Id);
+            if (existing is not null) {
+                existing.TenDonVi = item.TenDonVi;
+                existing.KeHoachId = keHoachId;
+            } else {
+                await dbContext.Set<DonViTuVanKeHoach>().AddAsync(new DonViTuVanKeHoach {
+                    Id = item.Id,
+                    KeHoachId = keHoachId,
+                    TenDonVi = item.TenDonVi
+                }, cancellationToken);
+            }
         }
     }
 

--- a/QLDA.WebApi/Controllers/PhanKhaiKinhPhiController.cs
+++ b/QLDA.WebApi/Controllers/PhanKhaiKinhPhiController.cs
@@ -43,16 +43,8 @@ public class PhanKhaiKinhPhiController : AggregateRootController {
     /// </summary>
     [ProducesResponseType<ResultApi<PaginatedList<PhanKhaiKinhPhiDto>>>(StatusCodes.Status200OK)]
     [HttpGet("danh-sach")]
-    public async Task<ResultApi> GetDanhSach(
-        [FromQuery] Guid? duAnId,
-        [FromQuery] string? globalFilter = null,
-        [FromQuery] int? trangThaiId = null,
-        int pageIndex = 0, int pageSize = 0) {
-        var res = await Mediator.Send(new PhanKhaiKinhPhiGetDanhSachQuery {
-            DuAnId = duAnId, GlobalFilter = globalFilter,
-            TrangThaiId = trangThaiId,
-            PageIndex = pageIndex, PageSize = pageSize, IsNoTracking = true,
-        });
+    public async Task<ResultApi> GetDanhSach([FromQuery] PhanKhaiKinhPhiSearchModel searchModel) {
+        var res = await Mediator.Send(searchModel.ToQuery());
         return ResultApi.Ok(res);
     }
 

--- a/QLDA.WebApi/Controllers/PrintController.cs
+++ b/QLDA.WebApi/Controllers/PrintController.cs
@@ -681,6 +681,9 @@ public class PrintController(IServiceProvider serviceProvider) : AggregateRootCo
         {
             DuAnId = searchModel.DuAnId,
             GlobalFilter = searchModel.GlobalFilter,
+            TenDuAn = searchModel.TenDuAn,
+            DonViPhuTrachChinhId = searchModel.DonViPhuTrachChinhId,
+            LoaiDuAnTheoNamId = searchModel.LoaiDuAnTheoNamId,
             TrangThaiId = searchModel.TrangThaiId,
         }, cancellationToken);
 

--- a/QLDA.WebApi/Controllers/TrienKhaiKeHoachLCNTController.cs
+++ b/QLDA.WebApi/Controllers/TrienKhaiKeHoachLCNTController.cs
@@ -109,27 +109,33 @@ public class TrienKhaiKeHoachLCNTController(IServiceProvider serviceProvider) : 
     [Consumes(MediaTypeNames.Application.Json)]
     public async Task<ResultApi> Update([FromBody] TrienKhaiKeHoachLCNTModel model, [FromServices] IUnitOfWork unitOfWork, CancellationToken cancellationToken = default)
     {
-        using var tx = await unitOfWork.BeginTransactionAsync(System.Data.IsolationLevel.ReadCommitted, cancellationToken); 
+        using var tx = await unitOfWork.BeginTransactionAsync(System.Data.IsolationLevel.ReadCommitted, cancellationToken);
         var entity = await Mediator.Send(new TrienKhaiKeHoachLCNTUpdateCommand(model.ToEntity()), cancellationToken);
 
-        List<TepDinhKem> files = [.. model.DanhSachTepDinhKem?.ToEntities(entity.Id, GroupTypeConstants.TrienKhaiKeHoachLCNT) ?? []];
+        var danhSachTepChinh = model.GetDanhSachTep(entity.Id).ToList();
         await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand
         {
             GroupId = entity.Id.ToString(),
-            Entities = files
+            Entities = danhSachTepChinh,
+            ScopeGroupTypes = [GroupTypeConstants.TrienKhaiKeHoachLCNT]
         }, cancellationToken);
 
-        await unitOfWork.SaveChangesAsync(cancellationToken);
-        var danhSachTepDinhKem = model.GetDanhSachTep(entity.Id);
-
-        await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand
+        foreach (var dv in model.DonViTuVans ?? [])
         {
-            GroupId = entity.Id.ToString(),
-            Entities = danhSachTepDinhKem
-        });
+            var dvId = dv.Id ?? dv.GetId();
+            var files = dv.GetDanhSachTep(dvId).ToList();
+            await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand
+            {
+                GroupId = dvId.ToString(),
+                Entities = files,
+                ScopeGroupTypes = [GroupTypeConstants.DonViTuVan]
+            }, cancellationToken);
+        }
+
+        await unitOfWork.SaveChangesAsync(cancellationToken);
         await unitOfWork.CommitTransactionAsync(cancellationToken);
 
-        return ResultApi.Ok(entity.ToDto(danhSachTepDinhKem.ToList()));
+        return ResultApi.Ok(entity.ToDto(danhSachTepChinh));
     }
 
     [ProducesResponseType<ResultApi<PaginatedList<TrienKhaiKeHoachLCNTDto>>>(StatusCodes.Status200OK)]

--- a/QLDA.WebApi/Models/DonViTuVanKeHoach/DonViTuVanKeHoachMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/DonViTuVanKeHoach/DonViTuVanKeHoachMappingConfiguration.cs
@@ -13,12 +13,15 @@ public static class DonViTuVanKeHoachMappingConfiguration {
         };
 
 
-    public static DonViTuVanKeHoach ToEntity(this DonViTuVanKeHoachModel model)
+    public static DonViTuVanKeHoach ToEntity(this DonViTuVanKeHoachModel model, Guid keHoachId)
         => new() {
-            Id = model.GetId(),
-            KeHoachId = model.KeHoachId,    
-            TenDonVi = model.TenDonVi   
+            Id = model.Id ?? model.GetId(),
+            KeHoachId = keHoachId,
+            TenDonVi = model.TenDonVi
         };
+
+    public static DonViTuVanKeHoach ToEntity(this DonViTuVanKeHoachModel model)
+        => model.ToEntity(model.KeHoachId);
 
   
 }

--- a/QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiMappingConfiguration.cs
@@ -1,9 +1,25 @@
+using QLDA.Application.PhanKhaiKinhPhis.DTOs;
+using QLDA.Application.PhanKhaiKinhPhis.Queries;
 using QLDA.Domain.Entities;
 using QLDA.WebApi.Models.TepDinhKems;
 
 namespace QLDA.WebApi.Models.PhanKhaiKinhPhis;
 
 public static class PhanKhaiKinhPhiMappingConfiguration {
+    public static PhanKhaiKinhPhiSearchDto ToSearchDto(this PhanKhaiKinhPhiSearchModel model) => new() {
+        DuAnId = model.DuAnId,
+        GlobalFilter = model.GlobalFilter,
+        TenDuAn = model.TenDuAn,
+        DonViPhuTrachChinhId = model.DonViPhuTrachChinhId,
+        LoaiDuAnTheoNamId = model.LoaiDuAnTheoNamId,
+        TrangThaiId = model.TrangThaiId,
+        PageIndex = model.PageIndex,
+        PageSize = model.PageSize,
+    };
+
+    public static PhanKhaiKinhPhiGetDanhSachQuery ToQuery(this PhanKhaiKinhPhiSearchModel model)
+        => new(model.ToSearchDto()) { IsNoTracking = true };
+
     public static PhanKhaiKinhPhiModel ToModel(this PhanKhaiKinhPhi entity) => new() {
         Id = entity.Id,
         DuAnId = entity.DuAnId,

--- a/QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiPrintSearchModel.cs
+++ b/QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiPrintSearchModel.cs
@@ -6,6 +6,9 @@ namespace QLDA.WebApi.Models.PhanKhaiKinhPhis;
 public record PhanKhaiKinhPhiPrintSearchModel {
     public Guid? DuAnId { get; set; }
     public string? GlobalFilter { get; set; }
+    public string? TenDuAn { get; set; }
+    public long? DonViPhuTrachChinhId { get; set; }
+    public int? LoaiDuAnTheoNamId { get; set; }
     public int? TrangThaiId { get; set; }
     public List<string>? HiddenColumns { get; set; }
 }

--- a/QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiSearchModel.cs
+++ b/QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiSearchModel.cs
@@ -1,0 +1,10 @@
+using QLDA.WebApi.Models.Common;
+
+namespace QLDA.WebApi.Models.PhanKhaiKinhPhis;
+
+public record PhanKhaiKinhPhiSearchModel : CommonSearchModel {
+    public string? TenDuAn { get; set; }
+    public long? DonViPhuTrachChinhId { get; set; }
+    public int? LoaiDuAnTheoNamId { get; set; }
+    public int? TrangThaiId { get; set; }
+}

--- a/QLDA.WebApi/Models/TrienKhaiKeHoachLCNT/TrienKhaiKeHoachLCNTMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/TrienKhaiKeHoachLCNT/TrienKhaiKeHoachLCNTMappingConfiguration.cs
@@ -43,7 +43,7 @@ public static class TrienKhaiKeHoachLCNTMappingConfiguration {
             ThoiGianThucHien = model.ThoiGianThucHien,
             NoiDung = model.NoiDung,
             YeuCau = model.YeuCau,
-            DonViTuVans = model.DonViTuVans?.Select(x => x.ToEntity()).ToList() ?? [],
+            DonViTuVans = model.DonViTuVans?.Select(x => x.ToEntity(model.GetId())).ToList() ?? [],
 
         };
 

--- a/docs/feature/DuAn/IMPLEMENTATION_GUIDE_theo-doi-du-an-phong-phan-cong-search-filters.md
+++ b/docs/feature/DuAn/IMPLEMENTATION_GUIDE_theo-doi-du-an-phong-phan-cong-search-filters.md
@@ -1,0 +1,463 @@
+# Bổ sung filter `lanhDaoPhuTrachId` & `trangThaiDuAnId` — API theo dõi dự án phòng phân công
+
+**Document date:** June 29, 2026  
+**Status:** ✅ **IMPLEMENTED** (June 29, 2026)  
+**Module:** QLDA — `DuAn` (UC #9527 — theo dõi dự án phòng phân công)  
+**Pattern tham chiếu:** `DuAnGetDanhSachQuery`, `DuAnGetDanhSachExportQuery`, `IMPLEMENTATION_GUIDE_9527_theo-doi-du-an-phong-phan-cong.md`
+
+**Mục lục:** [0. Trạng thái](#0-trạng-thái-hiện-tại) · [1. Mục tiêu](#1-mục-tiêu) · [2. Khảo sát source](#2-khảo-sát-source-đã-xác-minh) · [3. Thiết kế](#3-thiết-kế) · [4. Bước code](#4-bước-code-chi-tiết) · [5. API contract](#5-api-contract) · [6. Test plan](#6-test-plan) · [7. Checklist](#7-checklist-nghiệm-thu) · [8. Commit](#8-commit-đề-xuất)
+
+---
+
+## 0. Trạng thái hiện tại
+
+| Hạng mục | Trạng thái | Ghi chú |
+| -------- | ---------- | ------- |
+| Investigation / docs | ✅ Done | File này |
+| `TheoDoiDuAnPhongPhanCongSearchDto` | ✅ Done | `LanhDaoPhuTrachId`, `TrangThaiDuAnId` |
+| `TheoDoiDuAnPhongPhanCongQuery.BuildQuery` | ✅ Done | `WhereFunc` + `WhereIf` |
+| `DuAnController` | ✅ Không cần sửa | Đã bind `TheoDoiDuAnPhongPhanCongSearchDto` |
+| WebApi SearchModel mới | ✅ Không cần | DTO Application bind trực tiếp (`CLAUDE.md`) |
+| Migration | ✅ Không cần | Chỉ query/filter |
+| Integration test | ⏳ Tùy chọn | Khuyến nghị 4 case filter cơ bản |
+| Manual verify curl | ⏳ Pending | Mẫu ở [6.1](#61-curl-mẫu) |
+
+---
+
+## 1. Mục tiêu
+
+Bổ sung 2 query param cho API danh sách theo dõi dự án phòng phân công:
+
+| Param | Ý nghĩa | Map entity |
+| ----- | ------- | ---------- |
+| `lanhDaoPhuTrachId` | Lọc theo lãnh đạo phụ trách dự án | `DuAn.LanhDaoPhuTrachId` (`long?` → `UserMaster`) |
+| `trangThaiDuAnId` | Lọc theo **trạng thái dự án** (không phải trạng thái phê duyệt) | `DuAn.TrangThaiDuAnId` (`int?` → `DanhMucTrangThaiDuAn`) |
+
+### Acceptance criteria
+
+| # | Kịch bản | Kỳ vọng |
+| - | -------- | ------- |
+| AC1 | Không truyền 2 param | Hành vi **giữ nguyên** như hiện tại |
+| AC2 | Chỉ `lanhDaoPhuTrachId` | Chỉ dự án có `LanhDaoPhuTrachId` khớp |
+| AC3 | Chỉ `trangThaiDuAnId` | Chỉ dự án có `TrangThaiDuAnId` khớp |
+| AC4 | Cả 2 param | AND — thỏa **cả hai** điều kiện |
+| AC5 | Response | Giữ nguyên `tongSoDuAn`, `conHan`, `quaHan`, `daHoanThanh`, `danhSach` (paging/totalRows/data) |
+| AC6 | Build | Không warning/error mới |
+
+---
+
+## 2. Khảo sát source (đã xác minh)
+
+### 2.1 Luồng hiện tại
+
+```text
+GET /QuanLyDuAn/api/du-an/theo-doi-du-an-phong-phan-cong
+        │
+        ▼
+DuAnController.GetTheoDoiDuAnPhongPhanCong
+  └─ [FromQuery] TheoDoiDuAnPhongPhanCongSearchDto   ← bind trực tiếp, không qua WebApi model
+        │
+        ▼
+TheoDoiDuAnPhongPhanCongQuery + Handler
+  ├─ FilterVisible(DuAn) — đầu query
+  ├─ BuildQuery(...) — filter màn hình + panel `loai`
+  │    ├─ Dùng cho COUNT 4 panel (loai = TatCa)
+  │    └─ Dùng cho LIST phân trang (loai = search.Loai)
+  └─ Return TheoDoiDuAnPhongPhanCongResultDto
+```
+
+**File tham chiếu:**
+
+| Thành phần | Vị trí |
+| ---------- | ------ |
+| Controller | `QLDA.WebApi/Controllers/DuAnController.cs` (dòng ~115–122) |
+| Search DTO | `QLDA.Application/DuAns/DTOs/TheoDoiDuAnPhongPhanCongSearchDto.cs` |
+| Handler | `QLDA.Application/DuAns/Queries/TheoDoiDuAnPhongPhanCongQuery.cs` |
+| Entity | `QLDA.Domain/Entities/DuAn.cs` |
+| Guide gốc UC | `docs/feature/DuAn/IMPLEMENTATION_GUIDE_9527_theo-doi-du-an-phong-phan-cong.md` |
+
+### 2.2 Search DTO hiện tại — thiếu 2 field
+
+```csharp
+// TheoDoiDuAnPhongPhanCongSearchDto — HIỆN TẠI
+public record TheoDoiDuAnPhongPhanCongSearchDto : CommonSearchDto
+{
+    public long? DonViPhuTrachChinhId { get; set; }
+    public int? NamDuAn { get; set; }
+    public string? TenDuAn { get; set; }
+    public string? MaDuAn { get; set; }
+    public ETheoDoiDuAnPhongPhanCongLoai Loai { get; set; } = ETheoDoiDuAnPhongPhanCongLoai.TatCa;
+    // ❌ Chưa có LanhDaoPhuTrachId
+    // ❌ Chưa có TrangThaiDuAnId
+}
+```
+
+→ Query string `?lanhDaoPhuTrachId=1&trangThaiDuAnId=2` **bị bỏ qua** vì DTO không có property tương ứng.
+
+### 2.3 Handler `BuildQuery` — chưa lọc 2 field
+
+```csharp
+// TheoDoiDuAnPhongPhanCongQuery.BuildQuery — HIỆN TẠI (rút gọn)
+query = query
+    .AsNoTracking()
+    .WhereIf(donViPhuTrachChinhId is > 0, e => e.DonViPhuTrachChinhId == donViPhuTrachChinhId)
+    .WhereIf(search.TenDuAn.IsNotNullOrWhitespace(), ...)
+    .WhereIf(search.MaDuAn.IsNotNullOrWhitespace(), ...)
+    .WhereIf(search.NamDuAn > 0, ...)
+    .WhereGlobalFilter(search, e => e.TenDuAn, e => e.MaDuAn);
+// ❌ Không WhereIf LanhDaoPhuTrachId / TrangThaiDuAnId
+```
+
+### 2.4 Entity field — đã có sẵn
+
+```text
+DuAn
+├── LanhDaoPhuTrachId   long?   → UserMaster (legacy, join in-memory trong ProjectToDto)
+└── TrangThaiDuAnId     int?    → DanhMucTrangThaiDuAn
+```
+
+**Seed trạng thái dự án** (`DanhMucTrangThaiDuAn`):
+
+| Id | Ma | Ten |
+| -- | -- | --- |
+| 1 | `DTH` | Đang thực hiện |
+| 2 | `PDDT` | Đã phê duyệt đầu tư |
+| 3 | `HT` | Đã hoàn thành |
+| 4 | `TD` | Tạm dừng |
+
+> **Phân biệt:** `trangThaiDuAnId` = `DuAn.TrangThaiDuAnId`. **Không** nhầm với `TrangThaiId` / `DanhMucTrangThaiPheDuyet` dùng ở module phân khai, quyết định, v.v.
+
+### 2.5 Pattern đã có — `DuAnGetDanhSachQuery`
+
+Cùng module `DuAn`, đã implement đúng 2 filter này — **nên copy pattern**:
+
+```csharp
+// DuAnGetDanhSachQuery.cs — dòng 42–46
+.WhereFunc(request.SearchDto.LanhDaoPhuTrachId.HasValue, q => q
+    .WhereIf(request.SearchDto.LanhDaoPhuTrachId > 0, e => e.LanhDaoPhuTrachId == request.SearchDto.LanhDaoPhuTrachId)
+    .WhereIf(request.SearchDto.LanhDaoPhuTrachId == -1, e => e.LanhDaoPhuTrachId == null)
+)
+.WhereIf(request.SearchDto.TrangThaiDuAnId > 0, e => e.TrangThaiDuAnId == request.SearchDto.TrangThaiDuAnId)
+```
+
+| Giá trị `lanhDaoPhuTrachId` | Hành vi |
+| --------------------------- | ------- |
+| Không gửi / `null` | Không lọc |
+| `> 0` | `DuAn.LanhDaoPhuTrachId == value` |
+| `-1` | Dự án **chưa** gán lãnh đạo (`LanhDaoPhuTrachId == null`) |
+
+| Giá trị `trangThaiDuAnId` | Hành vi |
+| ------------------------- | ------- |
+| Không gửi / `null` / `0` | Không lọc |
+| `> 0` | `DuAn.TrangThaiDuAnId == value` |
+
+`DuAnSearchDto` đã khai báo 2 property tương tự (`QLDA.Application/DuAns/DTOs/DuAnSearchDto.cs` dòng 51, 71).
+
+### 2.6 Response DTO — không cần đổi
+
+`TheoDoiDuAnPhongPhanCongDto` **đã có** `TrangThaiDuAnId` trong response; `LanhDaoPhuTrach` là tên hiển thị (string). Không cần thêm field response cho task này.
+
+### 2.7 Ảnh hưởng 4 panel counter
+
+`BuildQuery` được dùng chung cho:
+
+1. **Count** 4 panel (`loai = TatCa`)
+2. **List** phân trang (`loai = search.Loai`)
+
+→ Khi thêm filter vào `BuildQuery`, **cả counter và list** đều lọc theo subset màn hình — **đúng UX** (giống `donViPhuTrachChinhId`, `namDuAn`, `tenDuAn`).
+
+Ví dụ: `trangThaiDuAnId=1` (Đang thực hiện) → `tongSoDuAn` chỉ đếm dự án DTH; `daHoanThanh` có thể = 0.
+
+### 2.8 Controller — không cần sửa
+
+```csharp
+// DuAnController.cs — ĐÃ ĐÚNG
+public async Task<ResultApi> GetTheoDoiDuAnPhongPhanCong(
+    [FromQuery] TheoDoiDuAnPhongPhanCongSearchDto searchDto)
+{
+    var res = await Mediator.Send(new TheoDoiDuAnPhongPhanCongQuery(searchDto));
+    return ResultApi.Ok(res);
+}
+```
+
+ASP.NET model binding tự map query string camelCase → property PascalCase khi thêm field vào DTO.
+
+---
+
+## 3. Thiết kế
+
+### 3.1 Nguyên tắc
+
+| Quy tắc | Cách làm |
+| ------- | -------- |
+| Logic lọc | Chỉ trong `TheoDoiDuAnPhongPhanCongQuery.BuildQuery` (Application) |
+| Không logic trong Controller | Giữ controller mỏng |
+| Pattern `WhereIf` | Giống `DuAnGetDanhSachQuery` |
+| Một nguồn filter | Thêm vào `BuildQuery` — counter + list đồng bộ |
+| Auth | Giữ `FilterVisible` ở đầu — **không đổi** |
+| Migration | **Không** |
+
+### 3.2 Vị trí thêm filter trong `BuildQuery`
+
+Thêm **sau** filter `NamDuAn`, **trước** `WhereGlobalFilter` (thứ tự không bắt buộc về SQL, nhưng đồng bộ với `DuAnGetDanhSachQuery`):
+
+```text
+FilterVisible
+  → AsNoTracking
+  → DonViPhuTrachChinhId
+  → TenDuAn / MaDuAn
+  → NamDuAn
+  → LanhDaoPhuTrachId      ← MỚI
+  → TrangThaiDuAnId        ← MỚI
+  → WhereGlobalFilter
+  → Apply loai (ConHan / QuaHan / DaHoanThanh)
+```
+
+### 3.2 Tương tác `loai` × `trangThaiDuAnId`
+
+Filter kết hợp bằng **AND**:
+
+| `loai` | `trangThaiDuAnId` | Kết quả |
+| ------ | ----------------- | ------- |
+| `DaHoanThanh` | `3` (HT) | Dự án hoàn thành |
+| `DaHoanThanh` | `1` (DTH) | **Rỗng** — mâu thuẫn có chủ đích |
+| `ConHan` | `1` (DTH) | Dự án DTH còn hạn |
+| `TatCa` | `2` (PDDT) | Mọi bucket chỉ tính trên dự án PDDT |
+
+Đây là hành vi mong đợi — FE chịu trách nhiệm gửi combo hợp lý.
+
+---
+
+## 4. Bước code chi tiết
+
+### 4.1 Mở rộng `TheoDoiDuAnPhongPhanCongSearchDto`
+
+**File:** `QLDA.Application/DuAns/DTOs/TheoDoiDuAnPhongPhanCongSearchDto.cs`
+
+```csharp
+/// <summary>Lãnh đạo phụ trách — UserMaster.Id. Gửi -1 để lọc dự án chưa gán.</summary>
+public long? LanhDaoPhuTrachId { get; set; }
+
+/// <summary>Trạng thái dự án — DanhMucTrangThaiDuAn (KHÔNG phải trạng thái phê duyệt)</summary>
+public int? TrangThaiDuAnId { get; set; }
+```
+
+### 4.2 Mở rộng `BuildQuery` trong handler
+
+**File:** `QLDA.Application/DuAns/Queries/TheoDoiDuAnPhongPhanCongQuery.cs`
+
+Thêm vào method `BuildQuery`, sau block `NamDuAn`:
+
+```csharp
+.WhereFunc(search.LanhDaoPhuTrachId.HasValue, q => q
+    .WhereIf(search.LanhDaoPhuTrachId > 0, e => e.LanhDaoPhuTrachId == search.LanhDaoPhuTrachId)
+    .WhereIf(search.LanhDaoPhuTrachId == -1, e => e.LanhDaoPhuTrachId == null))
+.WhereIf(search.TrangThaiDuAnId > 0, e => e.TrangThaiDuAnId == search.TrangThaiDuAnId)
+```
+
+> **Lưu ý:** Cần `using` extension `WhereFunc` nếu chưa có (đã dùng ở `DuAnGetDanhSachQuery` qua `BuildingBlocks` / `QLDA.Application.Common`).
+
+### 4.3 Files **không** sửa
+
+| File | Lý do |
+| ---- | ----- |
+| `DuAnController.cs` | DTO bind tự động |
+| `QLDA.WebApi/Models/*` | Không tạo model WebApi (`CLAUDE.md`) |
+| `TheoDoiDuAnPhongPhanCongDto.cs` | Response đủ field |
+| Migration / `AppDbContextModelSnapshot.cs` | Không đổi schema |
+
+### 4.4 Diff tóm tắt (ước lượng)
+
+```diff
+// TheoDoiDuAnPhongPhanCongSearchDto.cs
++ public long? LanhDaoPhuTrachId { get; set; }
++ public int? TrangThaiDuAnId { get; set; }
+
+// TheoDoiDuAnPhongPhanCongQuery.cs — BuildQuery
++ .WhereFunc(search.LanhDaoPhuTrachId.HasValue, q => q
++     .WhereIf(search.LanhDaoPhuTrachId > 0, e => e.LanhDaoPhuTrachId == search.LanhDaoPhuTrachId)
++     .WhereIf(search.LanhDaoPhuTrachId == -1, e => e.LanhDaoPhuTrachId == null))
++ .WhereIf(search.TrangThaiDuAnId > 0, e => e.TrangThaiDuAnId == search.TrangThaiDuAnId)
+```
+
+**Tổng:** 2 file Application, ~10 dòng code.
+
+---
+
+## 5. API contract
+
+### 5.1 Endpoint (không đổi)
+
+```http
+GET /QuanLyDuAn/api/du-an/theo-doi-du-an-phong-phan-cong
+```
+
+### 5.2 Query params — bổ sung
+
+| Param | Kiểu | Bắt buộc | Mô tả |
+| ----- | ---- | -------- | ----- |
+| `lanhDaoPhuTrachId` | `long?` | Không | `DuAn.LanhDaoPhuTrachId`. `-1` = chưa gán |
+| `trangThaiDuAnId` | `int?` | Không | `DuAn.TrangThaiDuAnId` — danh mục trạng thái **dự án** |
+
+**Params hiện có (giữ nguyên):** `donViPhuTrachChinhId`, `namDuAn`, `tenDuAn`, `maDuAn`, `globalFilter`, `loai`, `pageIndex`, `pageSize`.
+
+### 5.3 Ví dụ request
+
+```http
+GET /QuanLyDuAn/api/du-an/theo-doi-du-an-phong-phan-cong
+  ?pageIndex=1
+  &pageSize=10
+  &donViPhuTrachChinhId=218
+  &lanhDaoPhuTrachId=1
+  &trangThaiDuAnId=2
+  &loai=ConHan
+```
+
+```bash
+curl --location 'http://192.168.1.12:9051/QuanLyDuAn/api/du-an/theo-doi-du-an-phong-phan-cong?pageIndex=1&pageSize=10&lanhDaoPhuTrachId=1&trangThaiDuAnId=2' \
+  --header 'Authorization: Bearer <JWT_TOKEN>'
+```
+
+### 5.4 Response (không đổi shape)
+
+```json
+{
+  "success": true,
+  "data": {
+    "tongSoDuAn": 5,
+    "conHan": 3,
+    "quaHan": 1,
+    "daHoanThanh": 1,
+    "danhSach": {
+      "totalRows": 3,
+      "pageNumber": 1,
+      "totalPages": 1,
+      "data": [ "..." ]
+    }
+  }
+}
+```
+
+- 4 counter: tính trên subset sau **tất cả** filter màn hình (gồm 2 param mới), `loai` **không** áp dụng cho counter.
+- `danhSach`: thêm filter `loai` như hiện tại.
+
+---
+
+## 6. Test plan
+
+### 6.1 Curl mẫu
+
+```bash
+# Baseline — không filter mới
+curl -G 'http://192.168.1.12:9051/QuanLyDuAn/api/du-an/theo-doi-du-an-phong-phan-cong' \
+  --data-urlencode 'pageIndex=1' \
+  --data-urlencode 'pageSize=10' \
+  -H 'Authorization: Bearer <TOKEN>'
+
+# Chỉ lãnh đạo
+curl -G '.../theo-doi-du-an-phong-phan-cong' \
+  --data-urlencode 'pageIndex=1' \
+  --data-urlencode 'pageSize=10' \
+  --data-urlencode 'lanhDaoPhuTrachId=1' \
+  -H 'Authorization: Bearer <TOKEN>'
+
+# Chỉ trạng thái dự án
+curl -G '.../theo-doi-du-an-phong-phan-cong' \
+  --data-urlencode 'trangThaiDuAnId=2' \
+  -H 'Authorization: Bearer <TOKEN>'
+
+# Kết hợp (acceptance criteria)
+curl -G '.../theo-doi-du-an-phong-phan-cong' \
+  --data-urlencode 'pageIndex=1' \
+  --data-urlencode 'pageSize=10' \
+  --data-urlencode 'lanhDaoPhuTrachId=1' \
+  --data-urlencode 'trangThaiDuAnId=2' \
+  -H 'Authorization: Bearer <TOKEN>'
+
+# Chưa gán lãnh đạo (pattern -1)
+curl -G '.../theo-doi-du-an-phong-phan-cong' \
+  --data-urlencode 'lanhDaoPhuTrachId=-1' \
+  -H 'Authorization: Bearer <TOKEN>'
+```
+
+### 6.2 Case chức năng
+
+| # | Input | Kỳ vọng |
+| - | ----- | ------- |
+| F1 | Không gửi 2 param | Kết quả giống trước fix (so sánh `totalRows` / `tongSoDuAn`) |
+| F2 | `lanhDaoPhuTrachId={id có dữ liệu}` | Mọi item có LĐ phụ trách đúng `id` |
+| F3 | `trangThaiDuAnId=2` | Mọi item `trangThaiDuAnId == 2` |
+| F4 | Cả 2 param | Chỉ dự án thỏa **cả hai** |
+| F5 | `lanhDaoPhuTrachId=-1` | Chỉ dự án `lanhDaoPhuTrach` null/empty |
+| F6 | `trangThaiDuAnId=0` hoặc không gửi | Không lọc theo trạng thái |
+| F7 | F2 + `loai=QuaHan` | List quá hạn trong subset LĐ; counter vẫn trên full subset LĐ |
+| F8 | F3 + `donViPhuTrachChinhId` | AND với filter phòng |
+
+### 6.3 Case regression
+
+| # | Kiểm tra |
+| - | -------- |
+| R1 | `tongSoDuAn == conHan + quaHan + daHoanThanh` sau filter |
+| R2 | Paging: `pageIndex`, `pageSize`, `totalRows`, `stt` đúng |
+| R3 | `FilterVisible` — user không thấy dự án ngoài phạm vi auth dù filter LĐ |
+| R4 | Sort `OrderBy TenDuAn` không đổi |
+
+### 6.4 Build
+
+```bash
+dotnet build QLDA.WebApi/QLDA.WebApi.csproj
+```
+
+---
+
+## 7. Checklist nghiệm thu
+
+- [x] `TheoDoiDuAnPhongPhanCongSearchDto` có `LanhDaoPhuTrachId`, `TrangThaiDuAnId`
+- [x] `BuildQuery` có `WhereIf` / `WhereFunc` đúng pattern `DuAnGetDanhSachQuery`
+- [x] Không logic lọc trong Controller
+- [x] Không model WebApi mới
+- [x] Không migration
+- [ ] AC1–AC6 pass (curl / Postman)
+- [x] `tongSoDuAn` counter phản ánh subset sau filter mới (logic trong `BuildQuery` chung)
+- [x] Build pass, không warning mới
+
+---
+
+## 8. Commit đề xuất
+
+```bash
+git commit -m "feat(du-an): add leader and project status filters to assigned dept tracking
+
+- Extend TheoDoiDuAnPhongPhanCongSearchDto with lanhDaoPhuTrachId and trangThaiDuAnId
+- Apply filters in BuildQuery using same pattern as DuAnGetDanhSachQuery"
+```
+
+**Nhóm file (1 commit — chỉ Application):**
+
+1. `QLDA.Application/DuAns/DTOs/TheoDoiDuAnPhongPhanCongSearchDto.cs`
+2. `QLDA.Application/DuAns/Queries/TheoDoiDuAnPhongPhanCongQuery.cs`
+
+---
+
+## Phụ lục A — So sánh với `DuAnGetDanhSach`
+
+| | `GET /api/du-an/danh-sach` | `GET /api/du-an/theo-doi-du-an-phong-phan-cong` |
+| - | -------------------------- | ----------------------------------------------- |
+| Search DTO | `DuAnSearchDto` | `TheoDoiDuAnPhongPhanCongSearchDto` |
+| `lanhDaoPhuTrachId` | ✅ Có | ⏳ Thêm (task này) |
+| `trangThaiDuAnId` | ✅ Có | ⏳ Thêm (task này) |
+| Response | `PaginatedList<DuAnDto>` | Summary 4 panel + `PaginatedList<TheoDoiDuAnPhongPhanCongDto>` |
+| Filter logic | Inline trong handler | `BuildQuery` private method |
+
+## Phụ lục B — Câu hỏi đã chốt
+
+| Câu hỏi | Quyết định |
+| ------- | ---------- |
+| Counter có theo 2 filter mới? | **Có** — thêm vào `BuildQuery` chung |
+| Hỗ trợ `lanhDaoPhuTrachId=-1`? | **Có** — đồng bộ `DuAnGetDanhSachQuery` |
+| `trangThaiDuAnId` vs trạng thái phê duyệt? | Chỉ `DuAn.TrangThaiDuAnId` |
+| Sửa Controller? | **Không** |
+
+---
+
+*Document generated from codebase survey — June 29, 2026.*

--- a/docs/feature/PhanKhaiKinhPhi/IMPLEMENTATION_GUIDE_fix-danh-sach-search-filters.md
+++ b/docs/feature/PhanKhaiKinhPhi/IMPLEMENTATION_GUIDE_fix-danh-sach-search-filters.md
@@ -1,0 +1,431 @@
+# Fix search API danh sách Phân khai kinh phí
+
+**Document date:** June 29, 2026  
+**Status:** ✅ **IMPLEMENTED** (June 29, 2026)  
+**Module:** QLDA — `PhanKhaiKinhPhi` (UC40 — #9467)  
+**Pattern tham chiếu:** `QuyetDinhDuyetDuToanGetDanhSachQuery`, `DuAnGetDanhSachQuery`, `HoSoMoiThauDienTuGetDanhSachQuery`
+
+**Mục lục:** [0. Trạng thái](#0-trạng-thái-hiện-tại) · [1. Triệu chứng](#1-triệu-chứng-trước-fix) · [2. Root cause](#2-root-cause-đã-xác-minh) · [3. Khảo sát flow](#3-khảo-sát-flow) · [4. Đã implement](#4-đã-implement-as-built) · [5. API contract](#5-api-contract) · [6. Test plan](#6-test-plan) · [7. Checklist](#7-checklist-nghiệm-thu) · [8. Commit](#8-commit) · [9. Phụ lục](#phụ-lục-a--sơ-đồ-filter)
+
+---
+
+## 0. Trạng thái hiện tại
+
+| Hạng mục | Trạng thái | Ghi chú |
+| -------- | ---------- | ------- |
+| Investigation / docs | ✅ Done | File này |
+| `PhanKhaiKinhPhiSearchDto` (Application) | ✅ Done | `QLDA.Application/PhanKhaiKinhPhis/DTOs/PhanKhaiKinhPhiSearchDto.cs` |
+| `PhanKhaiKinhPhiSearchModel` (WebApi) | ✅ Done | `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiSearchModel.cs` |
+| `PhanKhaiKinhPhiMappingConfiguration` | ✅ Done | `ToSearchDto()` + `ToQuery()` |
+| `PhanKhaiKinhPhiGetDanhSachQuery` handler | ✅ Done | `Include(DuAn)` + filter 4 field |
+| `PhanKhaiKinhPhiController.GetDanhSach` | ✅ Done | Bind `PhanKhaiKinhPhiSearchModel` → `ToQuery()` |
+| `PhanKhaiKinhPhiGetDanhSachExportQuery` | ✅ Done | Cùng filter với `danh-sach` |
+| `PhanKhaiKinhPhiPrintSearchModel` | ✅ Done | Đủ field cho export Excel |
+| `PrintController.InDanhSachPhanKhaiKinhPhi` | ✅ Done | Map đủ filter sang export query |
+| Migration | ✅ Không cần | Chỉ query/filter |
+| Build | ✅ Pass | `dotnet build QLDA.WebApi` — 0 error |
+| Integration test | ⏳ Tùy chọn | Chưa thêm case filter mới |
+| Manual verify curl | ⏳ Pending | Mẫu ở [6.1](#61-curl-mẫu) |
+
+---
+
+## 1. Triệu chứng (trước fix)
+
+**Endpoint:**
+
+```http
+GET /QuanLyDuAn/api/phan-khai-kinh-phi/danh-sach
+```
+
+**FE / Postman gửi** (ví dụ từ màn hình lọc dự án chung):
+
+```http
+?pageIndex=1&pageSize=10&triger=3
+&tenDuAn=1111
+&thoiGianKhoiCong=2026&thoiGianHoanThanh=2026
+&hinhThucDauTuId=6&loaiDuAnId=4
+&donViPhuTrachChinhId=218
+&loaiDuAnTheoNamId=2
+&trangThaiId=32
+```
+
+### Expected
+
+| Param | Kỳ vọng |
+| ----- | ------- |
+| `tenDuAn` | Chỉ trả phân khai kinh phí của dự án có tên chứa keyword |
+| `donViPhuTrachChinhId` | Chỉ trả phân khai của dự án thuộc phòng ban phụ trách chính đó |
+| `loaiDuAnTheoNamId` | Chỉ trả phân khai của dự án thuộc loại dự án theo năm (tài chính) đó — **không** dùng `LoaiDuAnId` |
+| `trangThaiId` | Lọc theo trạng thái phê duyệt của bản ghi phân khai (`DanhMucTrangThaiPheDuyet`) |
+| Kết hợp nhiều param | AND logic — tất cả điều kiện đều thỏa |
+| Dự án match nhưng không có phân khai | Không hiển thị (inner filter qua `PhanKhaiKinhPhi`) |
+| Paging | `totalRows`, `pageNumber`, `items` giữ nguyên format `PaginatedList` |
+
+### Actual (trước fix)
+
+| Param | Hành vi |
+| ----- | ------- |
+| `duAnId` | ✅ Hoạt động |
+| `globalFilter` | ✅ Hoạt động (tìm `SoToTrinh`, `TenNguonVon`) |
+| `trangThaiId` | ✅ Handler đã có filter — controller **chưa** bind đầy đủ search model |
+| `tenDuAn` | ❌ Bị bỏ qua |
+| `donViPhuTrachChinhId` | ❌ Bị bỏ qua |
+| `loaiDuAnTheoNamId` | ❌ Bị bỏ qua |
+| `thoiGianKhoiCong`, `loaiDuAnId`, … | ❌ Ngoài scope (xem [5.3](#53-phạm-vi--ngoài-scope)) |
+
+---
+
+## 2. Root cause (đã xác minh)
+
+### 2.1 Controller bind thiếu param
+
+Controller cũ dùng inline `[FromQuery]` từng param — chỉ `duAnId`, `globalFilter`, `trangThaiId` + paging. Các query string `tenDuAn`, `donViPhuTrachChinhId`, `loaiDuAnTheoNamId` **không được map**.
+
+### 2.2 Handler không lọc theo `DuAn`
+
+Handler cũ không `Include(e => e.DuAn)` và không có `WhereIf` theo navigation `DuAn`.
+
+### 2.3 Không có Search DTO / SearchModel
+
+| Layer | Trước fix | Sau fix |
+| ----- | --------- | ------- |
+| Application | Chỉ field rời trên query record | `PhanKhaiKinhPhiSearchDto : CommonSearchDto` |
+| WebApi | Inline `[FromQuery]` | `PhanKhaiKinhPhiSearchModel` + `ToQuery()` |
+
+### 2.4 Export lệch filter (đã sync)
+
+`PhanKhaiKinhPhiGetDanhSachExportQuery` và `PhanKhaiKinhPhiPrintSearchModel` đã được cập nhật cùng filter với grid.
+
+---
+
+## 3. Khảo sát flow
+
+### 3.1 Luồng dữ liệu (sau fix)
+
+```text
+FE màn hình Phân khai kinh phí
+  └─ GET api/phan-khai-kinh-phi/danh-sach?...filters...
+       └─ PhanKhaiKinhPhiController.GetDanhSach
+            └─ PhanKhaiKinhPhiSearchModel.ToQuery()
+                 └─ PhanKhaiKinhPhiGetDanhSachQuery(SearchDto)
+                      └─ Handler: PhanKhaiKinhPhi ⟵ Include DuAn
+                           ├─ Filter DuAn: TenDuAn, DonViPhuTrachChinhId, LoaiDuAnTheoNamId
+                           └─ Filter PhanKhaiKinhPhi: DuAnId, TrangThaiId, GlobalFilter
+                      └─ PaginatedList<PhanKhaiKinhPhiDto>
+
+Export Excel (cùng filter):
+  GET api/print/danh-sach-phan-khai-kinh-phi
+       └─ PrintController.InDanhSachPhanKhaiKinhPhi
+            └─ PhanKhaiKinhPhiGetDanhSachExportQuery (cùng WhereIf)
+```
+
+### 3.2 Entity liên quan
+
+**`PhanKhaiKinhPhi`** — filter trực tiếp: `DuAnId`, `TrangThaiId`, `SoToTrinh`, `GlobalFilter` (qua `NguonVon.Ten`).
+
+**`DuAn`** — filter qua navigation:
+
+| Field API | Field entity | Kiểu |
+| --------- | ------------ | ---- |
+| `tenDuAn` | `TenDuAn` | `string?` — contains, case-insensitive |
+| `donViPhuTrachChinhId` | `DonViPhuTrachChinhId` | `long?` — `-1` = null |
+| `loaiDuAnTheoNamId` | `LoaiDuAnTheoNamId` | `int?` — **không** map `LoaiDuAnId` |
+
+**`trangThaiId`** = `PhanKhaiKinhPhi.TrangThaiId` → `DanhMucTrangThaiPheDuyet` (không phải `DuAn.TrangThaiDuAnId`).
+
+### 3.3 Authorization
+
+`PhanKhaiKinhPhiGetDanhSachQuery` **không** dùng `FilterVisible` — task này **không** mở rộng auth, giữ hành vi cũ.
+
+---
+
+## 4. Đã implement (as-built)
+
+### 4.1 Files thay đổi
+
+| File | Thay đổi |
+| ---- | -------- |
+| `QLDA.Application/PhanKhaiKinhPhis/DTOs/PhanKhaiKinhPhiSearchDto.cs` | **Mới** — search DTO Application |
+| `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiSearchModel.cs` | **Mới** — bind query string |
+| `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiMappingConfiguration.cs` | `ToSearchDto()`, `ToQuery()` |
+| `QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachQuery.cs` | Nhận `SearchDto`, filter `DuAn` |
+| `QLDA.WebApi/Controllers/PhanKhaiKinhPhiController.cs` | `GetDanhSach([FromQuery] PhanKhaiKinhPhiSearchModel)` |
+| `QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachExportQuery.cs` | Cùng filter |
+| `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiPrintSearchModel.cs` | Thêm 3 field DuAn |
+| `QLDA.WebApi/Controllers/PrintController.cs` | Map filter export |
+
+### 4.2 `PhanKhaiKinhPhiSearchDto`
+
+```csharp
+public record PhanKhaiKinhPhiSearchDto : CommonSearchDto {
+    public string? TenDuAn { get; set; }
+    public long? DonViPhuTrachChinhId { get; set; }
+    public int? LoaiDuAnTheoNamId { get; set; }
+    public int? TrangThaiId { get; set; }
+}
+```
+
+`CommonSearchDto` cung cấp `DuAnId`, `GlobalFilter`, `PageIndex`, `PageSize`.
+
+### 4.3 WebApi mapping
+
+```csharp
+// PhanKhaiKinhPhiMappingConfiguration.cs
+public static PhanKhaiKinhPhiGetDanhSachQuery ToQuery(this PhanKhaiKinhPhiSearchModel model)
+    => new(model.ToSearchDto()) { IsNoTracking = true };
+```
+
+### 4.4 Controller (mỏng)
+
+```csharp
+[HttpGet("danh-sach")]
+public async Task<ResultApi> GetDanhSach([FromQuery] PhanKhaiKinhPhiSearchModel searchModel) {
+    var res = await Mediator.Send(searchModel.ToQuery());
+    return ResultApi.Ok(res);
+}
+```
+
+### 4.5 Handler — logic lọc chính
+
+```csharp
+var search = request.SearchDto;
+
+var queryable = _repo.GetQueryableSet().AsNoTracking()
+    .Include(e => e.TrangThai)
+    .Include(e => e.NguonVon)
+    .Include(e => e.DuAn)
+    .Where(e => e.DuAn != null && !e.DuAn.IsDeleted)
+    .WhereIf(search.DuAnId != null, e => e.DuAnId == search.DuAnId)
+    .WhereIf(search.TrangThaiId > 0, e => e.TrangThaiId == search.TrangThaiId)
+    .WhereIf(search.TenDuAn.IsNotNullOrWhitespace(),
+        e => e.DuAn!.TenDuAn!.ToLower().Contains(search.TenDuAn!.ToLower()))
+    .WhereFunc(search.DonViPhuTrachChinhId.HasValue, q => q
+        .WhereIf(search.DonViPhuTrachChinhId > 0,
+            e => e.DuAn!.DonViPhuTrachChinhId == search.DonViPhuTrachChinhId)
+        .WhereIf(search.DonViPhuTrachChinhId == -1,
+            e => e.DuAn!.DonViPhuTrachChinhId == null))
+    .WhereIf(search.LoaiDuAnTheoNamId > 0,
+        e => e.DuAn!.LoaiDuAnTheoNamId == search.LoaiDuAnTheoNamId)
+    .WhereGlobalFilter(search,
+        e => e.SoToTrinh,
+        e => e.NguonVon != null ? e.NguonVon.Ten : null);
+```
+
+**Quyết định thiết kế:**
+
+- Query record nhận `PhanKhaiKinhPhiSearchDto` (Option A trong bản plan) — đồng bộ `DuAnGetDanhSachQuery`.
+- Filter `DuAn` qua `e.DuAn!` — chỉ dự án **có bản ghi phân khai** xuất hiện.
+- `WhereGlobalFilter` nhận `search` (`CommonSearchDto`) — không duplicate `GlobalFilter` trên query record.
+
+### 4.6 Export — đồng bộ filter
+
+`PhanKhaiKinhPhiGetDanhSachExportQuery` copy cùng `WhereIf` / `WhereFunc` như handler danh-sach.
+
+`PrintController.InDanhSachPhanKhaiKinhPhi` map:
+
+```csharp
+new PhanKhaiKinhPhiGetDanhSachExportQuery {
+    DuAnId = searchModel.DuAnId,
+    GlobalFilter = searchModel.GlobalFilter,
+    TenDuAn = searchModel.TenDuAn,
+    DonViPhuTrachChinhId = searchModel.DonViPhuTrachChinhId,
+    LoaiDuAnTheoNamId = searchModel.LoaiDuAnTheoNamId,
+    TrangThaiId = searchModel.TrangThaiId,
+}
+```
+
+> **Lưu ý:** `InKetQuaPhanKhaiVonDuocDuyet` vẫn chỉ filter `DuAnId` + `GlobalFilter` — endpoint riêng, ngoài scope task này.
+
+### 4.7 Files không sửa
+
+| File / area | Lý do |
+| ----------- | ----- |
+| `AppDbContextModelSnapshot.cs`, migrations | Không đổi schema |
+| `PhanKhaiKinhPhi` entity | Đủ field |
+| `PhanKhaiKinhPhiDto` response | Acceptance không yêu cầu thêm field |
+
+---
+
+## 5. API contract
+
+### 5.1 Query parameters
+
+| Param | Type | Bắt buộc | Lọc trên | Ghi chú |
+| ----- | ---- | -------- | -------- | ------- |
+| `pageIndex` | `int` | Không | — | 1-based |
+| `pageSize` | `int` | Không | — | |
+| `duAnId` | `Guid?` | Không | `PhanKhaiKinhPhi.DuAnId` | |
+| `globalFilter` | `string?` | Không | `SoToTrinh`, `TenNguonVon` | |
+| `tenDuAn` | `string?` | Không | `DuAn.TenDuAn` | Contains, ignore case |
+| `donViPhuTrachChinhId` | `long?` | Không | `DuAn.DonViPhuTrachChinhId` | `-1` = null |
+| `loaiDuAnTheoNamId` | `int?` | Không | `DuAn.LoaiDuAnTheoNamId` | **Không** map `loaiDuAnId` |
+| `trangThaiId` | `int?` | Không | `PhanKhaiKinhPhi.TrangThaiId` | `DanhMucTrangThaiPheDuyet` |
+
+### 5.2 Response — không đổi
+
+```json
+{
+  "result": true,
+  "dataResult": {
+    "items": [ { "id": "...", "duAnId": "...", "trangThaiId": 32, ... } ],
+    "pageNumber": 1,
+    "totalPages": 2,
+    "totalRows": 15,
+    "hasNextPage": true,
+    "hasPreviousPage": false
+  }
+}
+```
+
+### 5.3 Phạm vi / ngoài scope
+
+| Param | Xử lý |
+| ----- | ----- |
+| `thoiGianKhoiCong`, `thoiGianHoanThanh` | Ngoài scope |
+| `hinhThucDauTuId` | Ngoài scope |
+| `loaiDuAnId` | Ngoài scope — khác `loaiDuAnTheoNamId` |
+| `triger` | Param FE nội bộ — BE bỏ qua |
+
+---
+
+## 6. Test plan
+
+### 6.1 Curl mẫu
+
+**Danh sách:**
+
+```bash
+curl --location \
+  'http://192.168.1.12:9051/QuanLyDuAn/api/phan-khai-kinh-phi/danh-sach?pageIndex=1&pageSize=10&tenDuAn=1111&donViPhuTrachChinhId=218&loaiDuAnTheoNamId=2&trangThaiId=32' \
+  --header 'Authorization: Bearer <JWT_TOKEN>'
+```
+
+**Export Excel (cùng filter):**
+
+```bash
+curl --location \
+  'http://192.168.1.12:9051/QuanLyDuAn/api/print/danh-sach-phan-khai-kinh-phi?tenDuAn=1111&donViPhuTrachChinhId=218&loaiDuAnTheoNamId=2&trangThaiId=32' \
+  --header 'Authorization: Bearer <JWT_TOKEN>' \
+  -o PhanKhaiKinhPhi.xlsx
+```
+
+### 6.2 Manual checklist
+
+| # | Case | Kỳ vọng |
+| - | ---- | ------- |
+| 1 | Chỉ `tenDuAn` | Dự án tên chứa keyword; không có phân khai → không hiện |
+| 2 | Chỉ `donViPhuTrachChinhId=218` | `DuAn.DonViPhuTrachChinhId == 218` |
+| 3 | Chỉ `loaiDuAnTheoNamId=2` | `DuAn.LoaiDuAnTheoNamId == 2` |
+| 4 | Chỉ `trangThaiId=32` | Mọi item `trangThaiId == 32` |
+| 5 | Kết hợp 4 filter | AND |
+| 6 | Không match | `items: []`, `totalRows: 0` |
+| 7 | Paging | `pageIndex=2` đúng, `totalRows` ổn định |
+| 8 | Regression | `duAnId`, `globalFilter` vẫn OK |
+| 9 | Export | Excel cùng subset với grid khi gửi cùng filter |
+
+### 6.3 Build
+
+```bash
+dotnet build QLDA.WebApi/QLDA.WebApi.csproj
+```
+
+---
+
+## 7. Checklist nghiệm thu
+
+- [x] `tenDuAn` lọc theo tên dự án (contains)
+- [x] `donViPhuTrachChinhId` lọc theo phòng ban phụ trách chính dự án
+- [x] `loaiDuAnTheoNamId` lọc đúng cột — không nhầm `loaiDuAnId`
+- [x] `trangThaiId` lọc trạng thái phê duyệt phân khai
+- [x] Kết hợp nhiều param — AND logic
+- [x] Dự án match nhưng không có phân khai → không hiển thị
+- [x] Paging / `totalRows` / response shape không đổi
+- [x] Logic filter trong Application handler — không trong Controller
+- [x] Không sửa migration / snapshot
+- [x] Build pass
+- [x] Export Excel cùng filter với grid
+- [ ] Manual verify curl trên dev/staging
+
+---
+
+## 8. Commit
+
+```
+fix(phan-khai-kinh-phi): support search filters on danh-sach API
+
+Add DuAn-based filters (tenDuAn, donViPhuTrachChinhId, loaiDuAnTheoNamId)
+and wire trangThaiId through search model so list and export match FE grid.
+```
+
+**Files trong commit:**
+
+1. `QLDA.Application/PhanKhaiKinhPhis/DTOs/PhanKhaiKinhPhiSearchDto.cs`
+2. `QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachQuery.cs`
+3. `QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachExportQuery.cs`
+4. `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiSearchModel.cs`
+5. `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiPrintSearchModel.cs`
+6. `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiMappingConfiguration.cs`
+7. `QLDA.WebApi/Controllers/PhanKhaiKinhPhiController.cs`
+8. `QLDA.WebApi/Controllers/PrintController.cs`
+
+---
+
+## Phụ lục A — Sơ đồ filter
+
+```mermaid
+flowchart LR
+    subgraph Request
+        P1[tenDuAn]
+        P2[donViPhuTrachChinhId]
+        P3[loaiDuAnTheoNamId]
+        P4[trangThaiId]
+        P5[duAnId / globalFilter]
+    end
+
+    subgraph WebApi
+        M[PhanKhaiKinhPhiSearchModel]
+        T[ToQuery]
+    end
+
+    subgraph Handler
+        Q[PhanKhaiKinhPhi query]
+        D[DuAn navigation]
+    end
+
+    P1 --> M
+    P2 --> M
+    P3 --> M
+    P4 --> M
+    P5 --> M
+    M --> T --> Q
+    P1 --> D
+    P2 --> D
+    P3 --> D
+    P4 --> Q
+    P5 --> Q
+    D --> Q
+    Q --> R[PaginatedList PhanKhaiKinhPhiDto]
+```
+
+---
+
+## Phụ lục B — File map
+
+| Vai trò | Đường dẫn |
+| ------- | --------- |
+| Controller | `QLDA.WebApi/Controllers/PhanKhaiKinhPhiController.cs` |
+| Search model + mapping | `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiSearchModel.cs` |
+| Mapping extensions | `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiMappingConfiguration.cs` |
+| Search DTO | `QLDA.Application/PhanKhaiKinhPhis/DTOs/PhanKhaiKinhPhiSearchDto.cs` |
+| Query + Handler | `QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachQuery.cs` |
+| Export query | `QLDA.Application/PhanKhaiKinhPhis/Queries/PhanKhaiKinhPhiGetDanhSachExportQuery.cs` |
+| Print search | `QLDA.WebApi/Models/PhanKhaiKinhPhis/PhanKhaiKinhPhiPrintSearchModel.cs` |
+| Print controller | `QLDA.WebApi/Controllers/PrintController.cs` → `InDanhSachPhanKhaiKinhPhi` |
+| Entity PKP | `QLDA.Domain/Entities/PhanKhaiKinhPhi.cs` |
+| Entity DuAn | `QLDA.Domain/Entities/DuAn.cs` |
+| Integration tests | `QLDA.Tests/Integration/PhanKhaiKinhPhiControllerTests.cs` |
+| Docs export gốc | `docs/feature/PhanKhaiKinhPhi/task-excel-import-export-phan-khai-kinh-phi.md` |
+
+---
+
+*Document updated after implementation — June 29, 2026.*

--- a/docs/feature/TrienKhaiKeHoachLCNT/IMPLEMENTATION_GUIDE_fix-cap-nhat-don-vi-tu-van-tep-dinh-kem.md
+++ b/docs/feature/TrienKhaiKeHoachLCNT/IMPLEMENTATION_GUIDE_fix-cap-nhat-don-vi-tu-van-tep-dinh-kem.md
@@ -1,0 +1,587 @@
+# Fix cập nhật Triển khai KHLCNT — đơn vị tư vấn & tệp đính kèm
+
+**Document date:** June 29, 2026  
+**Status:** ✅ **IMPLEMENTED**  
+**Module:** QLDA — `TrienKhaiKeHoachLCNT`  
+**Pattern tham chiếu:** `KeHoachTrienKhaiHangMucUpdateCommand`, `TrienKhaiKeHoachLCNTController.Create`, `HoSoMoiThauDienTu/fix-tep-dinh-kem.md`
+
+**Mục lục:** [0. Trạng thái](#0-trạng-thái-hiện-tại) · [1. Triệu chứng](#1-triệu-chứng) · [2. Root cause](#2-root-cause-đã-xác-minh) · [3. Khảo sát flow](#3-khảo-sát-flow) · [4. Bước code chi tiết](#4-bước-code-chi-tiết) · [5. API contract](#5-api-contract) · [6. Test plan](#6-test-plan) · [7. Checklist](#7-checklist-nghiệm-thu) · [8. Commit](#8-commit-đề-xuất)
+
+---
+
+## 0. Trạng thái hiện tại
+
+| Hạng mục | Trạng thái | Ghi chú |
+| -------- | ---------- | ------- |
+| Investigation / docs | ✅ Done | File này |
+| Fix `TrienKhaiKeHoachLCNTUpdateCommand` | ✅ Done | Sync `DonViTuVans` đúng cách |
+| Fix `TrienKhaiKeHoachLCNTController.Update` | ✅ Done | Thêm sync file đơn vị tư vấn |
+| Fix mapping `DonViTuVanKeHoach` | ✅ Done | Gán `KeHoachId` khi `ToEntity` |
+| Fix bug gán `So` | ✅ Done | Đang gán nhầm `TrichYeu` |
+| Migration | ✅ Không cần | Chỉ sửa logic Application/WebApi |
+| Manual verify curl | ⏳ Pending | Payload mẫu ở [6.1](#61-curl-mẫu) |
+
+---
+
+## 1. Triệu chứng
+
+**Endpoint:**
+
+```http
+PUT /QuanLyDuAn/api/trien-khai-ke-hoach-lcnt/cap-nhat
+```
+
+**Payload điển hình:** Cập nhật tờ trình triển khai KHLCNT kèm:
+
+1. **Đơn vị tư vấn đã có** (`id` có giá trị) + file đính kèm có `groupId` / `groupType`
+2. **Đơn vị tư vấn mới** (`id: null`) + file mới chưa có `groupId` / `groupType`
+3. **`danhSachTepDinhKem` cấp chính** = mảng rỗng `[]`
+
+### Expected
+
+| Case | Kỳ vọng |
+| ---- | ------- |
+| Cập nhật thông tin chính | API 200, lưu đúng `so`, `ngayTrinh`, `giaTri`, … |
+| Đơn vị tư vấn cũ | Cập nhật `tenDonVi`, giữ file cũ |
+| Đơn vị tư vấn mới | Tạo bản ghi mới, file gán `groupId` = id DVTV mới, `groupType` = `"DonViTuVan"` |
+| File cấp chính rỗng | Không lỗi; không xóa nhầm file đơn vị tư vấn |
+
+### Actual
+
+API **lỗi** khi PUT với payload trên (exception EF / FK / tracking — tùy môi trường).
+
+---
+
+## 2. Root cause (đã xác minh)
+
+### 2.1 Tổng quan luồng lỗi
+
+```text
+Controller.Update
+  └─ model.ToEntity()          → DonViTuVans[].KeHoachId = Guid.Empty (mới)
+  └─ UpdateCommand             → entity.DonViTuVans = request.Dto.DonViTuVans  ❌
+  └─ (thiếu) sync file DVTV    → file mới không được gán GroupId/GroupType    ❌
+```
+
+### 2.2 Lỗi A — Gán thẳng navigation collection (UpdateCommand)
+
+**File:** `QLDA.Application/TrienKhaiKeHoachLCNT/Commands/TrienKhaiKeHoachLCNTUpdateCommand.cs`
+
+```csharp
+// TRƯỚC (sai) — dòng 66
+entity.DonViTuVans = request.Dto.DonViTuVans;
+```
+
+**Vì sao sai:**
+
+- Collection đã được `Include` và **tracked** bởi EF; gán list mới → detach/attach lỗi hoặc EF cố insert trùng PK.
+- Không có logic **update / add / remove** từng phần tử.
+- `SyncDonViTuVan()` đã có trong `TrienKhaiKeHoachLCNTMappings.cs` nhưng **không được gọi** (và bản hiện tại dùng `Clear()` — không phù hợp tracked entity).
+
+**So sánh pattern đúng:** `KeHoachTrienKhaiHangMucUpdateCommand` dùng `SyncHelper.SyncCollection` cho child `HangMucKeHoach` (entity implement `IAggregateRoot`).
+
+> `DonViTuVanKeHoach` **không** implement `Entity<Guid>` / `IAggregateRoot` → **không dùng** `SyncHelper.SyncCollection` trực tiếp. Cần sync thủ công trên navigation collection đã tracked (hoặc refactor entity sau — **ngoài scope** task này).
+
+---
+
+### 2.3 Lỗi B — `KeHoachId` không được gán khi map DVTV mới
+
+**File:** `QLDA.WebApi/Models/DonViTuVanKeHoach/DonViTuVanKeHoachMappingConfiguration.cs`
+
+```csharp
+// TRƯỚC
+public static DonViTuVanKeHoach ToEntity(this DonViTuVanKeHoachModel model)
+    => new() {
+        Id = model.GetId(),
+        KeHoachId = model.KeHoachId,   // FE không gửi → Guid.Empty
+        TenDonVi = model.TenDonVi
+    };
+```
+
+**File:** `QLDA.WebApi/Models/TrienKhaiKeHoachLCNT/TrienKhaiKeHoachLCNTMappingConfiguration.cs`
+
+```csharp
+DonViTuVans = model.DonViTuVans?.Select(x => x.ToEntity()).ToList() ?? [],
+// Không truyền parent Id
+```
+
+**Hệ quả:** Insert DVTV mới vi phạm FK `KeHoachLCNTId` (required).
+
+**Chuẩn Create (đã đúng một phần):** Controller gọi `dv.GetId()` trước khi sync file — ID ổn định trước khi persist. Nhưng `KeHoachId` vẫn thiếu ở mapping.
+
+---
+
+### 2.4 Lỗi C — Controller Update thiếu sync file đơn vị tư vấn
+
+**File:** `QLDA.WebApi/Controllers/TrienKhaiKeHoachLCNTController.cs`
+
+| Action | Sync file cấp chính | Sync file `DonViTuVans` |
+| ------ | -------------------- | ----------------------- |
+| `Create` | ✅ `GetDanhSachTep(entity.Id)` | ✅ `foreach (dv in dto.DonViTuVans)` |
+| `Update` | ✅ (có, kể cả khi `[]`) | ❌ **Thiếu hoàn toàn** |
+
+Create (đúng pattern):
+
+```csharp
+foreach (var dv in dto.DonViTuVans)
+{
+    var id = dv.GetId();
+    var danhSachFileKetQua = dv.GetDanhSachTep(id).ToList();
+    await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand
+    {
+        GroupId = id.ToString(),
+        Entities = danhSachFileKetQua
+    });
+}
+```
+
+Update **không có** vòng lặp tương tự → file DVTV mới không lưu / không gán `GroupId` + `GroupType`.
+
+`GetDanhSachTep` đã có sẵn:
+
+```csharp
+// TepDinhKemMappingConfigurations.cs
+public static List<TepDinhKem> GetDanhSachTep(this DonViTuVanKeHoachModel model, Guid groupId)
+    => model.DanhSachTepDinhKem?.ToEntities(groupId, EGroupType.DonViTuVan).ToList() ?? [];
+```
+
+`ToEntities` dùng `ResolveId` — file mới (không `groupId`) → tạo Id mới; gán `GroupId` + `GroupType` đúng target.
+
+---
+
+### 2.5 Lỗi D — Gán nhầm `So` trong UpdateCommand
+
+```csharp
+// TRƯỚC (sai) — dòng 56
+entity.So = request.Dto.TrichYeu;
+
+// ĐÚNG
+entity.So = request.Dto.So;
+```
+
+Regression nhỏ nhưng ảnh hưởng dữ liệu khi cập nhật.
+
+---
+
+### 2.6 Lỗi E — `danhSachTepDinhKem` rỗng ở cấp chính
+
+Update hiện gọi `TepDinhKemBulkInsertOrUpdateCommand` với `Entities = []` khi mảng rỗng.
+
+**Hành vi `TepDinhKemBulkInsertOrUpdateCommand` (đã fix trước đó):**
+
+- Không early-return khi list rỗng → **soft-delete** file không còn trong request (đúng nghiệp vụ).
+- File DVTV dùng `GroupId` = **id đơn vị tư vấn**, không phải `entity.Id` → sync cấp chính **không** ảnh hưởng file DVTV.
+
+**Khuyến nghị khi implement:** Truyền `ScopeGroupTypes = [GroupTypeConstants.TrienKhaiKeHoachLCNT]` khi sync file cấp chính (phòng trường hợp sau này có nhiều `GroupType` cùng `GroupId`).
+
+---
+
+### 2.7 Bảng tóm tắt root cause
+
+| # | Layer | Vấn đề | Mức độ |
+| - | ----- | ------ | ------ |
+| A | `UpdateCommand` | Gán thẳng `DonViTuVans` | 🔴 Blocker |
+| B | WebApi mapping | `KeHoachId` = Empty cho DVTV mới | 🔴 Blocker |
+| C | `Controller.Update` | Thiếu sync file DVTV | 🔴 Blocker |
+| D | `UpdateCommand` | `So` ← `TrichYeu` | 🟡 Data bug |
+| E | Controller | Nên thêm `ScopeGroupTypes` khi sync file chính | 🟢 Hardening |
+
+---
+
+## 3. Khảo sát flow
+
+### 3.1 Entity & quan hệ
+
+```text
+TrienKhaiKeHoachLCNT (parent)
+├── Id, DuAnId, BuocId, So, NgayTrinh, ...
+└── DonViTuVans[]  DonViTuVanKeHoach (child — không soft-delete)
+    ├── Id           Guid PK
+    ├── KeHoachId    FK → TrienKhaiKeHoachLCNT.Id (cột DB: KeHoachLCNTId)
+    └── TenDonVi
+
+TepDinhKem (không FK trực tiếp)
+├── GroupId + GroupType → liên kết logic
+├── Cấp chính:  GroupId = TrienKhaiKeHoachLCNT.Id,  GroupType = "TrienKhaiKeHoachLCNT"
+└── Cấp DVTV:   GroupId = DonViTuVanKeHoach.Id,     GroupType = "DonViTuVan"
+```
+
+**File tham chiếu:**
+
+| Thành phần | Vị trí |
+| ---------- | ------ |
+| Entity parent | `QLDA.Domain/Entities/TrienKhaiKeHoachLCNT.cs` |
+| Entity child | `QLDA.Domain/Entities/DonViTuVanKeHoach.cs` |
+| EF config child | `QLDA.Persistence/Configurations/DonViTuVanKeHoachConfiguration.cs` |
+| Insert | `QLDA.Application/.../TrienKhaiKeHoachLCNTInsertCommand.cs` |
+| Update | `QLDA.Application/.../TrienKhaiKeHoachLCNTUpdateCommand.cs` |
+| Mapping sync (chưa dùng) | `QLDA.Application/.../TrienKhaiKeHoachLCNTMappings.cs` → `SyncDonViTuVan` |
+| Controller | `QLDA.WebApi/Controllers/TrienKhaiKeHoachLCNTController.cs` |
+| File mapping | `QLDA.WebApi/Models/TepDinhKems/TepDinhKemMappingConfigurations.cs` |
+
+### 3.2 Luồng Create (reference — đúng)
+
+```mermaid
+sequenceDiagram
+    participant FE
+    participant Ctrl as Controller
+    participant Cmd as InsertCommand
+    participant Tep as TepDinhKemBulkInsertOrUpdate
+
+    FE->>Ctrl: POST them-moi
+    Ctrl->>Cmd: InsertCommand(dto.ToEntity())
+    Cmd-->>Ctrl: entity (có DonViTuVans)
+    Ctrl->>Tep: sync file cấp chính (GroupId=entity.Id)
+    loop mỗi DonViTuVan
+        Ctrl->>Ctrl: id = dv.GetId()
+        Ctrl->>Tep: sync file (GroupId=id, GroupType=DonViTuVan)
+    end
+    Ctrl-->>FE: 200 OK
+```
+
+### 3.3 Luồng Update (hiện tại — sai)
+
+```mermaid
+sequenceDiagram
+    participant FE
+    participant Ctrl as Controller
+    participant Cmd as UpdateCommand
+    participant Tep as TepDinhKemBulkInsertOrUpdate
+
+    FE->>Ctrl: PUT cap-nhat
+    Ctrl->>Cmd: UpdateCommand(model.ToEntity())
+    Note over Cmd: DonViTuVans = request list (gán thẳng) ❌
+    Cmd-->>Ctrl: entity
+    Ctrl->>Tep: sync file cấp chính only
+    Note over Ctrl: Không sync file DVTV ❌
+    Ctrl-->>FE: Error / data sai
+```
+
+### 3.4 Luồng Update (target — sau fix)
+
+```mermaid
+sequenceDiagram
+    participant FE
+    participant Ctrl as Controller
+    participant Cmd as UpdateCommand
+    participant Tep as TepDinhKemBulkInsertOrUpdate
+
+    FE->>Ctrl: PUT cap-nhat
+    Ctrl->>Cmd: UpdateCommand(model.ToEntity())
+    Note over Cmd: SyncDonViTuVan tracked collection ✅
+    Cmd-->>Ctrl: entity (DonViTuVans đã persist)
+    Ctrl->>Tep: sync file chính + ScopeGroupTypes
+    loop mỗi DonViTuVan trong model
+        Ctrl->>Ctrl: id = dv.Id ?? matched từ entity
+        Ctrl->>Tep: GetDanhSachTep(id) + ScopeGroupTypes DonViTuVan
+    end
+    Ctrl-->>FE: 200 OK
+```
+
+---
+
+## 4. Bước code chi tiết
+
+### 4.1 Phase 1 — Mapping `DonViTuVanKeHoach`
+
+**File:** `QLDA.WebApi/Models/DonViTuVanKeHoach/DonViTuVanKeHoachMappingConfiguration.cs`
+
+Thêm overload nhận `keHoachId`:
+
+```csharp
+public static DonViTuVanKeHoach ToEntity(this DonViTuVanKeHoachModel model, Guid keHoachId)
+    => new() {
+        Id = model.Id ?? model.GetId(),
+        KeHoachId = keHoachId,
+        TenDonVi = model.TenDonVi
+    };
+
+// Giữ ToEntity(model) cũ → delegate sang overload (hoặc obsolete) để không break caller khác
+public static DonViTuVanKeHoach ToEntity(this DonViTuVanKeHoachModel model)
+    => model.ToEntity(model.KeHoachId);
+```
+
+**File:** `QLDA.WebApi/Models/TrienKhaiKeHoachLCNT/TrienKhaiKeHoachLCNTMappingConfiguration.cs`
+
+```csharp
+// TRƯỚC
+DonViTuVans = model.DonViTuVans?.Select(x => x.ToEntity()).ToList() ?? [],
+
+// SAU
+DonViTuVans = model.DonViTuVans?.Select(x => x.ToEntity(model.GetId())).ToList() ?? [],
+```
+
+> `model.GetId()` dùng `Id` có sẵn khi update; không sinh Id mới cho parent.
+
+---
+
+### 4.2 Phase 2 — `SyncDonViTuVan` (Application mapping)
+
+**File:** `QLDA.Application/TrienKhaiKeHoachLCNT/TrienKhaiKeHoachLCNTMappings.cs`
+
+Thay `Clear()` + add all bằng sync trên collection **đã tracked**:
+
+```csharp
+public static void SyncDonViTuVan(this TrienKhaiKeHoachLCNT entity, List<DonViTuVanKeHoach>? donVis)
+{
+    entity.DonViTuVans ??= [];
+    var requestList = donVis ?? [];
+    var requestIds = requestList.Select(d => d.Id).ToHashSet();
+
+    // Xóa khỏi collection những DVTV không còn trong request
+    foreach (var existing in entity.DonViTuVans.Where(d => !requestIds.Contains(d.Id)).ToList())
+        entity.DonViTuVans.Remove(existing);
+
+    foreach (var item in requestList)
+    {
+        var existing = entity.DonViTuVans.FirstOrDefault(d => d.Id == item.Id);
+        if (existing is not null)
+        {
+            existing.TenDonVi = item.TenDonVi;
+            existing.KeHoachId = entity.Id;
+        }
+        else
+        {
+            entity.DonViTuVans.Add(new DonViTuVanKeHoach
+            {
+                Id = item.Id,
+                KeHoachId = entity.Id,
+                TenDonVi = item.TenDonVi
+            });
+        }
+    }
+}
+```
+
+**Lưu ý:**
+
+- `item.Id` đã được `ToEntity(keHoachId)` / `GetId()` gán trước khi vào command.
+- Cascade delete FK: xóa DVTV khỏi collection → EF xóa row; file `TepDinhKem` **không** tự xóa — cân nhắc gọi `SyncHelper.SetDeleteWithRelatedFiles` khi remove DVTV (optional, nếu BA yêu cầu dọn file orphan).
+
+---
+
+### 4.3 Phase 3 — `TrienKhaiKeHoachLCNTUpdateCommand`
+
+**File:** `QLDA.Application/TrienKhaiKeHoachLCNT/Commands/TrienKhaiKeHoachLCNTUpdateCommand.cs`
+
+```csharp
+// Thay các dòng gán field + DonViTuVans:
+
+entity.So = request.Dto.So;                    // fix bug D
+entity.TrichYeu = request.Dto.TrichYeu;
+// ... các field khác giữ nguyên ...
+
+entity.SyncDonViTuVan(request.Dto.DonViTuVans);  // thay vì gán thẳng
+
+await _repo.UpdateAsync(entity, cancellationToken);
+await _unitOfWork.SaveChangesAsync(cancellationToken);
+```
+
+**Không** mở transaction mới trong handler nếu controller đã `BeginTransaction` — pattern hiện tại `SaveChanges` trong handler vẫn OK khi `HasTransaction = true`.
+
+---
+
+### 4.4 Phase 4 — `TrienKhaiKeHoachLCNTController.Update`
+
+**File:** `QLDA.WebApi/Controllers/TrienKhaiKeHoachLCNTController.cs`
+
+Sau khi `UpdateCommand` trả `entity`, bổ sung sync file DVTV (mirror Create):
+
+```csharp
+// Sync file cấp chính
+var danhSachTepChinh = model.GetDanhSachTep(entity.Id).ToList();
+await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand
+{
+    GroupId = entity.Id.ToString(),
+    Entities = danhSachTepChinh,
+    ScopeGroupTypes = [GroupTypeConstants.TrienKhaiKeHoachLCNT]
+}, cancellationToken);
+
+// Sync file từng đơn vị tư vấn
+foreach (var dv in model.DonViTuVans ?? [])
+{
+    // Id ổn định: FE gửi id có sẵn, hoặc GetId() đã chạy lúc ToEntity
+    var dvId = dv.Id ?? dv.GetId();
+    var files = dv.GetDanhSachTep(dvId).ToList();
+    await Mediator.Send(new TepDinhKemBulkInsertOrUpdateCommand
+    {
+        GroupId = dvId.ToString(),
+        Entities = files,
+        ScopeGroupTypes = [GroupTypeConstants.DonViTuVan]
+    }, cancellationToken);
+}
+
+await unitOfWork.SaveChangesAsync(cancellationToken);
+await unitOfWork.CommitTransactionAsync(cancellationToken);
+```
+
+**Dọn code trùng:** Update hiện gọi `TepDinhKemBulkInsertOrUpdate` **hai lần** cho file cấp chính (`ToEntities` rồi `GetDanhSachTep`). Sau fix chỉ giữ **một** lần qua `GetDanhSachTep`.
+
+**Response:** Có thể enrich `entity.ToDto()` kèm file DVTV nếu FE cần — optional; GET chi-tiet đã load đủ.
+
+---
+
+### 4.5 Phase 5 — Build
+
+```bash
+dotnet build QLDA.Application/QLDA.Application.csproj
+dotnet build QLDA.WebApi/QLDA.WebApi.csproj
+```
+
+> Stop `QLDA.WebApi` nếu process đang lock DLL.
+
+---
+
+## 5. API contract
+
+### 5.1 Request body (PUT `cap-nhat`)
+
+| Field | Type | Ghi chú |
+| ----- | ---- | ------- |
+| `id` | `Guid` | Bắt buộc — id tờ trình |
+| `duAnId`, `buocId` | | Bắt buộc cho auth bước |
+| `donViTuVans` | `array` | Optional; mỗi phần tử: |
+| `donViTuVans[].id` | `Guid?` | `null` = thêm mới |
+| `donViTuVans[].tenDonVi` | `string` | |
+| `donViTuVans[].danhSachTepDinhKem` | `array` | File mới có thể thiếu `groupId`/`groupType` |
+| `danhSachTepDinhKem` | `array` | `[]` hợp lệ — xóa file cấp chính (nếu có) |
+
+### 5.2 Quy tắc `TepDinhKem` (chuẩn dự án)
+
+| Vùng | GroupId | GroupType |
+| ---- | ------- | --------- |
+| Tờ trình chính | `TrienKhaiKeHoachLCNT.Id` | `TrienKhaiKeHoachLCNT` |
+| Đơn vị tư vấn | `DonViTuVanKeHoach.Id` | `DonViTuVan` |
+
+`ToEntities(groupId, groupType)` + `ResolveId`:
+
+- File **đã thuộc** đúng group → giữ `Id` (update metadata).
+- File **mới** hoặc copy từ group khác → `Id` mới + `GroupId`/`GroupType` target.
+
+---
+
+## 6. Test plan
+
+### 6.1 Curl mẫu
+
+```bash
+curl --location --request PUT 'http://192.168.1.12:9051/QuanLyDuAn/api/trien-khai-ke-hoach-lcnt/cap-nhat' \
+--header 'Authorization: Bearer <JWT_TOKEN>' \
+--header 'Content-Type: application/json' \
+--data '{
+    "id": "08ded585-d386-33f8-687a-7b174805f884",
+    "duAnId": "08deb0bb-9c28-6fe6-687a-7b2f840244bc",
+    "so": "14.PC123",
+    "ngayTrinh": "2026-06-29",
+    "trichYeu": "",
+    "buocId": 5032,
+    "hinhThucLCNT": 2,
+    "goiThauId": "dcbf5f92-bc05-446d-9888-2dd65be57e31",
+    "giaTri": 11111111111111,
+    "thoiGianThucHien": "1",
+    "noiDung": "1",
+    "yeuCau": "1",
+    "donViTuVans": [
+        {
+            "id": "08ded585-d386-35f9-687a-7b174805f885",
+            "tenDonVi": "đơn vị",
+            "danhSachTepDinhKem": [
+                {
+                    "id": "08ded585-d39f-83d4-687a-7b174805f889",
+                    "groupId": "08ded585-d386-35f9-687a-7b174805f885",
+                    "groupType": "DonViTuVan",
+                    "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "fileName": "DanhSach_TreHanPhongBan_270620261802 (1).xlsx",
+                    "originalName": "DanhSach_TreHanPhongBan_270620261802 (1).xlsx",
+                    "path": "2026/06/29/d25aceef-b068-42a4-9a1d-35f0b1d37569.xlsx",
+                    "size": 12814
+                }
+            ]
+        },
+        {
+            "id": null,
+            "tenDonVi": "đơn vị 2",
+            "danhSachTepDinhKem": [
+                {
+                    "id": "62bb08ff-9074-436c-87ca-4ef9655598f1",
+                    "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    "fileName": "DanhSach_TinhHinhDauThau_260620261659.xlsx",
+                    "originalName": "DanhSach_TinhHinhDauThau_260620261659.xlsx",
+                    "path": "2026/06/29/11640b13-c204-49d2-aedf-0b5742b040d3.xlsx",
+                    "size": 14217
+                }
+            ]
+        }
+    ],
+    "danhSachTepDinhKem": [],
+    "trangThaiDangTaiId": 0,
+    "trangThaiId": 30
+}'
+```
+
+### 6.2 Manual test cases
+
+| # | Case | Steps | Kỳ vọng |
+| - | ---- | ----- | ------- |
+| T1 | Cập nhật DVTV cũ + giữ file | PUT payload trên | 200; `tenDonVi` cập nhật; file cũ còn trong DB |
+| T2 | Thêm DVTV mới + file mới | Payload có `id: null` + file không `groupId` | 200; row mới `DonViTuVanKeHoach`; file có `GroupId` = id DVTV mới, `GroupType` = `DonViTuVan` |
+| T3 | `danhSachTepDinhKem: []` | PUT không file cấp chính | 200; không exception; file DVTV không bị xóa |
+| T4 | GET chi tiết sau PUT | `GET {id}/chi-tiet` | 2 DVTV; mỗi DVTV có đúng `danhSachTepDinhKem` |
+| T5 | Xóa DVTV khỏi list | PUT bỏ 1 phần tử `donViTuVans` | DVTV bị remove khỏi DB (cascade) |
+| T6 | Trạng thái không DT/Trả lại | PUT khi đã trình | 400 `Trạng thái không thể cập nhật!` |
+
+### 6.3 Verify DB (optional)
+
+```sql
+-- Đơn vị tư vấn
+SELECT Id, KeHoachLCNTId, TenDonVi
+FROM DonViTuVanKeHoach
+WHERE KeHoachLCNTId = '08ded585-d386-33f8-687a-7b174805f884';
+
+-- File đính kèm DVTV
+SELECT Id, GroupId, GroupType, FileName, IsDeleted
+FROM TepDinhKem
+WHERE GroupType = 'DonViTuVan'
+  AND GroupId IN (SELECT CAST(Id AS nvarchar(36)) FROM DonViTuVanKeHoach WHERE KeHoachLCNTId = '...');
+```
+
+---
+
+## 7. Checklist nghiệm thu
+
+- [ ] `SyncDonViTuVan` sync add/update/remove trên tracked collection
+- [ ] `UpdateCommand` gọi `SyncDonViTuVan`, không gán thẳng list
+- [ ] `entity.So = request.Dto.So` (không nhầm `TrichYeu`)
+- [ ] `ToEntity(keHoachId)` gán FK đúng cho DVTV mới
+- [ ] `Controller.Update` sync file từng DVTV + `ScopeGroupTypes`
+- [ ] Bỏ duplicate sync file cấp chính
+- [ ] Không migration / không sửa snapshot
+- [ ] Curl T1 + T2 pass
+- [ ] `gitnexus impact` trước khi sửa + `detect_changes()` trước commit
+
+---
+
+## 8. Commit đề xuất
+
+```
+fix(trien-khai-ke-hoach-lcnt): sync don vi tu van and attachments on update
+
+- Sync DonViTuVans on tracked collection instead of replacing navigation
+- Map KeHoachId when converting DonViTuVan models to entities
+- Mirror Create flow: bulk sync TepDinhKem per consulting unit on PUT
+- Fix So field assignment in update handler
+```
+
+**Files dự kiến thay đổi:**
+
+| File | Phase |
+| ---- | ----- |
+| `QLDA.Application/TrienKhaiKeHoachLCNT/TrienKhaiKeHoachLCNTMappings.cs` | 2 |
+| `QLDA.Application/TrienKhaiKeHoachLCNT/Commands/TrienKhaiKeHoachLCNTUpdateCommand.cs` | 3 |
+| `QLDA.WebApi/Models/DonViTuVanKeHoach/DonViTuVanKeHoachMappingConfiguration.cs` | 1 |
+| `QLDA.WebApi/Models/TrienKhaiKeHoachLCNT/TrienKhaiKeHoachLCNTMappingConfiguration.cs` | 1 |
+| `QLDA.WebApi/Controllers/TrienKhaiKeHoachLCNTController.cs` | 4 |
+
+---
+
+**Next step:** Implement theo [mục 4](#4-bước-code-chi-tiết), chạy curl [6.1](#61-curl-mẫu), tick checklist [mục 7](#7-checklist-nghiệm-thu).


### PR DESCRIPTION
## những công việc đã làm: 
- Theo doi du an phong phan cong: add lanhDaoPhuTrachId and trangThaiDuAnId filters in BuildQuery
- Phan khai kinh phi danh-sach: add search DTO/model and DuAn-based filters; sync Excel export
- Trien khai ke hoach lcnt cap-nhat: fix DonViTuVans sync, attachment handling and So field mapping

## Summary

- **Theo dõi dự án phòng phân công:** bổ sung filter `lanhDaoPhuTrachId`, `trangThaiDuAnId` trong `BuildQuery` (áp dụng cho cả 4 panel counter và danh sách phân trang).
- **Phân khai kinh phí — danh sách:** thêm `PhanKhaiKinhPhiSearchDto` / `SearchModel`, lọc theo `tenDuAn`, `donViPhuTrachChinhId`, `loaiDuAnTheoNamId`, `trangThaiId`; đồng bộ filter sang export Excel.
- **Triển khai KHLCNT — cập nhật:** sửa sync `DonViTuVans`, xử lý tệp đính kèm đơn vị tư vấn, fix mapping field `So`.

Không thay đổi migration / schema.

## Test plan

- [ ] `GET /api/du-an/theo-doi-du-an-phong-phan-cong` — không truyền filter mới → kết quả như cũ
- [ ] Cùng API — `lanhDaoPhuTrachId`, `trangThaiDuAnId` riêng lẻ và kết hợp
- [ ] `GET /api/phan-khai-kinh-phi/danh-sach` — filter `tenDuAn`, `donViPhuTrachChinhId`, `loaiDuAnTheoNamId`, `trangThaiId`
- [ ] `GET /api/print/danh-sach-phan-khai-kinh-phi` — Excel cùng subset với grid
- [ ] `PUT /api/trien-khai-ke-hoach-lcnt/cap-nhat` — cập nhật đơn vị tư vấn cũ/mới + file đính kèm
- [ ] `dotnet build QLDA.WebApi` — pass