### PR TITLE
fix(du-an): align assigned department tracking filters with danh-sach

### DIFF
--- a/QLDA.Application/DuAns/DTOs/TheoDoiDuAnPhongPhanCongSearchDto.cs
+++ b/QLDA.Application/DuAns/DTOs/TheoDoiDuAnPhongPhanCongSearchDto.cs
@@ -5,8 +5,11 @@ namespace QLDA.Application.DuAns.DTOs;
 
 public record TheoDoiDuAnPhongPhanCongSearchDto : CommonSearchDto
 {
-    /// <summary>Đơn vị/phòng phụ trách chính — fallback phòng user khi không gửi</summary>
+    /// <summary>Đơn vị/phòng phụ trách chính — fallback phòng user khi không gửi filter khác</summary>
     public long? DonViPhuTrachChinhId { get; set; }
+
+    /// <summary>Lãnh đạo phụ trách — logic giống DuAnSearchDto</summary>
+    public long? LanhDaoPhuTrachId { get; set; }
 
     /// <summary>Filter năm dự án — logic NamDuAn (#9121)</summary>
     public int? NamDuAn { get; set; }

--- a/QLDA.Application/DuAns/Queries/TheoDoiDuAnPhongPhanCongQuery.cs
+++ b/QLDA.Application/DuAns/Queries/TheoDoiDuAnPhongPhanCongQuery.cs
@@ -33,14 +33,12 @@ internal class TheoDoiDuAnPhongPhanCongQueryHandler(
         var search = request.SearchDto;
         var hoanThanhId = await ResolveHoanThanhIdAsync(cancellationToken);
         var namHienTai = dateTimeProvider.OffsetUtcNow.Year;
-        var donViPhuTrachChinhId = ResolveDonViPhuTrachChinhId(search.DonViPhuTrachChinhId);
 
         var root = authManager.FilterVisible(duAn.GetQueryableSet(), AuthorizationResourceKeys.DuAn);
 
         var counters = await BuildQuery(
                 root,
                 search,
-                donViPhuTrachChinhId,
                 namHienTai,
                 hoanThanhId,
                 ETheoDoiDuAnPhongPhanCongLoai.TatCa)
@@ -58,7 +56,6 @@ internal class TheoDoiDuAnPhongPhanCongQueryHandler(
                 BuildQuery(
                     root,
                     search,
-                    donViPhuTrachChinhId,
                     namHienTai,
                     hoanThanhId,
                     search.Loai)
@@ -88,26 +85,21 @@ internal class TheoDoiDuAnPhongPhanCongQueryHandler(
         return hoanThanh!.Id;
     }
 
-    private long? ResolveDonViPhuTrachChinhId(long? donViPhuTrachChinhId)
-    {
-        if (donViPhuTrachChinhId is > 0)
-            return donViPhuTrachChinhId;
-
-        var phongBanId = userProvider.Info.PhongBanID;
-        return phongBanId > 0 ? phongBanId : donViPhuTrachChinhId;
-    }
-
-    private static IQueryable<DuAn> BuildQuery(
+    private IQueryable<DuAn> BuildQuery(
         IQueryable<DuAn> query,
         TheoDoiDuAnPhongPhanCongSearchDto search,
-        long? donViPhuTrachChinhId,
         int namHienTai,
         int hoanThanhId,
         ETheoDoiDuAnPhongPhanCongLoai loai)
     {
         query = query
             .AsNoTracking()
-            .WhereIf(donViPhuTrachChinhId is > 0, e => e.DonViPhuTrachChinhId == donViPhuTrachChinhId)
+            .WhereFunc(search.DonViPhuTrachChinhId.HasValue, q => q
+                .WhereIf(search.DonViPhuTrachChinhId > 0, e => e.DonViPhuTrachChinhId == search.DonViPhuTrachChinhId)
+                .WhereIf(search.DonViPhuTrachChinhId == -1, e => e.DonViPhuTrachChinhId == null))
+            .WhereFunc(search.LanhDaoPhuTrachId.HasValue, q => q
+                .WhereIf(search.LanhDaoPhuTrachId > 0, e => e.LanhDaoPhuTrachId == search.LanhDaoPhuTrachId)
+                .WhereIf(search.LanhDaoPhuTrachId == -1, e => e.LanhDaoPhuTrachId == null))
             .WhereIf(search.TenDuAn.IsNotNullOrWhitespace(),
                 e => e.TenDuAn!.ToLower().Contains(search.TenDuAn!.ToLower()))
             .WhereIf(search.MaDuAn.IsNotNullOrWhitespace(),
@@ -117,6 +109,13 @@ internal class TheoDoiDuAnPhongPhanCongQueryHandler(
                      && ((e.ThoiGianHoanThanh == null && e.ThoiGianKhoiCong == search.NamDuAn)
                          || search.NamDuAn <= e.ThoiGianHoanThanh))
             .WhereGlobalFilter(search, e => e.TenDuAn, e => e.MaDuAn);
+
+        if (!search.DonViPhuTrachChinhId.HasValue && !search.LanhDaoPhuTrachId.HasValue)
+        {
+            var phongBanId = userProvider.Info.PhongBanID;
+            if (phongBanId > 0)
+                query = query.Where(e => e.DonViPhuTrachChinhId == phongBanId);
+        }
 
         return loai switch
         {


### PR DESCRIPTION
## Summary

- Bổ sung `LanhDaoPhuTrachId` cho API `theo-doi-du-an-phong-phan-cong` để dùng chung filter với `danh-sach`.
- Đồng bộ logic filter `donViPhuTrachChinhId` / `lanhDaoPhuTrachId` theo `DuAnGetDanhSachQuery`.
- Khi FE gửi `lanhDaoPhuTrachId` thì không còn tự fallback phòng user — tránh lệch kết quả so với `danh-sach`.

## Vấn đề

Cùng query:
`?pageIndex=1&pageSize=10&lanhDaoPhuTrachId=5&namDuAn=2026`

| API | Trước |
|-----|-------|
| `danh-sach` | 5 dự án |
| `theo-doi-du-an-phong-phan-cong` | 1 dự án |

Nguyên nhân: API theo dõi bỏ qua `lanhDaoPhuTrachId` và luôn filter theo phòng user login.

## Files changed

- QLDA.Application/DuAns/DTOs/TheoDoiDuAnPhongPhanCongSearchDto.cs
- QLDA.Application/DuAns/Queries/TheoDoiDuAnPhongPhanCongQuery.cs

## Test plan

- [x] Gọi cả 2 API với `lanhDaoPhuTrachId=5&namDuAn=2026` → cùng số lượng dự án
- [x] Không gửi filter → vẫn fallback phòng user (UX màn hình mặc định)
- [x] Gửi `donViPhuTrachChinhId` → filter đúng phòng
- [x] Gửi `lanhDaoPhuTrachId=-1` → chỉ dự án chưa có lãnh đạo phụ trách