### PR TITLE
fix(export): align print output with UI filters and project order

### DIFF
--- a/QLDA.Application/GoiThaus/DTOs/TinhHinhThucHienDauThauPrintSearchDto.cs
+++ b/QLDA.Application/GoiThaus/DTOs/TinhHinhThucHienDauThauPrintSearchDto.cs
@@ -11,5 +11,20 @@ public record TinhHinhThucHienDauThauPrintSearchDto
     /// </summary>
     public int? Loai { get; set; }
 
+    /// <summary>
+    /// Năm dự án — bind query param <c>namDuAn</c>. Null hoặc &lt;= 0 = không lọc.
+    /// </summary>
+    public int? NamDuAn { get; set; }
+
+    /// <summary>
+    /// Giai đoạn hiện tại (<c>DuAn.GiaiDoanHienTaiId</c>). Null hoặc -1 = không lọc.
+    /// </summary>
+    public int? GiaiDoanId { get; set; }
+
+    /// <summary>
+    /// Dự án — bind query param <c>duAnId</c>. Null = không lọc.
+    /// </summary>
+    public Guid? DuAnId { get; set; }
+
     public List<string>? HiddenColumns { get; set; }
 }

--- a/QLDA.Application/GoiThaus/GoiThauTinhHinhDauThauQueryableExtensions.cs
+++ b/QLDA.Application/GoiThaus/GoiThauTinhHinhDauThauQueryableExtensions.cs
@@ -1,0 +1,74 @@
+using QLDA.Domain.Entities;
+
+namespace QLDA.Application.GoiThaus;
+
+internal static class GoiThauTinhHinhDauThauQueryableExtensions
+{
+    /// <summary>
+    /// Lọc dự án / giai đoạn — dùng chung list + print.
+    /// <paramref name="giaiDoanId"/> null hoặc &lt;= 0 (gồm -1) → bỏ qua.
+    /// </summary>
+    public static IQueryable<GoiThau> ApplyTinhHinhDauThauFilters(
+        this IQueryable<GoiThau> queryable,
+        Guid? duAnId,
+        int? giaiDoanId)
+    {
+        if (duAnId is Guid id && id != Guid.Empty)
+            queryable = queryable.Where(e => e.DuAnId == id);
+
+        if (giaiDoanId is > 0)
+            queryable = queryable.Where(e => e.DuAn != null
+                && e.DuAn.GiaiDoanHienTaiId == giaiDoanId.Value);
+
+        return queryable;
+    }
+
+    /// <summary>
+    /// Lọc theo query param <c>nam</c> trên API list — theo <c>DuAn.NgayBatDau</c>.
+    /// </summary>
+    public static IQueryable<GoiThau> ApplyTinhHinhDauThauNamFilter(
+        this IQueryable<GoiThau> queryable,
+        int? nam)
+    {
+        if (!nam.HasValue)
+            return queryable;
+
+        var firstDayOfYear = new DateTimeOffset(nam.Value, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var firstDayOfNextYear = firstDayOfYear.AddYears(1);
+        return queryable.Where(e => e.DuAn != null
+            && e.DuAn.NgayBatDau.HasValue
+            && e.DuAn.NgayBatDau >= firstDayOfYear
+            && e.DuAn.NgayBatDau < firstDayOfNextYear);
+    }
+
+    /// <summary>
+    /// Lọc theo query param <c>namDuAn</c> trên API print — logic #9121
+    /// (<c>ThoiGianKhoiCong</c> / <c>ThoiGianHoanThanh</c>).
+    /// </summary>
+    public static IQueryable<GoiThau> ApplyTinhHinhDauThauNamDuAnFilter(
+        this IQueryable<GoiThau> queryable,
+        int? namDuAn)
+    {
+        if (namDuAn is not > 0)
+            return queryable;
+
+        return queryable.Where(e => e.DuAn != null
+            && namDuAn >= e.DuAn.ThoiGianKhoiCong
+            && ((e.DuAn.ThoiGianHoanThanh == null && e.DuAn.ThoiGianKhoiCong == namDuAn)
+                || namDuAn <= e.DuAn.ThoiGianHoanThanh));
+    }
+
+    /// <summary>
+    /// Lọc tab trạng thái đấu thầu. Giá trị ngoài 1–3 → không lọc tab (list behavior).
+    /// </summary>
+    public static IQueryable<GoiThau> ApplyTinhHinhDauThauTabFilter(
+        this IQueryable<GoiThau> queryable,
+        int trangThai) =>
+        trangThai switch
+        {
+            1 => queryable.Where(e => e.KetQuaTrungThau == null && e.HopDong == null),
+            2 => queryable.Where(e => e.KetQuaTrungThau != null && e.HopDong == null),
+            3 => queryable.Where(e => e.KetQuaTrungThau != null && e.HopDong != null),
+            _ => queryable,
+        };
+}

--- a/QLDA.Application/GoiThaus/Queries/GoiThauGetTinhHinhDauThauPrintQuery.cs
+++ b/QLDA.Application/GoiThaus/Queries/GoiThauGetTinhHinhDauThauPrintQuery.cs
@@ -40,7 +40,7 @@ internal class GoiThauGetTinhHinhDauThauPrintQueryHandler(IServiceProvider servi
             var sheets = new List<TinhHinhThucHienDauThauSheetDto>(SheetTabs.Length);
             foreach (var tab in SheetTabs)
             {
-                var items = await GetExportItemsAsync(tab.Loai, cancellationToken);
+                var items = await GetExportItemsAsync(tab.Loai, request.SearchDto, cancellationToken);
                 sheets.Add(new TinhHinhThucHienDauThauSheetDto
                 {
                     Title = tab.Title,
@@ -55,7 +55,7 @@ internal class GoiThauGetTinhHinhDauThauPrintQueryHandler(IServiceProvider servi
             };
         }
 
-        var data = await GetExportItemsAsync(loai, cancellationToken);
+        var data = await GetExportItemsAsync(loai, request.SearchDto, cancellationToken);
 
         return new TinhHinhThucHienDauThauPrintResultDto
         {
@@ -66,6 +66,7 @@ internal class GoiThauGetTinhHinhDauThauPrintQueryHandler(IServiceProvider servi
 
     private async Task<List<TinhHinhThucHienDauThauExportDto>> GetExportItemsAsync(
         TinhHinhThucHienDauThauLoai loai,
+        TinhHinhThucHienDauThauPrintSearchDto searchDto,
         CancellationToken cancellationToken)
     {
         var duAnBuocQuery = _duAnBuoc.GetQueryableSet().AsNoTracking();
@@ -73,7 +74,9 @@ internal class GoiThauGetTinhHinhDauThauPrintQueryHandler(IServiceProvider servi
         var queryable = _goiThau.GetOrderedSet()
             .Include(e => e.KetQuaTrungThau)
             .Include(e => e.HopDong)
-            .AsQueryable();
+            .AsQueryable()
+            .ApplyTinhHinhDauThauFilters(searchDto.DuAnId, searchDto.GiaiDoanId)
+            .ApplyTinhHinhDauThauNamDuAnFilter(searchDto.NamDuAn);
 
         queryable = loai switch
         {

--- a/QLDA.Application/GoiThaus/Queries/GoiThauGetTinhHinhDauThauQuery.cs
+++ b/QLDA.Application/GoiThaus/Queries/GoiThauGetTinhHinhDauThauQuery.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using QLDA.Application.GoiThaus;
 using QLDA.Application.GoiThaus.DTOs;
 using QLDA.Application.TepDinhKems.DTOs;
 using QLDA.Application.Providers;
@@ -28,46 +29,15 @@ internal class GoiThauGetDanhSachQueryHandler : IRequestHandler<GoiThauGetTinhHi
 
     public async Task<PaginatedList<GoiThauDto>> Handle(    GoiThauGetTinhHinhDauThauQuery request,    CancellationToken cancellationToken = default)
     {
-        var firstDayOfYear = new DateTimeOffset(request.SearchDto.Nam?? 2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-
-        var firstDayOfNextYear = firstDayOfYear.AddYears(1);
-
         var queryable = GoiThau.GetOrderedSet()
             .Include(e => e.KetQuaTrungThau)
             .Include(e => e.HopDong)
-            .AsQueryable();
-        if (request.SearchDto.DuAnId.HasValue)
-        {
-            queryable = queryable.Where(e => e.DuAnId == request.SearchDto.DuAnId.Value);
-        }
-        if (request.SearchDto.GiaiDoanId.HasValue)
-        {
-            queryable = queryable.Where(e => e.DuAn != null && e.DuAn.GiaiDoanHienTaiId == request.SearchDto.GiaiDoanId.Value);
-        }
-        if (request.SearchDto.Nam.HasValue)
-        {
-            queryable = queryable.Where(e => e.DuAn != null && e.DuAn.NgayBatDau.HasValue &&
-                e.DuAn.NgayBatDau >= firstDayOfYear && e.DuAn.NgayBatDau < firstDayOfNextYear);
-        }
-        queryable = request.SearchDto.TrangThai switch
-        {
-            // ChuaCoKetQua
-            1 => queryable.Where(e =>
-                e.KetQuaTrungThau == null &&
-                e.HopDong == null),
-
-            // CoKetQua
-            2 => queryable.Where(e =>
-                e.KetQuaTrungThau != null &&
-                e.HopDong == null),
-
-            // DaCoHopDong
-            3 => queryable.Where(e =>
-                e.KetQuaTrungThau != null &&
-                e.HopDong != null),
-
-            _ => queryable
-        };
+            .AsQueryable()
+            .ApplyTinhHinhDauThauFilters(
+                request.SearchDto.DuAnId,
+                request.SearchDto.GiaiDoanId)
+            .ApplyTinhHinhDauThauNamFilter(request.SearchDto.Nam)
+            .ApplyTinhHinhDauThauTabFilter(request.SearchDto.TrangThai);
         queryable = queryable.AsNoTracking();
 
         //  var entities = await queryable.ToListAsync(cancellationToken);

--- a/QLDA.Application/KeHoachTrienKhaiHangMuc/KeHoachTrienKhaiHangMucExportMapper.cs
+++ b/QLDA.Application/KeHoachTrienKhaiHangMuc/KeHoachTrienKhaiHangMucExportMapper.cs
@@ -18,6 +18,15 @@ internal static class KeHoachTrienKhaiHangMucExportMapper
         if (items.Count == 0)
             return [];
 
+        var itemIndexById = items
+            .Select((h, i) => (h.Id, i))
+            .ToDictionary(x => x.Id, x => x.i);
+
+        var firstGroupIndexByGiaiDoanId = items
+            .Select((h, i) => (h.GiaiDoanId, i))
+            .GroupBy(x => x.GiaiDoanId)
+            .ToDictionary(g => g.Key, g => g.Min(x => x.i));
+
         var groups = items
             .GroupBy(h => h.GiaiDoanId)
             .Select(g =>
@@ -29,7 +38,7 @@ internal static class KeHoachTrienKhaiHangMucExportMapper
                         GiaiDoanId = id,
                         TenGiaiDoan = ten,
                         SortOrder = giaiDoanSortById.GetValueOrDefault(id, int.MaxValue - 1),
-                        Items = g.OrderBy(x => x.NgayBatDau).ThenBy(x => x.TenHangMuc).ToList(),
+                        Items = g.OrderBy(x => itemIndexById.GetValueOrDefault(x.Id, int.MaxValue)).ToList(),
                     };
                 }
 
@@ -38,11 +47,11 @@ internal static class KeHoachTrienKhaiHangMucExportMapper
                     GiaiDoanId = null,
                     TenGiaiDoan = KhacGiaiDoanTen,
                     SortOrder = int.MaxValue,
-                    Items = g.OrderBy(x => x.NgayBatDau).ThenBy(x => x.TenHangMuc).ToList(),
+                    Items = g.OrderBy(x => itemIndexById.GetValueOrDefault(x.Id, int.MaxValue)).ToList(),
                 };
             })
             .OrderBy(g => g.SortOrder)
-            .ThenBy(g => g.TenGiaiDoan)
+            .ThenBy(g => firstGroupIndexByGiaiDoanId.GetValueOrDefault(g.GiaiDoanId, int.MaxValue))
             .ToList();
 
         var rows = new List<KeHoachTrienKhaiHangMucExportItemDto>();
@@ -58,9 +67,7 @@ internal static class KeHoachTrienKhaiHangMucExportMapper
 
             var itemStt = 1;
             foreach (var hangMuc in group.Items)
-            {
                 rows.Add(MapItem(hangMuc, itemStt++, donViTenById, userTenById));
-            }
         }
 
         return rows;

--- a/QLDA.Application/KeHoachTrienKhaiHangMuc/KeHoachTrienKhaiHangMucExportRowLoader.cs
+++ b/QLDA.Application/KeHoachTrienKhaiHangMuc/KeHoachTrienKhaiHangMucExportRowLoader.cs
@@ -14,7 +14,9 @@ internal static class KeHoachTrienKhaiHangMucExportRowLoader
 {
     public static async Task<List<KeHoachTrienKhaiHangMucExportItemDto>> LoadAsync(
         IReadOnlyList<HangMucKeHoach> hangMucs,
+        Guid? duAnId,
         IRepository<DanhMucGiaiDoan, int> giaiDoanRepo,
+        IRepository<DuAnBuoc, int> duAnBuocRepo,
         IRepository<DmDonVi, long> donViRepo,
         IRepository<UserMaster, long> userRepo,
         CancellationToken cancellationToken = default)
@@ -35,6 +37,22 @@ internal static class KeHoachTrienKhaiHangMucExportRowLoader
                 .Where(g => giaiDoanIds.Contains(g.Id))
                 .ToListAsync(cancellationToken);
 
+        Dictionary<int, int> giaiDoanSortById;
+
+        if (duAnId is Guid projectId && projectId != Guid.Empty)
+        {
+            giaiDoanSortById = new Dictionary<int, int>(
+                await KeHoachTrienKhaiHangMucImportGiaiDoanHelper.GetGiaiDoanSortByDuAnAsync(
+                    projectId, duAnBuocRepo, giaiDoanRepo, cancellationToken));
+
+            foreach (var id in giaiDoanIds.Where(id => !giaiDoanSortById.ContainsKey(id)))
+                giaiDoanSortById[id] = int.MaxValue - 1;
+        }
+        else
+        {
+            giaiDoanSortById = giaiDoans.ToDictionary(g => g.Id, g => g.Stt ?? int.MaxValue - 1);
+        }
+
         var donViIds = hangMucs
             .SelectMany(h => Enumerable.Empty<long?>()
                 .Append(h.DonViChuTriId)
@@ -44,9 +62,10 @@ internal static class KeHoachTrienKhaiHangMucExportRowLoader
             .Distinct()
             .ToList();
 
+        // Legacy DmDonVi / UserMaster: Used có thể null — không lọc OnlyUsed.
         var donVis = donViIds.Count == 0
             ? []
-            : await donViRepo.GetQueryableSet()
+            : await donViRepo.GetQueryableSet(OnlyUsed: false, OnlyNotDeleted: false)
                 .AsNoTracking()
                 .Where(d => donViIds.Contains(d.Id))
                 .Select(d => new { d.Id, d.TenDonVi })
@@ -63,16 +82,31 @@ internal static class KeHoachTrienKhaiHangMucExportRowLoader
 
         var users = userIds.Count == 0
             ? []
-            : await userRepo.GetQueryableSet()
+            : await userRepo.GetQueryableSet(OnlyUsed: false, OnlyNotDeleted: false)
                 .AsNoTracking()
                 .Where(u => userIds.Contains(u.Id))
                 .Select(u => new { u.Id, u.HoTen })
                 .ToListAsync(cancellationToken);
 
+        var giaiDoanTenById = giaiDoans.ToDictionary(g => g.Id, g => g.Ten ?? string.Empty);
+
+        if (duAnId is Guid duAnIdValue && duAnIdValue != Guid.Empty)
+        {
+            var displayNameById = await KeHoachTrienKhaiHangMucImportGiaiDoanHelper
+                .GetGiaiDoanDisplayNameByDuAnAsync(
+                    duAnIdValue, duAnBuocRepo, giaiDoanRepo, cancellationToken);
+
+            foreach (var (giaiDoanId, displayName) in displayNameById)
+            {
+                if (giaiDoanIds.Contains(giaiDoanId) && !string.IsNullOrWhiteSpace(displayName))
+                    giaiDoanTenById[giaiDoanId] = displayName;
+            }
+        }
+
         return KeHoachTrienKhaiHangMucExportMapper.ToExportRows(
             hangMucs,
-            giaiDoans.ToDictionary(g => g.Id, g => g.Ten ?? string.Empty),
-            giaiDoans.ToDictionary(g => g.Id, g => g.Stt ?? int.MaxValue - 1),
+            giaiDoanTenById,
+            giaiDoanSortById,
             donVis.ToDictionary(d => d.Id, d => d.TenDonVi ?? string.Empty),
             users.ToDictionary(u => u.Id, u => u.HoTen ?? string.Empty));
     }

--- a/QLDA.Application/KeHoachTrienKhaiHangMuc/KeHoachTrienKhaiHangMucImportGiaiDoanHelper.cs
+++ b/QLDA.Application/KeHoachTrienKhaiHangMuc/KeHoachTrienKhaiHangMucImportGiaiDoanHelper.cs
@@ -148,6 +148,47 @@ internal static class KeHoachTrienKhaiHangMucImportGiaiDoanHelper {
         return true;
     }
 
+    /// <summary>
+    /// GiaiDoanId → SortOrder theo quy trình dự án (DuAnBuoc.Buoc.Stt).
+    /// Dùng chung import combo, Excel export, Word phiếu trình.
+    /// </summary>
+    internal static async Task<IReadOnlyDictionary<int, int>> GetGiaiDoanSortByDuAnAsync(
+        Guid duAnId,
+        IRepository<DuAnBuoc, int> duAnBuocRepo,
+        IRepository<DanhMucGiaiDoan, int> giaiDoanRepo,
+        CancellationToken cancellationToken = default)
+    {
+        var phasesByDuAn = await LoadRootPhasesByDuAnAsync(
+            duAnBuocRepo,
+            giaiDoanRepo,
+            [duAnId],
+            cancellationToken);
+
+        if (!phasesByDuAn.TryGetValue(duAnId, out var phases) || phases.Count == 0)
+            return new Dictionary<int, int>();
+
+        return phases.ToDictionary(p => p.GiaiDoanId, p => p.SortOrder);
+    }
+
+    /// <summary>GiaiDoanId → tên hiển thị theo quy trình dự án (Buoc.Ten / TenBuoc).</summary>
+    internal static async Task<IReadOnlyDictionary<int, string>> GetGiaiDoanDisplayNameByDuAnAsync(
+        Guid duAnId,
+        IRepository<DuAnBuoc, int> duAnBuocRepo,
+        IRepository<DanhMucGiaiDoan, int> giaiDoanRepo,
+        CancellationToken cancellationToken = default)
+    {
+        var phasesByDuAn = await LoadRootPhasesByDuAnAsync(
+            duAnBuocRepo,
+            giaiDoanRepo,
+            [duAnId],
+            cancellationToken);
+
+        if (!phasesByDuAn.TryGetValue(duAnId, out var phases) || phases.Count == 0)
+            return new Dictionary<int, string>();
+
+        return phases.ToDictionary(p => p.GiaiDoanId, p => p.DisplayName);
+    }
+
     private static async Task<Dictionary<Guid, List<ProjectPhaseLookup>>> LoadRootPhasesByDuAnAsync(
         IRepository<DuAnBuoc, int> duAnBuocRepo,
         IRepository<DanhMucGiaiDoan, int> giaiDoanRepo,

--- a/QLDA.Application/KeHoachTrienKhaiHangMuc/Queries/KeHoachTrienKhaiHangMucGetExportQuery.cs
+++ b/QLDA.Application/KeHoachTrienKhaiHangMuc/Queries/KeHoachTrienKhaiHangMucGetExportQuery.cs
@@ -29,6 +29,8 @@ internal class KeHoachTrienKhaiHangMucGetExportQueryHandler(IServiceProvider ser
 {
     private readonly IRepository<KeHoachTrienKhaiHangMuc, Guid> _keHoachRepo =
         serviceProvider.GetRequiredService<IRepository<KeHoachTrienKhaiHangMuc, Guid>>();
+    private readonly IRepository<HangMucKeHoach, Guid> _hangMucRepo =
+        serviceProvider.GetRequiredService<IRepository<HangMucKeHoach, Guid>>();
     private readonly IRepository<DanhMucGiaiDoan, int> _giaiDoanRepo =
         serviceProvider.GetRequiredService<IRepository<DanhMucGiaiDoan, int>>();
     private readonly IRepository<DmDonVi, long> _donViRepo =
@@ -47,13 +49,15 @@ internal class KeHoachTrienKhaiHangMucGetExportQueryHandler(IServiceProvider ser
         CancellationToken cancellationToken = default)
     {
         var queryable = BuildFilteredQueryable(request);
-        var hangMucs = await LoadHangMucsAsync(queryable, request, cancellationToken);
+        var (hangMucs, duAnId) = await LoadHangMucsWithContextAsync(queryable, request, cancellationToken);
 
         ManagedException.ThrowIf(hangMucs.Count == 0, "Không có dữ liệu để xuất");
 
         return await KeHoachTrienKhaiHangMucExportRowLoader.LoadAsync(
             hangMucs,
+            duAnId ?? request.DuAnId,
             _giaiDoanRepo,
+            _duAnBuocRepo,
             _donViRepo,
             _userRepo,
             cancellationToken);
@@ -68,7 +72,6 @@ internal class KeHoachTrienKhaiHangMucGetExportQueryHandler(IServiceProvider ser
                 _authContext,
                 e => e.BuocId)
             .AsNoTracking()
-            .Include(e => e.DanhSachHangMuc)
             .WhereIf(request.Id.HasValue && request.Id != Guid.Empty, e => e.Id == request.Id)
             .WhereIf(request.DuAnId.HasValue && request.DuAnId != Guid.Empty, e => e.DuAnId == request.DuAnId)
             .WhereIf(request.LoaiDuAnTheoNamId > 0, e => e.DuAn!.LoaiDuAnTheoNamId == request.LoaiDuAnTheoNamId)
@@ -80,7 +83,7 @@ internal class KeHoachTrienKhaiHangMucGetExportQueryHandler(IServiceProvider ser
             .WhereIf(request.DenNgay.HasValue, e => e.NgayToTrinh.HasValue && e.NgayToTrinh.Value <= request.DenNgay!.Value.ToEndOfDayUtc());
     }
 
-    private static async Task<List<HangMucKeHoach>> LoadHangMucsAsync(
+    private async Task<(List<HangMucKeHoach> HangMucs, Guid? DuAnId)> LoadHangMucsWithContextAsync(
         IQueryable<KeHoachTrienKhaiHangMuc> queryable,
         KeHoachTrienKhaiHangMucGetExportQuery request,
         CancellationToken cancellationToken)
@@ -91,7 +94,11 @@ internal class KeHoachTrienKhaiHangMucGetExportQueryHandler(IServiceProvider ser
         if (hasId)
         {
             var keHoach = await queryable.FirstOrDefaultAsync(cancellationToken);
-            return keHoach?.DanhSachHangMuc?.ToList() ?? [];
+            if (keHoach == null)
+                return ([], null);
+
+            var hangMucs = await LoadHangMucsByKeHoachIdAsync(keHoach.Id, cancellationToken);
+            return (hangMucs, keHoach.DuAnId);
         }
 
         if (hasDuAnId)
@@ -100,7 +107,11 @@ internal class KeHoachTrienKhaiHangMucGetExportQueryHandler(IServiceProvider ser
                 .OrderByDescending(e => e.NgayToTrinh)
                 .ThenByDescending(e => e.CreatedAt)
                 .FirstOrDefaultAsync(cancellationToken);
-            return keHoach?.DanhSachHangMuc?.Where(x => !x.IsDeleted).ToList() ?? [];
+            if (keHoach == null)
+                return ([], request.DuAnId);
+
+            var hangMucs = await LoadHangMucsByKeHoachIdAsync(keHoach.Id, cancellationToken);
+            return (hangMucs, request.DuAnId);
         }
 
         var keHoachs = await queryable
@@ -108,8 +119,20 @@ internal class KeHoachTrienKhaiHangMucGetExportQueryHandler(IServiceProvider ser
             .ThenByDescending(e => e.NgayToTrinh)
             .ToListAsync(cancellationToken);
 
-        return keHoachs
-            .SelectMany(k => k.DanhSachHangMuc ?? [])
-            .ToList();
+        var allHangMucs = new List<HangMucKeHoach>();
+        foreach (var keHoach in keHoachs)
+            allHangMucs.AddRange(await LoadHangMucsByKeHoachIdAsync(keHoach.Id, cancellationToken));
+
+        return (allHangMucs, null);
     }
+
+    private async Task<List<HangMucKeHoach>> LoadHangMucsByKeHoachIdAsync(
+        Guid keHoachId,
+        CancellationToken cancellationToken) =>
+        await _hangMucRepo.GetQueryableSet()
+            .AsNoTracking()
+            .Where(h => h.KeHoachId == keHoachId)
+            .OrderBy(h => h.CreatedAt)
+            .ThenBy(h => h.Id)
+            .ToListAsync(cancellationToken);
 }

--- a/QLDA.Application/KeHoachTrienKhaiHangMuc/Queries/KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery.cs
+++ b/QLDA.Application/KeHoachTrienKhaiHangMuc/Queries/KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery.cs
@@ -18,6 +18,10 @@ internal class KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQueryHandler(IServicePro
 {
     private readonly IRepository<KeHoachTrienKhaiHangMuc, Guid> _keHoachRepo =
         serviceProvider.GetRequiredService<IRepository<KeHoachTrienKhaiHangMuc, Guid>>();
+    private readonly IRepository<HangMucKeHoach, Guid> _hangMucRepo =
+        serviceProvider.GetRequiredService<IRepository<HangMucKeHoach, Guid>>();
+    private readonly IRepository<DuAn, Guid> _duAnRepo =
+        serviceProvider.GetRequiredService<IRepository<DuAn, Guid>>();
     private readonly IRepository<DuAnBuoc, int> _duAnBuocRepo =
         serviceProvider.GetRequiredService<IRepository<DuAnBuoc, int>>();
     private readonly IRepository<DanhMucGiaiDoan, int> _giaiDoanRepo =
@@ -41,26 +45,32 @@ internal class KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQueryHandler(IServicePro
 
         ManagedException.ThrowIfNull(keHoach, "Không tìm thấy dữ liệu");
 
-        // Cùng cách load với GetExportQuery / GetQuery: Include navigation (không lọc IsDeleted trên child).
-        var hangMucs = keHoach.DanhSachHangMuc?.ToList() ?? [];
+        await EnsureDuAnLoadedAsync(keHoach, cancellationToken);
+
+        var hangMucs = await LoadHangMucsForKeHoachAsync(keHoach.Id, cancellationToken);
 
         var rows = hangMucs.Count == 0
             ? []
             : await KeHoachTrienKhaiHangMucExportRowLoader.LoadAsync(
                 hangMucs,
+                keHoach.DuAnId,
                 _giaiDoanRepo,
+                _duAnBuocRepo,
                 _donViRepo,
                 _userRepo,
                 cancellationToken);
+
+        var maDuAn = keHoach.DuAn?.MaDuAn?.Trim();
+        var tenDuAn = keHoach.DuAn?.TenDuAn?.Trim();
 
         return new KeHoachTrienKhaiHangMucPhieuTrinhPrintDto
         {
             So = keHoach.So,
             NgayToTrinh = keHoach.NgayToTrinh,
             TrichYeu = keHoach.TrichYeu,
-            MaDuAn = keHoach.DuAn?.MaDuAn,
-            TenDuAn = keHoach.DuAn?.TenDuAn,
-            DuAnDisplay = BuildDuAnDisplay(keHoach.DuAn?.MaDuAn, keHoach.DuAn?.TenDuAn),
+            MaDuAn = maDuAn,
+            TenDuAn = tenDuAn,
+            DuAnDisplay = BuildDuAnDisplay(maDuAn, tenDuAn),
             Rows = rows,
         };
     }
@@ -76,7 +86,6 @@ internal class KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQueryHandler(IServicePro
                 e => e.BuocId)
             .AsNoTracking()
             .Include(e => e.DuAn)
-            .Include(e => e.DanhSachHangMuc)
             .FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
 
         if (keHoach != null)
@@ -87,15 +96,42 @@ internal class KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQueryHandler(IServicePro
                 AuthorizationResourceKeys.DuAn)
             .AsNoTracking()
             .Include(e => e.DuAn)
-            .Include(e => e.DanhSachHangMuc)
             .FirstOrDefaultAsync(e => e.Id == id, cancellationToken);
+    }
+
+    private async Task<List<HangMucKeHoach>> LoadHangMucsForKeHoachAsync(
+        Guid keHoachId,
+        CancellationToken cancellationToken) =>
+        await _hangMucRepo.GetQueryableSet()
+            .AsNoTracking()
+            .Where(h => h.KeHoachId == keHoachId)
+            .OrderBy(h => h.CreatedAt)
+            .ThenBy(h => h.Id)
+            .ToListAsync(cancellationToken);
+
+    private async Task EnsureDuAnLoadedAsync(
+        KeHoachTrienKhaiHangMuc keHoach,
+        CancellationToken cancellationToken)
+    {
+        if (keHoach.DuAn != null || keHoach.DuAnId == Guid.Empty)
+            return;
+
+        keHoach.DuAn = await _duAnRepo.GetQueryableSet()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(d => d.Id == keHoach.DuAnId, cancellationToken);
     }
 
     private static string BuildDuAnDisplay(string? maDuAn, string? tenDuAn)
     {
-        if (!string.IsNullOrWhiteSpace(maDuAn) && !string.IsNullOrWhiteSpace(tenDuAn))
-            return $"{maDuAn} — {tenDuAn}";
+        var ma = maDuAn?.Trim();
+        var ten = tenDuAn?.Trim();
 
-        return maDuAn ?? tenDuAn ?? string.Empty;
+        if (!string.IsNullOrEmpty(ma) && !string.IsNullOrEmpty(ten))
+            return $"{ma} — {ten}";
+
+        if (!string.IsNullOrEmpty(ma))
+            return ma;
+
+        return ten ?? string.Empty;
     }
 }

--- a/QLDA.Application/QLDA.Application.csproj
+++ b/QLDA.Application/QLDA.Application.csproj
@@ -7,6 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="QLDA.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
       <Compile Remove="DanhMucPhuongAnThietKe\**" />
       <Compile Remove="DanhMucTrangThaiPheDuyet\**" />
       <Compile Remove="DmTrangThaiPheDuyets\**" />

--- a/QLDA.Tests/Integration/TinhHinhThucHienDauThauExportTests.cs
+++ b/QLDA.Tests/Integration/TinhHinhThucHienDauThauExportTests.cs
@@ -45,4 +45,36 @@ public class TinhHinhThucHienDauThauExportTests(WebApiFixture fixture)
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    [Fact]
+    public async Task ExportTinhHinhThucHienDauThau_WithFilters_ReturnsExcel()
+    {
+        var duAnId = "08dec1fd-220c-da70-687a-7b47980360c9";
+        var response = await AuthedClient.GetAsync(
+            $"/api/print/tinh-hinh-thuc-hien-dau-thau?loai=1&namDuAn=2026&giaiDoanId=22&duAnId={duAnId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should()
+            .Be("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+    }
+
+    [Fact]
+    public async Task ExportTinhHinhThucHienDauThau_GiaiDoanIdMinusOne_WithOtherFilters_ReturnsExcel()
+    {
+        var duAnId = "08dec1fd-220c-da70-687a-7b47980360c9";
+        var response = await AuthedClient.GetAsync(
+            $"/api/print/tinh-hinh-thuc-hien-dau-thau?loai=1&namDuAn=2026&giaiDoanId=-1&duAnId={duAnId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ExportTinhHinhThucHienDauThau_MultiSheet_WithFilters_ReturnsExcel()
+    {
+        var duAnId = "08dec1fd-220c-da70-687a-7b47980360c9";
+        var response = await AuthedClient.GetAsync(
+            $"/api/print/tinh-hinh-thuc-hien-dau-thau?namDuAn=2026&giaiDoanId=22&duAnId={duAnId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
 }

--- a/QLDA.Tests/Unit/GoiThauTinhHinhDauThauQueryableExtensionsTests.cs
+++ b/QLDA.Tests/Unit/GoiThauTinhHinhDauThauQueryableExtensionsTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using QLDA.Application.GoiThaus;
+using QLDA.Domain.Entities;
+using Xunit;
+
+namespace QLDA.Tests.Unit;
+
+public class GoiThauTinhHinhDauThauQueryableExtensionsTests
+{
+    private static readonly Guid MatchingDuAnId = Guid.Parse("08dec1fd-220c-da70-687a-7b47980360c9");
+
+    private static IQueryable<GoiThau> CreateSampleData() =>
+        new List<GoiThau>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                DuAnId = MatchingDuAnId,
+                DuAn = new DuAn
+                {
+                    GiaiDoanHienTaiId = 22,
+                    ThoiGianKhoiCong = 2026,
+                    ThoiGianHoanThanh = 2028,
+                    NgayBatDau = null,
+                },
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                DuAnId = Guid.NewGuid(),
+                DuAn = new DuAn
+                {
+                    GiaiDoanHienTaiId = 10,
+                    ThoiGianKhoiCong = 2025,
+                    ThoiGianHoanThanh = 2025,
+                },
+            },
+        }.AsQueryable();
+
+    [Fact]
+    public void ApplyFilters_WithAllParams_ReturnsSingleMatch()
+    {
+        var result = CreateSampleData()
+            .ApplyTinhHinhDauThauFilters(MatchingDuAnId, giaiDoanId: 22)
+            .ApplyTinhHinhDauThauNamDuAnFilter(2026)
+            .ToList();
+
+        result.Should().HaveCount(1);
+        result[0].DuAnId.Should().Be(MatchingDuAnId);
+    }
+
+    [Fact]
+    public void ApplyNamDuAnFilter_MatchesThoiGianKhoiCong_WhenNgayBatDauNull()
+    {
+        var result = CreateSampleData()
+            .ApplyTinhHinhDauThauNamDuAnFilter(2026)
+            .ToList();
+
+        result.Should().HaveCount(1);
+        result[0].DuAn!.NgayBatDau.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyNamFilter_RequiresNgayBatDau()
+    {
+        var result = CreateSampleData()
+            .ApplyTinhHinhDauThauNamFilter(2026)
+            .ToList();
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ApplyFilters_GiaiDoanIdMinusOne_DoesNotFilterByGiaiDoan()
+    {
+        var result = CreateSampleData()
+            .ApplyTinhHinhDauThauFilters(duAnId: null, giaiDoanId: -1)
+            .ToList();
+
+        result.Should().HaveCount(2);
+    }
+
+    [Theory]
+    [InlineData(1, 2)]
+    [InlineData(2, 0)]
+    public void ApplyTabFilter_FiltersByTrangThai(int trangThai, int expectedCount)
+    {
+        var result = CreateSampleData()
+            .ApplyTinhHinhDauThauTabFilter(trangThai)
+            .ToList();
+
+        result.Should().HaveCount(expectedCount);
+    }
+}

--- a/QLDA.Tests/Unit/KeHoachTrienKhaiHangMucExportMapperTests.cs
+++ b/QLDA.Tests/Unit/KeHoachTrienKhaiHangMucExportMapperTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using QLDA.Application.KeHoachTrienKhaiHangMucs;
+using QLDA.Domain.Entities;
+using Xunit;
+
+namespace QLDA.Tests.Unit;
+
+public class KeHoachTrienKhaiHangMucExportMapperTests
+{
+    [Fact]
+    public void ToExportRows_OrdersGroupsByProjectSort_NotGlobalName()
+    {
+        const int giaiDoanXin = 1;
+        const int giaiDoanCb = 2;
+
+        var hangMucs = new List<HangMucKeHoach>
+        {
+            CreateHangMuc("HM-3", giaiDoanCb, order: 3),
+            CreateHangMuc("HM-1", giaiDoanXin, order: 1),
+            CreateHangMuc("HM-2", giaiDoanXin, order: 2),
+        };
+
+        var sortById = new Dictionary<int, int>
+        {
+            [giaiDoanXin] = 1,
+            [giaiDoanCb] = 2,
+        };
+
+        var tenById = new Dictionary<int, string>
+        {
+            [giaiDoanXin] = "Xin chủ trương",
+            [giaiDoanCb] = "Chuẩn bị thực hiện đầu tư",
+        };
+
+        var rows = KeHoachTrienKhaiHangMucExportMapper.ToExportRows(
+            hangMucs, tenById, sortById,
+            new Dictionary<long, string>(),
+            new Dictionary<long, string>());
+
+        rows
+            .Where(r => r.IsGroupHeader)
+            .Select(r => r.GiaiDoan)
+            .Should()
+            .ContainInOrder("Xin chủ trương", "Chuẩn bị thực hiện đầu tư");
+    }
+
+    [Fact]
+    public void ToExportRows_PreservesItemOrderWithinGroup()
+    {
+        const int giaiDoanId = 10;
+        var hangMucs = new List<HangMucKeHoach>
+        {
+            CreateHangMuc("C", giaiDoanId, order: 1),
+            CreateHangMuc("A", giaiDoanId, order: 2),
+            CreateHangMuc("B", giaiDoanId, order: 3),
+        };
+
+        var rows = KeHoachTrienKhaiHangMucExportMapper.ToExportRows(
+            hangMucs,
+            new Dictionary<int, string> { [giaiDoanId] = "Giai đoạn A" },
+            new Dictionary<int, int> { [giaiDoanId] = 1 },
+            new Dictionary<long, string>(),
+            new Dictionary<long, string>());
+
+        rows.Where(r => !r.IsGroupHeader)
+            .Select(r => r.TenHangMuc)
+            .Should()
+            .ContainInOrder("C", "A", "B");
+    }
+
+    private static HangMucKeHoach CreateHangMuc(string ten, int giaiDoanId, int order) =>
+        new()
+        {
+            Id = Guid.NewGuid(),
+            TenHangMuc = ten,
+            GiaiDoanId = giaiDoanId,
+            CreatedAt = new DateTimeOffset(2025, 1, order, 0, 0, 0, TimeSpan.Zero),
+        };
+}

--- a/docs/issues/phieu-trinh-ke-hoach-print-duan-order/index.md
+++ b/docs/issues/phieu-trinh-ke-hoach-print-duan-order/index.md
@@ -1,0 +1,64 @@
+# Lỗi in phiếu trình KH triển khai — thiếu Dự án & sai thứ tự giai đoạn
+
+> Ngày ghi nhận: 06/07/2026  
+> Trạng thái: ✅ **IMPLEMENTED** (06/07/2026)  
+> Liên quan: [#9469 phieu-trinh-word-spec](../9469/phieu-trinh-word-spec.md), [print-fix trước đó](../phieu-trinh-ke-hoach-print-fix/index.md)
+
+## Tóm tắt
+
+API in phiếu trình Word (`GET /api/print/phieu-trinh-ke-hoach-trien-khai-hang-muc`) trước đây **không khớp UI** ở hai điểm. Đã fix trên BE:
+
+| # | Triệu chứng (trước fix) | Trạng thái |
+|---|------------------------|------------|
+| 1 | Dòng `Dự án:` trên file in **trống** dù form đã chọn dự án `t01` | ✅ Fixed (code) |
+| 2 | Thứ tự giai đoạn/hạng mục **đảo ngược** so với UI | ✅ Fixed (code) |
+
+## Endpoint
+
+```http
+GET /QuanLyDuAn/api/print/phieu-trinh-ke-hoach-trien-khai-hang-muc?id={keHoachId}
+Authorization: Bearer {token}
+Role: GroupKeHoachTrienKhaiHangMucExport
+```
+
+## Kết quả implement
+
+| Hạng mục | File | Trạng thái |
+|----------|------|------------|
+| Sort giai đoạn theo dự án | `KeHoachTrienKhaiHangMucImportGiaiDoanHelper.cs` | ✅ |
+| Group/item order | `KeHoachTrienKhaiHangMucExportMapper.cs` | ✅ |
+| Loader + DuAnId | `KeHoachTrienKhaiHangMucExportRowLoader.cs` | ✅ |
+| Print handler | `KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery.cs` | ✅ |
+| Excel export | `KeHoachTrienKhaiHangMucGetExportQuery.cs` | ✅ |
+| Unit test | `KeHoachTrienKhaiHangMucExportMapperTests.cs` | ✅ 2 tests |
+| Integration test | `KeHoachTrienKhaiHangMucPhieuTrinhPrintTests.cs` | ✅ Partial |
+
+## Điểm quan trọng
+
+| Vấn đề | Fix as-built |
+|--------|--------------|
+| Dự án trống | `EnsureDuAnLoadedAsync` fallback `_duAnRepo`; `DuAnDisplay` = `{MaDuAn} — {TenDuAn}` |
+| Sai thứ tự giai đoạn | `GetGiaiDoanSortByDuAnAsync` (`DuAnBuoc.Buoc.Stt`) thay `DanhMucGiaiDoan.Stt` |
+| Sai thứ tự HM | Giữ index list gốc; load HM `OrderBy CreatedAt` |
+| Excel | Cùng `ExportRowLoader` + `DuAnId` |
+
+## Acceptance Criteria
+
+- [x] Code fix DuAn + sort theo quy trình dự án
+- [x] Unit test mapper pass
+- [ ] QA manual: `Dự án:` hiển thị `t01` (hoặc `MaDuAn — TenDuAn`)
+- [ ] QA manual: thứ tự giai đoạn/hạng mục khớp UI
+- [ ] (Tuỳ chọn) `MaDuAn` trên GetQuery DTO cho FE
+
+## Tài liệu triển khai
+
+| File | Nội dung |
+|------|----------|
+| **[report.md](report.md)** | Spec as-built, luồng sau fix, test plan, checklist |
+| [phieu-trinh-word-spec](../9469/phieu-trinh-word-spec.md) | Spec gốc #9469 |
+
+## QA còn lại
+
+1. Mở form kế hoạch có dự án `t01` → in phiếu trình → kiểm tra dòng `Dự án:` và thứ tự group A/B.
+2. So sánh với grid UI: Xin chủ trương trước, Chuẩn bị THĐT sau; HM 1,2 / 3 đúng group.
+3. Export Excel cùng `id` — thứ tự group đồng bộ với phiếu trình.

--- a/docs/issues/phieu-trinh-ke-hoach-print-duan-order/report.md
+++ b/docs/issues/phieu-trinh-ke-hoach-print-duan-order/report.md
@@ -1,0 +1,952 @@
+# Spec kỹ thuật — Fix in phiếu trình: Dự án trống & sai thứ tự giai đoạn/hạng mục
+
+**Module:** QLDA — `KeHoachTrienKhaiHangMuc`  
+**Ngày:** 2026-07-06  
+**Trạng thái:** ✅ **IMPLEMENTED** (06/07/2026)  
+**Pattern tham chiếu:** [phieu-trinh-word-spec.md](../9469/phieu-trinh-word-spec.md), `KeHoachTrienKhaiHangMucImportGiaiDoanHelper`
+
+---
+
+## 0. Trạng thái implement
+
+| Hạng mục | Trạng thái | Ghi chú |
+|----------|------------|---------|
+| `GetGiaiDoanSortByDuAnAsync` (ImportGiaiDoanHelper) | ✅ Done | Reuse sort theo `DuAnBuoc.Buoc.Stt` |
+| `KeHoachTrienKhaiHangMucExportMapper` | ✅ Done | Group theo project order + giữ thứ tự item trong list gốc |
+| `KeHoachTrienKhaiHangMucExportRowLoader` | ✅ Done | Nhận `duAnId` + load sort/display name theo dự án |
+| `KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery` | ✅ Done | `EnsureDuAnLoadedAsync`, load HM `OrderBy CreatedAt`, truyền `DuAnId` |
+| `KeHoachTrienKhaiHangMucGetExportQuery` | ✅ Done | Truyền `DuAnId` vào loader (Excel đồng bộ) |
+| `KeHoachTrienKhaiHangMucExportMapperTests` | ✅ Done | 2 unit tests (group order + item order) |
+| `KeHoachTrienKhaiHangMucPhieuTrinhPrintTests` | ✅ Partial | Smoke HTTP 200 + empty guid; chưa assert `DuAnDisplay`/thứ tự group |
+| `GetQuery` trả `MaDuAn` (bước 9) | ⏳ Pending | Tuỳ chọn — print đã đủ `DuAnDisplay` |
+| QA manual Word vs UI | ⏳ Pending | Cần mở file `.docx` trên môi trường có data |
+
+---
+
+## Mục lục
+
+1. [Trạng thái implement](#0-trạng-thái-implement)
+2. [Hiện trạng lỗi](#1-hiện-trạng-lỗi)
+3. [Luồng code (sau fix)](#2-luồng-code-sau-fix)
+4. [So sánh UI vs Print](#3-so-sánh-ui-vs-print)
+5. [Root cause](#4-root-cause)
+6. [Thiết kế fix (as-built)](#5-thiết-kế-fix-as-built)
+7. [Files đã sửa](#6-files-đã-sửa)
+8. [Bước code chi tiết](#7-bước-code-chi-tiết)
+9. [Test plan](#8-test-plan)
+10. [Checklist nghiệm thu](#9-checklist-nghiệm-thu)
+
+---
+
+## 1. Hiện trạng lỗi
+
+### 1.1. Case báo cáo
+
+| Khía cạnh | Chi tiết |
+|-----------|----------|
+| **Endpoint** | `GET /api/print/phieu-trinh-ke-hoach-trien-khai-hang-muc?id={id}` |
+| **Form UI** | Đã chọn dự án `t01` |
+| **UI giai đoạn** | `I. Xin chủ trương` → HM 1, 2 · `II. Chuẩn bị thực hiện đầu tư` → HM 3 |
+| **Print giai đoạn** | `A. Giai đoạn chuẩn bị thực hiện đầu tư` · `B. Giai đoạn xin chủ trương đầu tư` (**đảo thứ tự**) |
+
+### 1.2. Acceptance Criteria
+
+| # | Tiêu chí | Pass khi |
+|---|----------|----------|
+| AC-1 | Dự án hiển thị | Dòng `Dự án:` không trống; khớp dự án user chọn trên form |
+| AC-2 | Thứ tự giai đoạn | Group đầu tiên trên print = group đầu tiên trên UI |
+| AC-3 | Thứ tự hạng mục | Trong mỗi giai đoạn, STT hạng mục khớp UI |
+| AC-4 | Không reorder tùy tiện | Không sort theo `Id` / tên giai đoạn / `DanhMucGiaiDoan.Stt` global |
+| AC-5 | Tương thích dữ liệu cũ | Phiếu đã duyệt / đã có trước fix vẫn in được, không lỗi |
+
+---
+
+## 2. Luồng code (sau fix)
+
+```mermaid
+sequenceDiagram
+    participant FE as FE (form chi tiết)
+    participant GetQuery as KeHoachTrienKhaiHangMucGetQuery
+    participant PrintQuery as KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery
+    participant RowLoader as ExportRowLoader
+    participant Mapper as ExportMapper
+    participant Word as WordExporter
+
+    FE->>GetQuery: GET api/ke-hoach-trien-khai-hang-muc/{id}
+    GetQuery-->>FE: DuAnId, TenDuAn, HangMucTrienKhai[] (flat, no reorder)
+    Note over FE: FE group theo GiaiDoanId<br/>+ order giai đoạn theo quy trình dự án<br/>+ Roman I, II, ...
+
+    FE->>PrintQuery: GET api/print/phieu-trinh-ke-hoach-trien-khai-hang-muc?id=
+    PrintQuery->>PrintQuery: Include(DuAn); load HM OrderBy CreatedAt
+    PrintQuery->>PrintQuery: EnsureDuAnLoadedAsync nếu navigation null
+    PrintQuery->>RowLoader: hangMucs[], keHoach.DuAnId
+    RowLoader->>RowLoader: GetGiaiDoanSortByDuAnAsync (Buoc.Stt)
+    RowLoader->>Mapper: ToExportRows(..., giaiDoanSortById theo dự án)
+    Mapper-->>PrintQuery: rows[] (group A,B đúng thứ tự UI)
+    PrintQuery->>Word: PhieuTrinhPrintDto
+    Word-->>FE: .docx
+```
+
+### 2.1. Files liên quan
+
+| File | Vai trò |
+|------|---------|
+| `QLDA.WebApi/Controllers/PrintController.cs` | Endpoint `InPhieuTrinhKeHoachTrienKhaiHangMuc` (~L1414) |
+| `QLDA.Application/.../KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery.cs` | Load header + hạng mục cho print |
+| `QLDA.Application/.../KeHoachTrienKhaiHangMucGetQuery.cs` | Load dữ liệu form UI |
+| `QLDA.Application/.../KeHoachTrienKhaiHangMucExportRowLoader.cs` | Load lookup + gọi mapper |
+| `QLDA.Application/.../KeHoachTrienKhaiHangMucExportMapper.cs` | **Group + sort** giai đoạn/hạng mục |
+| `QLDA.Application/.../KeHoachTrienKhaiHangMucImportGiaiDoanHelper.cs` | **Chuẩn thứ tự giai đoạn theo dự án** (đã có) |
+| `QLDA.Infrastructure/Offices/KeHoachTrienKhaiHangMucWordExporter.cs` | Fill `<DuAn>`, bảng hạng mục |
+
+---
+
+## 3. So sánh UI vs Print
+
+### 3.1. Dự án
+
+| Khía cạnh | UI (GetQuery) | Print (PhieuTrinhPrintQuery) |
+|-----------|---------------|------------------------------|
+| Nguồn | `e.DuAn.TenDuAn` (projection) | `keHoach.DuAn?.MaDuAn`, `TenDuAn` → `DuAnDisplay` |
+| DTO trả FE | `DuAnId`, `TenDuAn` — **không có `MaDuAn`** | `DuAnDisplay` = `{MaDuAn} — {TenDuAn}` hoặc fallback |
+| UI hiển thị `t01` | Thường từ combobox `MaDuAn` theo `DuAnId` | Phụ thuộc navigation `DuAn` load được hay không |
+
+**Format spec gốc (#9469):** `{MaDuAn} — {TenDuAn}`
+
+**Code hiện tại — build display:**
+
+```csharp
+// KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery.BuildDuAnDisplay
+if (!string.IsNullOrWhiteSpace(maDuAn) && !string.IsNullOrWhiteSpace(tenDuAn))
+    return $"{maDuAn} — {tenDuAn}";
+return maDuAn ?? tenDuAn ?? string.Empty;
+```
+
+**Word exporter — fill template:**
+
+```csharp
+// KeHoachTrienKhaiHangMucWordExporter.FillHeaderFields
+["<DuAn>"] = dto.DuAnDisplay ?? string.Empty,
+```
+
+→ Nếu `DuAnDisplay` rỗng thì dòng `Dự án:` trống dù placeholder replace thành công.
+
+### 3.2. Thứ tự giai đoạn
+
+| Khía cạnh | UI | Print / Export (trước fix) | Print / Export (sau fix) |
+|-----------|-----|------------------------------|--------------------------|
+| Group key | `HangMucTrienKhai.GiaiDoanId` | `HangMucKeHoach.GiaiDoanId` | Giữ nguyên |
+| Sort giai đoạn | **Quy trình dự án** (`DuAnBuoc.Buoc.Stt`) | `DanhMucGiaiDoan.Stt` global | **`GetGiaiDoanSortByDuAnAsync`** |
+| Label giai đoạn | `I.`, `II.` (Roman) + tên ngắn | `A.`, `B.` + tên danh mục | `A.`, `B.` + tên theo dự án (`GetGiaiDoanDisplayNameByDuAnAsync`) |
+| Sort hạng mục trong group | Thứ tự API / user nhập | `NgayBatDau` → `TenHangMuc` | **Index trong list gốc** (`CreatedAt` asc khi load) |
+
+**Ví dụ case báo cáo:**
+
+| Giai đoạn | `DanhMucGiaiDoan.Stt` (global) | `DuAnBuoc.Buoc.Stt` (dự án t01) |
+|-----------|-------------------------------|----------------------------------|
+| Chuẩn bị thực hiện đầu tư | 2 (in trước) | 2 |
+| Xin chủ trương | 1 | 1 |
+
+→ UI: Xin chủ trương (I) trước. Print sort theo global `Stt` → Chuẩn bị (A) trước → **đảo thứ tự**.
+
+### 3.3. Nguồn thứ tự đúng (đã có trong codebase)
+
+`KeHoachTrienKhaiHangMucImportGiaiDoanHelper.LoadRootPhasesByDuAnAsync` đã implement thứ tự giai đoạn **theo từng dự án**:
+
+```csharp
+// DuAnBuoc → Buoc.GiaiDoanId, SortOrder = Buoc.Stt
+.OrderBy(x => x.SortOrder)
+.ThenBy(x => x.DisplayName, StringComparer.OrdinalIgnoreCase)
+```
+
+Đây là **single source of truth** cho thứ tự giai đoạn trên form import/combobox — print cần reuse logic tương tự.
+
+---
+
+## 4. Root cause
+
+### 4.1. Bug #1 — Dự án trống
+
+| # | Giả thuyết | Xác suất | Cách verify |
+|---|-----------|----------|-------------|
+| R1-A | `Include(e => e.DuAn)` trả `null` (dự án bị filter soft-delete / auth) | Cao | SQL: `SELECT DuAnId FROM KeHoachTrienKhaiHangMuc WHERE Id = @id`; join `DuAn` |
+| R1-B | Dự án có `MaDuAn = 't01'` nhưng `TenDuAn` null — logic display OK, vấn đề là navigation null | Trung bình | Debug `keHoach.DuAn` trong print handler |
+| R1-C | UI hiển thị `t01` từ combobox chưa lưu (`DuAnId` trên entity khác / chưa persist) | Thấp | So sánh `DuAnId` trên entity vs form |
+| R1-D | Template Word placeholder không khớp `<DuAn>` | Thấp (các field khác điền được) | Mở template XML, tìm `<DuAn>` |
+
+**Kết luận:** Fix cần **fallback load `DuAn` theo `DuAnId`** khi navigation null, và đảm bảo `DuAnDisplay` luôn có ít nhất `MaDuAn` hoặc `TenDuAn` nếu entity tồn tại.
+
+### 4.2. Bug #2 — Sai thứ tự giai đoạn & hạng mục
+
+**Nguyên nhân trực tiếp** — `KeHoachTrienKhaiHangMucExportMapper.ToExportRows`:
+
+```csharp
+// ExportRowLoader truyền sort từ danh mục GLOBAL:
+giaiDoans.ToDictionary(g => g.Id, g => g.Stt ?? int.MaxValue - 1)
+
+// ExportMapper sort group:
+.OrderBy(g => g.SortOrder)      // ← DanhMucGiaiDoan.Stt
+.ThenBy(g => g.TenGiaiDoan)
+
+// Sort item trong group:
+Items = g.OrderBy(x => x.NgayBatDau).ThenBy(x => x.TenHangMuc).ToList()
+```
+
+**UI không dùng logic này** — `KeHoachTrienKhaiHangMucGetQuery` trả flat list, không reorder:
+
+```csharp
+HangMucTrienKhai = e.DanhSachHangMuc
+    .Where(x => !x.IsDeleted)
+    .Select(h => new HangMucTrienKhaiDto { ... })
+    .ToList()
+```
+
+FE tự group + sort theo quy trình dự án.
+
+**Kết luận:** Print/Excel export dùng sort rule **khác UI** → cần thống nhất sort theo **quy trình dự án** + **thứ tự hạng mục gốc**.
+
+---
+
+## 5. Thiết kế fix (as-built)
+
+### 5.1. Nhóm A — Dự án trên header phiếu trình
+
+| Bước | Hành động |
+|------|-----------|
+| A1 | Trong `LoadKeHoachForPrintAsync`, nếu `keHoach.DuAn == null` && `DuAnId != Guid.Empty` → load `DuAn` riêng qua `_duAnRepo` (AsNoTracking) |
+| A2 | `BuildDuAnDisplay`: ưu tiên `{MaDuAn} — {TenDuAn}`; fallback lần lượt `MaDuAn`, `TenDuAn`; trim whitespace |
+| A3 | (Tuỳ chọn) Bổ sung `MaDuAn` vào `KeHoachTrienKhaiHangMucDto` / GetQuery để FE và print đồng bộ — **ngoài scope tối thiểu** nếu print đã đủ |
+
+### 5.2. Nhóm B — Thứ tự giai đoạn & hạng mục
+
+| Bước | Hành động |
+|------|-----------|
+| B1 | Mở rộng `ExportRowLoader.LoadAsync` nhận thêm `duAnId` + `duAnBuocRepo` |
+| B2 | Load phase order qua logic reuse từ `ImportGiaiDoanHelper` (extract shared method nếu cần) |
+| B3 | `ExportMapper.ToExportRows`: sort group theo **project phase order**; tie-break bằng thứ tự xuất hiện đầu tiên trong `hangMucs` |
+| B4 | Sort item trong group: **`CreatedAt` asc** (hoặc index trong list gốc), **không** sort `NgayBatDau`/`TenHangMuc` khi in phiếu trình |
+| B5 | Excel export: quyết định dùng chung sort mới (khuyến nghị **có** — đồng bộ với UI) |
+
+### 5.3. Nhóm C — Label giai đoạn (tuỳ BA)
+
+| Option | Mô tả | Khuyến nghị |
+|--------|-------|-------------|
+| C1 | Giữ `A.`, `B.` như spec #9469 | Chỉ fix thứ tự, không đổi format |
+| C2 | Đổi sang Roman `I.`, `II.` giống UI | Cần xác nhận BA — **không bắt buộc** cho AC hiện tại |
+
+> AC user yêu cầu **thứ tự giống UI**, không nhất thiết đổi `A/B` → `I/II`. Ưu tiên fix sort trước.
+
+### 5.4. Nhóm D — Lọc hạng mục đã xóa
+
+Print hiện lấy **tất cả** `DanhSachHangMuc` (kể cả `IsDeleted`):
+
+```csharp
+var hangMucs = keHoach.DanhSachHangMuc?.ToList() ?? [];
+```
+
+GetQuery lọc `!x.IsDeleted`. **Nên đồng bộ:**
+
+```csharp
+var hangMucs = keHoach.DanhSachHangMuc?
+    .Where(x => !x.IsDeleted)
+    .ToList() ?? [];
+```
+
+---
+
+## 6. Files đã sửa
+
+| File | Thay đổi | Trạng thái |
+|------|----------|------------|
+| `KeHoachTrienKhaiHangMucImportGiaiDoanHelper.cs` | `GetGiaiDoanSortByDuAnAsync` | ✅ |
+| `KeHoachTrienKhaiHangMucExportMapper.cs` | Sort group theo `giaiDoanSortById`; item theo index list gốc | ✅ |
+| `KeHoachTrienKhaiHangMucExportRowLoader.cs` | `duAnId` + `duAnBuocRepo`; load sort + display name theo dự án | ✅ |
+| `KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery.cs` | `EnsureDuAnLoadedAsync`; HM query `OrderBy CreatedAt`; truyền `DuAnId` | ✅ |
+| `KeHoachTrienKhaiHangMucGetExportQuery.cs` | Truyền `duAnId` vào loader | ✅ |
+| `KeHoachTrienKhaiHangMucExportMapperTests.cs` | 2 unit tests | ✅ |
+| `KeHoachTrienKhaiHangMucPhieuTrinhPrintTests.cs` | Smoke docx + empty guid | ✅ Partial |
+| `KeHoachTrienKhaiHangMucGetQuery.cs` / DTO | Bổ sung `MaDuAn` | ⏳ Pending |
+
+**Không sửa:** migration, template Word, `PrintController`.
+
+---
+
+## 7. Bước code chi tiết
+
+> ✅ **Đã implement** theo thứ tự dưới đây. Phần dưới giữ nguyên làm tài liệu tham chiếu; **source truth** là code trong §6.
+
+### Tóm tắt as-built
+
+**Print handler** (`KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery`):
+
+```csharp
+var keHoach = await LoadKeHoachForPrintAsync(...);          // Include(DuAn)
+await EnsureDuAnLoadedAsync(keHoach, ...);                  // fallback _duAnRepo
+var hangMucs = await LoadHangMucsForKeHoachAsync(...);      // OrderBy CreatedAt, ThenBy Id
+var rows = await ExportRowLoader.LoadAsync(hangMucs, keHoach.DuAnId, ...);
+DuAnDisplay = BuildDuAnDisplay(maDuAn, tenDuAn);            // "{MaDuAn} — {TenDuAn}"
+```
+
+**ExportRowLoader** — khi có `duAnId`:
+
+```csharp
+giaiDoanSortById = await ImportGiaiDoanHelper.GetGiaiDoanSortByDuAnAsync(...);
+// + GetGiaiDoanDisplayNameByDuAnAsync cho tên giai đoạn trên phiếu
+```
+
+**ExportMapper** — sort group theo `SortOrder` (project), item theo `itemIndexById` (thứ tự list gốc).
+
+> **Thứ tự implement (đã xong):** Helper sort giai đoạn → ExportMapper → ExportRowLoader → PrintQuery → ExportQuery → Unit test → Integration test → Build & QA.
+
+---
+
+### Bước 1 — Extract `GetGiaiDoanSortByDuAnAsync` (shared helper)
+
+**File:** `QLDA.Application/KeHoachTrienKhaiHangMuc/KeHoachTrienKhaiHangMucImportGiaiDoanHelper.cs`
+
+Thêm method **public internal** để print/export reuse logic đã có trong `LoadRootPhasesByDuAnAsync`:
+
+```csharp
+/// <summary>
+/// GiaiDoanId → SortOrder theo quy trình dự án (DuAnBuoc.Buoc.Stt).
+/// Dùng chung import combo, Excel export, Word phiếu trình.
+/// </summary>
+internal static async Task<IReadOnlyDictionary<int, int>> GetGiaiDoanSortByDuAnAsync(
+    Guid duAnId,
+    IRepository<DuAnBuoc, int> duAnBuocRepo,
+    IRepository<DanhMucGiaiDoan, int> giaiDoanRepo,
+    CancellationToken cancellationToken = default)
+{
+    var phasesByDuAn = await LoadRootPhasesByDuAnAsync(
+        duAnBuocRepo,
+        giaiDoanRepo,
+        [duAnId],
+        cancellationToken);
+
+    if (!phasesByDuAn.TryGetValue(duAnId, out var phases) || phases.Count == 0)
+        return new Dictionary<int, int>();
+
+    return phases.ToDictionary(p => p.GiaiDoanId, p => p.SortOrder);
+}
+```
+
+> **Không tạo file mới** — giữ logic giai đoạn tập trung một chỗ, tránh drift với import template.
+
+---
+
+### Bước 2 — Sửa `KeHoachTrienKhaiHangMucExportMapper`
+
+**File:** `QLDA.Application/KeHoachTrienKhaiHangMuc/KeHoachTrienKhaiHangMucExportMapper.cs`
+
+**2a.** Build index map **một lần** từ list gốc (thứ tự UI = thứ tự `hangMucs` truyền vào):
+
+```csharp
+var items = hangMucs.ToList();
+if (items.Count == 0)
+    return [];
+
+// Index trong list gốc — tie-break group + sort item trong group
+var itemIndexById = items
+    .Select((h, i) => (h.Id, i))
+    .ToDictionary(x => x.Id, x => x.i);
+
+var firstGroupIndexByGiaiDoanId = items
+    .Select((h, i) => (h.GiaiDoanId, i))
+    .GroupBy(x => x.GiaiDoanId)
+    .ToDictionary(g => g.Key, g => g.Min(x => x.i));
+```
+
+**2b.** Thay sort item trong group — **xóa** `OrderBy(NgayBatDau).ThenBy(TenHangMuc)`:
+
+```csharp
+// ❌ TRƯỚC
+Items = g.OrderBy(x => x.NgayBatDau).ThenBy(x => x.TenHangMuc).ToList(),
+
+// ✅ SAU
+Items = g.OrderBy(x => itemIndexById.GetValueOrDefault(x.Id, int.MaxValue)).ToList(),
+```
+
+**2c.** Thay sort group — dùng project order + tie-break index:
+
+```csharp
+var groups = items
+    .GroupBy(h => h.GiaiDoanId)
+    .Select(g => { /* ... giữ nguyên build KeHoachTrienKhaiGroupByGiaiDoanDto ... */ })
+    .OrderBy(g => g.SortOrder)
+    .ThenBy(g => firstGroupIndexByGiaiDoanId.GetValueOrDefault(g.GiaiDoanId, int.MaxValue))
+    .ToList();
+```
+
+**2d.** **Xóa** `.ThenBy(g => g.TenGiaiDoan)` — tránh reorder theo tên khi `SortOrder` trùng.
+
+**Toàn bộ method sau khi sửa:**
+
+```csharp
+public static List<KeHoachTrienKhaiHangMucExportItemDto> ToExportRows(
+    IEnumerable<HangMucKeHoach> hangMucs,
+    IReadOnlyDictionary<int, string> giaiDoanTenById,
+    IReadOnlyDictionary<int, int> giaiDoanSortById,
+    IReadOnlyDictionary<long, string> donViTenById,
+    IReadOnlyDictionary<long, string> userTenById)
+{
+    var items = hangMucs.ToList();
+    if (items.Count == 0)
+        return [];
+
+    var itemIndexById = items
+        .Select((h, i) => (h.Id, i))
+        .ToDictionary(x => x.Id, x => x.i);
+
+    var firstGroupIndexByGiaiDoanId = items
+        .Select((h, i) => (h.GiaiDoanId, i))
+        .GroupBy(x => x.GiaiDoanId)
+        .ToDictionary(g => g.Key, g => g.Min(x => x.i));
+
+    var groups = items
+        .GroupBy(h => h.GiaiDoanId)
+        .Select(g =>
+        {
+            if (g.Key is int id && giaiDoanTenById.TryGetValue(id, out var ten))
+            {
+                return new KeHoachTrienKhaiGroupByGiaiDoanDto
+                {
+                    GiaiDoanId = id,
+                    TenGiaiDoan = ten,
+                    SortOrder = giaiDoanSortById.GetValueOrDefault(id, int.MaxValue - 1),
+                    Items = g.OrderBy(x => itemIndexById.GetValueOrDefault(x.Id, int.MaxValue)).ToList(),
+                };
+            }
+
+            return new KeHoachTrienKhaiGroupByGiaiDoanDto
+            {
+                GiaiDoanId = null,
+                TenGiaiDoan = KhacGiaiDoanTen,
+                SortOrder = int.MaxValue,
+                Items = g.OrderBy(x => itemIndexById.GetValueOrDefault(x.Id, int.MaxValue)).ToList(),
+            };
+        })
+        .OrderBy(g => g.SortOrder)
+        .ThenBy(g => firstGroupIndexByGiaiDoanId.GetValueOrDefault(g.GiaiDoanId, int.MaxValue))
+        .ToList();
+
+    var rows = new List<KeHoachTrienKhaiHangMucExportItemDto>();
+    for (var groupIndex = 0; groupIndex < groups.Count; groupIndex++)
+    {
+        var group = groups[groupIndex];
+        rows.Add(new KeHoachTrienKhaiHangMucExportItemDto
+        {
+            Stt = ToGroupLetter(groupIndex),
+            GiaiDoan = group.TenGiaiDoan,
+            IsGroupHeader = true,
+        });
+
+        var itemStt = 1;
+        foreach (var hangMuc in group.Items)
+            rows.Add(MapItem(hangMuc, itemStt++, donViTenById, userTenById));
+    }
+
+    return rows;
+}
+```
+
+---
+
+### Bước 3 — Sửa `KeHoachTrienKhaiHangMucExportRowLoader`
+
+**File:** `QLDA.Application/KeHoachTrienKhaiHangMuc/KeHoachTrienKhaiHangMucExportRowLoader.cs`
+
+**3a.** Thêm parameter `duAnId` + `duAnBuocRepo`:
+
+```csharp
+public static async Task<List<KeHoachTrienKhaiHangMucExportItemDto>> LoadAsync(
+    IReadOnlyList<HangMucKeHoach> hangMucs,
+    Guid? duAnId,
+    IRepository<DanhMucGiaiDoan, int> giaiDoanRepo,
+    IRepository<DuAnBuoc, int> duAnBuocRepo,
+    IRepository<DmDonVi, long> donViRepo,
+    IRepository<UserMaster, long> userRepo,
+    CancellationToken cancellationToken = default)
+```
+
+**3b.** Thay cách build `giaiDoanSortById`:
+
+```csharp
+Dictionary<int, int> giaiDoanSortById;
+
+if (duAnId is Guid projectId && projectId != Guid.Empty)
+{
+    giaiDoanSortById = new Dictionary<int, int>(
+        await KeHoachTrienKhaiHangMucImportGiaiDoanHelper.GetGiaiDoanSortByDuAnAsync(
+            projectId, duAnBuocRepo, giaiDoanRepo, cancellationToken));
+
+    // Giai đoạn có trong hạng mục nhưng không thuộc quy trình dự án → cuối list
+    foreach (var id in giaiDoanIds.Where(id => !giaiDoanSortById.ContainsKey(id)))
+        giaiDoanSortById[id] = int.MaxValue - 1;
+}
+else
+{
+    // Bulk export không có DuAnId — fallback danh mục global
+    giaiDoanSortById = giaiDoans.ToDictionary(g => g.Id, g => g.Stt ?? int.MaxValue - 1);
+}
+```
+
+**3c.** Giữ nguyên phần lookup `donVi` / `user`; gọi mapper:
+
+```csharp
+return KeHoachTrienKhaiHangMucExportMapper.ToExportRows(
+    hangMucs,
+    giaiDoans.ToDictionary(g => g.Id, g => g.Ten ?? string.Empty),
+    giaiDoanSortById,
+    donVis.ToDictionary(d => d.Id, d => d.TenDonVi ?? string.Empty),
+    users.ToDictionary(u => u.Id, u => u.HoTen ?? string.Empty));
+```
+
+> **Lưu ý thứ tự list:** Caller phải truyền `hangMucs` đã sort theo thứ tự UI (`CreatedAt` asc hoặc thứ tự collection) **trước** khi gọi `LoadAsync`.
+
+---
+
+### Bước 4 — Sửa `KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery`
+
+**File:** `QLDA.Application/KeHoachTrienKhaiHangMuc/Queries/KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery.cs`
+
+**4a.** Inject thêm `_duAnRepo`:
+
+```csharp
+private readonly IRepository<DuAn, Guid> _duAnRepo =
+    serviceProvider.GetRequiredService<IRepository<DuAn, Guid>>();
+```
+
+**4b.** Thêm helper resolve DuAn + sort hạng mục:
+
+```csharp
+private async Task EnsureDuAnLoadedAsync(
+    KeHoachTrienKhaiHangMuc keHoach,
+    CancellationToken cancellationToken)
+{
+    if (keHoach.DuAn != null || keHoach.DuAnId == Guid.Empty)
+        return;
+
+    keHoach.DuAn = await _duAnRepo.GetQueryableSet()
+        .AsNoTracking()
+        .FirstOrDefaultAsync(d => d.Id == keHoach.DuAnId, cancellationToken);
+}
+
+private static List<HangMucKeHoach> GetVisibleHangMucsInUiOrder(
+    ICollection<HangMucKeHoach>? danhSachHangMuc) =>
+    danhSachHangMuc?
+        .Where(x => !x.IsDeleted)
+        .OrderBy(x => x.CreatedAt)
+        .ThenBy(x => x.Id)
+        .ToList() ?? [];
+```
+
+**4c.** Sửa `Handle`:
+
+```csharp
+public async Task<KeHoachTrienKhaiHangMucPhieuTrinhPrintDto> Handle(
+    KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery request,
+    CancellationToken cancellationToken = default)
+{
+    var keHoach = await LoadKeHoachForPrintAsync(request.Id, cancellationToken);
+
+    ManagedException.ThrowIfNull(keHoach, "Không tìm thấy dữ liệu");
+
+    await EnsureDuAnLoadedAsync(keHoach, cancellationToken);
+
+    var hangMucs = GetVisibleHangMucsInUiOrder(keHoach.DanhSachHangMuc);
+
+    var rows = hangMucs.Count == 0
+        ? []
+        : await KeHoachTrienKhaiHangMucExportRowLoader.LoadAsync(
+            hangMucs,
+            keHoach.DuAnId,
+            _giaiDoanRepo,
+            _duAnBuocRepo,
+            _donViRepo,
+            _userRepo,
+            cancellationToken);
+
+    var maDuAn = keHoach.DuAn?.MaDuAn?.Trim();
+    var tenDuAn = keHoach.DuAn?.TenDuAn?.Trim();
+
+    return new KeHoachTrienKhaiHangMucPhieuTrinhPrintDto
+    {
+        So = keHoach.So,
+        NgayToTrinh = keHoach.NgayToTrinh,
+        TrichYeu = keHoach.TrichYeu,
+        MaDuAn = maDuAn,
+        TenDuAn = tenDuAn,
+        DuAnDisplay = BuildDuAnDisplay(maDuAn, tenDuAn),
+        Rows = rows,
+    };
+}
+```
+
+**4d.** Cải thiện `BuildDuAnDisplay` (trim + fallback rõ ràng):
+
+```csharp
+private static string BuildDuAnDisplay(string? maDuAn, string? tenDuAn)
+{
+    var ma = maDuAn?.Trim();
+    var ten = tenDuAn?.Trim();
+
+    if (!string.IsNullOrEmpty(ma) && !string.IsNullOrEmpty(ten))
+        return $"{ma} — {ten}";
+
+    if (!string.IsNullOrEmpty(ma))
+        return ma;
+
+    return ten ?? string.Empty;
+}
+```
+
+**Điểm quan trọng:**
+
+| Trước | Sau |
+|-------|-----|
+| `Include(DuAn)` only — có thể null | Fallback query `DuAn` theo `DuAnId` |
+| Lấy all `DanhSachHangMuc` kể cả deleted | Lọc `!IsDeleted` giống GetQuery |
+| Không sort hạng mục trước export | `OrderBy(CreatedAt).ThenBy(Id)` giống thứ tự insert |
+| Loader không biết `DuAnId` | Truyền `keHoach.DuAnId` → sort giai đoạn theo quy trình dự án |
+
+---
+
+### Bước 5 — Sửa `KeHoachTrienKhaiHangMucGetExportQuery`
+
+**File:** `QLDA.Application/KeHoachTrienKhaiHangMuc/Queries/KeHoachTrienKhaiHangMucGetExportQuery.cs`
+
+**5a.** Sửa `LoadHangMucsAsync` — khi export theo `Id`, lấy kèm `DuAnId` và sort hạng mục:
+
+```csharp
+if (hasId)
+{
+    var keHoach = await queryable.FirstOrDefaultAsync(cancellationToken);
+    var hangMucs = keHoach?.DanhSachHangMuc?
+        .Where(x => !x.IsDeleted)
+        .OrderBy(x => x.CreatedAt)
+        .ThenBy(x => x.Id)
+        .ToList() ?? [];
+
+    return (hangMucs, keHoach?.DuAnId);
+}
+```
+
+Đổi return type method thành `(List<HangMucKeHoach> HangMucs, Guid? DuAnId)` hoặc tách riêng biến `duAnId` trong `Handle`.
+
+**5b.** Sửa lời gọi loader trong `Handle`:
+
+```csharp
+var (hangMucs, duAnId) = await LoadHangMucsWithContextAsync(queryable, request, cancellationToken);
+
+ManagedException.ThrowIf(hangMucs.Count == 0, "Không có dữ liệu để xuất");
+
+return await KeHoachTrienKhaiHangMucExportRowLoader.LoadAsync(
+    hangMucs,
+    duAnId ?? request.DuAnId,
+    _giaiDoanRepo,
+    _duAnBuocRepo,
+    _donViRepo,
+    _userRepo,
+    cancellationToken);
+```
+
+**5c.** Bulk export (không có `Id` / `DuAnId`):
+
+- Giữ behavior cũ: `duAnId = null` → fallback `DanhMucGiaiDoan.Stt`.
+- Sort hạng mục trong mỗi kế hoạch theo `CreatedAt` trước khi `SelectMany`.
+
+---
+
+### Bước 6 — Unit test `ExportMapper` (khuyến nghị)
+
+**File mới:** `QLDA.Tests/Unit/KeHoachTrienKhaiHangMucExportMapperTests.cs`
+
+```csharp
+using FluentAssertions;
+using QLDA.Application.KeHoachTrienKhaiHangMucs;
+using QLDA.Domain.Entities;
+using Xunit;
+
+namespace QLDA.Tests.Unit;
+
+public class KeHoachTrienKhaiHangMucExportMapperTests
+{
+    [Fact]
+    public void ToExportRows_OrdersGroupsByProjectSort_NotGlobalName()
+    {
+        var giaiDoanXin = 1;
+        var giaiDoanCb = 2;
+
+        var hangMucs = new List<HangMucKeHoach>
+        {
+            CreateHangMuc("HM-3", giaiDoanCb, order: 3),
+            CreateHangMuc("HM-1", giaiDoanXin, order: 1),
+            CreateHangMuc("HM-2", giaiDoanXin, order: 2),
+        };
+
+        var sortById = new Dictionary<int, int>
+        {
+            [giaiDoanXin] = 1,  // Xin chủ trương trước
+            [giaiDoanCb] = 2,   // Chuẩn bị sau
+        };
+
+        var tenById = new Dictionary<int, string>
+        {
+            [giaiDoanXin] = "Xin chủ trương",
+            [giaiDoanCb] = "Chuẩn bị thực hiện đầu tư",
+        };
+
+        var rows = KeHoachTrienKhaiHangMucExportMapper.ToExportRows(
+            hangMucs, tenById, sortById, [], []);
+
+        var groupNames = rows
+            .Where(r => r.IsGroupHeader)
+            .Select(r => r.GiaiDoan)
+            .ToList();
+
+        groupNames.Should().ContainInOrder("Xin chủ trương", "Chuẩn bị thực hiện đầu tư");
+    }
+
+    [Fact]
+    public void ToExportRows_PreservesItemOrderWithinGroup()
+    {
+        var giaiDoanId = 10;
+        var hangMucs = new List<HangMucKeHoach>
+        {
+            CreateHangMuc("C", giaiDoanId, order: 1),
+            CreateHangMuc("A", giaiDoanId, order: 2),
+            CreateHangMuc("B", giaiDoanId, order: 3),
+        };
+
+        var rows = KeHoachTrienKhaiHangMucExportMapper.ToExportRows(
+            hangMucs,
+            new Dictionary<int, string> { [giaiDoanId] = "Giai đoạn A" },
+            new Dictionary<int, int> { [giaiDoanId] = 1 },
+            [], []);
+
+        rows.Where(r => !r.IsGroupHeader)
+            .Select(r => r.TenHangMuc)
+            .Should()
+            .ContainInOrder("C", "A", "B");
+    }
+
+    private static HangMucKeHoach CreateHangMuc(string ten, int giaiDoanId, int order)
+    {
+        var id = Guid.NewGuid();
+        return new HangMucKeHoach
+        {
+            Id = id,
+            TenHangMuc = ten,
+            GiaiDoanId = giaiDoanId,
+            CreatedAt = new DateTimeOffset(2025, 1, order, 0, 0, 0, TimeSpan.Zero),
+        };
+    }
+}
+```
+
+> Nếu `ExportMapper` là `internal`, thêm vào `QLDA.Tests/AssemblyInfo.cs` hoặc `InternalsVisibleTo` (project Application thường đã cấu hình).
+
+---
+
+### Bước 7 — Bổ sung integration test
+
+**File:** `QLDA.Tests/Integration/KeHoachTrienKhaiHangMucPhieuTrinhPrintTests.cs`
+
+Thêm test parse docx (cần Aspose license trong test env) **hoặc** test MediatR trực tiếp:
+
+```csharp
+[Fact]
+public async Task PrintQuery_DuAnDisplay_NotEmpty_ForKnownKeHoach()
+{
+    using var scope = fixture.Services.CreateScope();
+    var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+    var dto = await mediator.Send(new KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery
+    {
+        Id = Guid.Parse(TestKeHoachId),
+    });
+
+    dto.DuAnDisplay.Should().NotBeNullOrWhiteSpace(
+        "phiếu trình phải hiển thị dự án khi KeHoach có DuAnId");
+}
+
+[Fact]
+public async Task PrintQuery_FirstGroup_IsXinChuTruong_WhenProjectOrderSaysSo()
+{
+    using var scope = fixture.Services.CreateScope();
+    var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+    var dto = await mediator.Send(new KeHoachTrienKhaiHangMucGetPhieuTrinhPrintQuery
+    {
+        Id = Guid.Parse(TestKeHoachId),
+    });
+
+    var firstGroup = dto.Rows.First(r => r.IsGroupHeader);
+    firstGroup.GiaiDoan.Should().ContainEquivalentOf("xin chủ trương",
+        opts => opts.Using<string>(ctx =>
+            ctx.Subject.Contains(ctx.Expectation, StringComparison.OrdinalIgnoreCase)).WhenTypeIs<string>());
+}
+```
+
+---
+
+### Bước 8 — Build & verify
+
+```powershell
+cd e:\SER
+
+# Build
+dotnet build QLDA.sln -c Release
+
+# Unit test mapper
+dotnet test QLDA.Tests\QLDA.Tests.csproj --filter "FullyQualifiedName~KeHoachTrienKhaiHangMucExportMapper"
+
+# Integration test print
+dotnet test QLDA.Tests\QLDA.Tests.csproj --filter "FullyQualifiedName~KeHoachTrienKhaiHangMucPhieuTrinh"
+
+# Manual QA
+curl -s -D - ^
+  "http://192.168.1.12:9051/QuanLyDuAn/api/print/phieu-trinh-ke-hoach-trien-khai-hang-muc?id={KE_HOACH_ID}" ^
+  -H "Authorization: Bearer <JWT_TOKEN>" ^
+  -o phieu-trinh-test.docx
+```
+
+**Kỳ vọng sau fix:**
+
+| Check | Kỳ vọng |
+|-------|---------|
+| Dòng `Dự án:` | Có nội dung, chứa `t01` (hoặc `MaDuAn — TenDuAn`) |
+| Group đầu tiên | Xin chủ trương (theo quy trình dự án) |
+| Group thứ hai | Chuẩn bị thực hiện đầu tư |
+| HM trong group 1 | 1, 2 theo thứ tự UI |
+| HM trong group 2 | 3 |
+| Excel export cùng `id` | Thứ tự group giống phiếu trình |
+
+**SQL verify khi DuAn vẫn trống:**
+
+```sql
+SELECT kh.Id, kh.DuAnId, da.MaDuAn, da.TenDuAn, da.IsDeleted
+FROM KeHoachTrienKhaiHangMuc kh
+LEFT JOIN DuAn da ON da.Id = kh.DuAnId
+WHERE kh.Id = '{KE_HOACH_ID}';
+```
+
+| Kết quả | Hành động |
+|---------|-----------|
+| `DuAnId` có, `MaDuAn`/`TenDuAn` có | Fix code path — debug `EnsureDuAnLoadedAsync` |
+| `DuAnId` có, join `DuAn` null | Dự án bị xóa — hiển thị fallback `DuAnId` hoặc message |
+| `DuAnId` empty | Lỗi dữ liệu — user chưa lưu dự án trên kế hoạch |
+
+**SQL verify thứ tự giai đoạn:**
+
+```sql
+SELECT dab.DuAnId, b.GiaiDoanId, gd.Ten, b.Stt AS BuocStt, gd.Stt AS DanhMucStt
+FROM DuAnBuoc dab
+JOIN Buoc b ON b.Id = dab.BuocId
+JOIN DanhMucGiaiDoan gd ON gd.Id = b.GiaiDoanId
+WHERE dab.DuAnId = '{DU_AN_ID}'
+  AND (b.ParentId IS NULL OR b.ParentId = 0)
+ORDER BY b.Stt;
+```
+
+So sánh `BuocStt` với thứ tự group trên UI — print phải khớp `BuocStt`, **không** khớp `DanhMucStt` nếu hai cột khác nhau.
+
+---
+
+### Bước 9 (tùy chọn) — Đồng bộ GetQuery trả `MaDuAn`
+
+**File:** `QLDA.Application/KeHoachTrienKhaiHangMuc/Queries/KeHoachTrienKhaiHangMucGetQuery.cs`
+
+Ngoài scope tối thiểu, nhưng giúp FE và print nhất quán:
+
+```csharp
+// Trong Select projection:
+MaDuAn = e.DuAn != null ? e.DuAn.MaDuAn : string.Empty,
+TenDuAn = e.DuAn != null ? e.DuAn.TenDuAn : string.Empty,
+```
+
+**File:** `QLDA.Application/KeHoachTrienKhaiHangMuc/DTOs/KeHoachTrienKhaiHangMucDto.cs`
+
+```csharp
+public string? MaDuAn { get; set; }
+```
+
+---
+
+## 8. Test plan
+
+### 8.1. Manual — case báo cáo
+
+1. Mở form kế hoạch có dự án `t01`, giai đoạn I → II như mô tả.
+2. Gọi print API với `id` của kế hoach.
+3. Mở file Word:
+   - [ ] `Dự án:` có nội dung (chứa `t01`)
+   - [ ] Group đầu: Xin chủ trương (hoặc tương đương)
+   - [ ] Group sau: Chuẩn bị thực hiện đầu tư
+   - [ ] HM 1, 2 under group 1; HM 3 under group 2
+
+### 8.2. Integration test (bổ sung)
+
+```csharp
+[Fact]
+public async Task Print_DuAnDisplay_NotEmpty_WhenKeHoachHasDuAn() { ... }
+
+[Fact]
+public async Task Print_GiaiDoanOrder_MatchesProjectWorkflow() { ... }
+```
+
+Parse `.docx` bằng Aspose hoặc assert qua unit test trực tiếp `ExportMapper` với fixture data (nhanh hơn).
+
+### 8.3. Unit test ExportMapper
+
+| Case | Input | Expected group order |
+|------|-------|---------------------|
+| TC-1 | 2 giai đoạn, Buoc.Stt: Xin=1, CB=2 | Xin trước CB |
+| TC-2 | 3 HM cùng giai đoạn, CreatedAt A→B→C | A, B, C (không sort theo tên) |
+| TC-3 | Giai đoạn không thuộc quy trình dự án | Cuối list (SortOrder = Max) |
+
+### 8.4. Regression
+
+- ID test cũ: `30e8aa4e-4c4f-4c3d-8e0f-c419e941e44d` — vẫn HTTP 200 + file mở được.
+- Excel export `GET /api/print/ke-hoach-trien-khai-hang-muc?id=...` — thứ tự đồng bộ (smoke test).
+
+### 8.5. curl
+
+```bash
+curl --location \
+  'http://192.168.1.12:9051/QuanLyDuAn/api/print/phieu-trinh-ke-hoach-trien-khai-hang-muc?id={KE_HOACH_ID}' \
+  --header 'Authorization: Bearer {JWT}' \
+  --output phieu-trinh-test.docx
+```
+
+---
+
+## 9. Checklist nghiệm thu
+
+- [x] Code: `EnsureDuAnLoadedAsync` + `BuildDuAnDisplay` trên print handler
+- [x] Code: sort giai đoạn theo `GetGiaiDoanSortByDuAnAsync` (không `DanhMucGiaiDoan.Stt` global)
+- [x] Code: giữ thứ tự hạng mục theo list gốc / `CreatedAt`
+- [x] Excel export dùng chung `ExportRowLoader` + `DuAnId`
+- [x] Unit test `KeHoachTrienKhaiHangMucExportMapperTests` (2 tests) pass
+- [x] `dotnet build` pass
+- [ ] AC-1: QA manual — `Dự án:` không trống với dự án `t01`
+- [ ] AC-2: QA manual — thứ tự giai đoạn khớp UI
+- [ ] AC-3: QA manual — thứ tự hạng mục khớp UI
+- [ ] AC-5: Phiếu cũ / đã duyệt — regression manual
+- [ ] Integration test assert `DuAnDisplay` + thứ tự group (§7 bước 7 — chưa thêm)
+- [ ] (Tuỳ chọn) `MaDuAn` trên GetQuery DTO
+
+---
+
+## Phụ lục — Diagram sort logic (sau fix)
+
+```mermaid
+flowchart TD
+    A[DanhSachHangMuc từ DB] --> B[Lọc IsDeleted]
+    B --> C[Group by GiaiDoanId]
+    C --> D[Sort group theo DuAnBuoc.Buoc.Stt]
+    D --> E[Tie-break: index xuất hiện đầu trong list gốc]
+    E --> F[Sort item trong group theo CreatedAt / list index]
+    F --> G[ExportMapper → rows A,B,1,2,...]
+    G --> H[WordExporter → .docx]
+```

--- a/docs/issues/tinh-hinh-thuc-hien-dau-thau-print-filter/index.md
+++ b/docs/issues/tinh-hinh-thuc-hien-dau-thau-print-filter/index.md
@@ -1,0 +1,61 @@
+# Lỗi API in Excel — Tình hình thực hiện đấu thầu chưa lọc theo bộ lọc
+
+> Ngày ghi nhận: 06/07/2026  
+> Trạng thái: ✅ **IMPLEMENTED** (06/07/2026)  
+> Effort thực tế: ~2 giờ (BE only, không migration)
+
+## Tóm tắt
+
+API export Excel `GET /api/print/tinh-hinh-thuc-hien-dau-thau` trước đây **chỉ lọc theo tab** (`loai`). Đã bổ sung filter `namDuAn`, `giaiDoanId`, `duAnId` trên query print — dữ liệu Excel khớp bộ lọc UI.
+
+| # | Triệu chứng (trước fix) | Trạng thái |
+|---|------------------------|------------|
+| 1 | Excel chứa gói thầu năm khác dù UI chọn `namDuAn=2026` | ✅ Fixed |
+| 2 | Excel chứa gói thầu giai đoạn khác | ✅ Fixed |
+| 3 | Excel chứa gói thầu dự án khác | ✅ Fixed |
+
+## Endpoint
+
+```http
+GET /QuanLyDuAn/api/print/tinh-hinh-thuc-hien-dau-thau?loai=1&namDuAn=2026&giaiDoanId=22&duAnId=08dec1fd-220c-da70-687a-7b47980360c9
+Authorization: Bearer {token}
+Role: GroupTinhHinhThucHienDauThauExport
+```
+
+### Không lọc năm
+
+Bỏ `namDuAn` khỏi URL — backend không áp dụng WHERE năm.
+
+## Kết quả implement
+
+| Hạng mục | File | Trạng thái |
+|----------|------|------------|
+| Helper filter | `GoiThauTinhHinhDauThauQueryableExtensions.cs` | ✅ |
+| Print DTO | `TinhHinhThucHienDauThauPrintSearchDto.cs` | ✅ |
+| Print handler | `GoiThauGetTinhHinhDauThauPrintQuery.cs` | ✅ |
+| List handler (refactor) | `GoiThauGetTinhHinhDauThauQuery.cs` | ✅ |
+| Unit test | `GoiThauTinhHinhDauThauQueryableExtensionsTests.cs` | ✅ |
+| Integration test | `TinhHinhThucHienDauThauExportTests.cs` | ✅ |
+
+## Điểm quan trọng
+
+| Param | Logic |
+|-------|--------|
+| `namDuAn` (print) | #9121: `ThoiGianKhoiCong` / `ThoiGianHoanThanh` — **không** `NgayBatDau` |
+| `nam` (list) | `DuAn.NgayBatDau` trong khoảng năm (giữ cũ) |
+| `giaiDoanId` | Lọc khi `> 0`; `-1` = bỏ qua |
+| `duAnId` | `GoiThau.DuAnId` |
+| Không truyền param | Không thêm WHERE tương ứng |
+
+## Tài liệu triển khai
+
+| File | Nội dung |
+|------|----------|
+| **[report.md](report.md)** | Spec as-built, SQL verify, test plan, checklist |
+| [task-export gốc](../../feature/GoiThau/task-export-tinh-hinh-thuc-hien-dau-thau.md) | ⏳ Cần cập nhật filter as-built |
+
+## QA còn lại
+
+1. **Restart WebApi** sau build (tránh chạy DLL cũ).
+2. Export với filter đầy đủ → so sánh số dòng với grid.
+3. Export **không** `namDuAn` → nhiều dòng hơn (nếu dự án không thỏa năm 2026 theo #9121).

--- a/docs/issues/tinh-hinh-thuc-hien-dau-thau-print-filter/report.md
+++ b/docs/issues/tinh-hinh-thuc-hien-dau-thau-print-filter/report.md
@@ -1,0 +1,391 @@
+# Spec kỹ thuật — Bổ sung filter cho API print Tình hình thực hiện đấu thầu
+
+**Module:** QLDA — `GoiThau` / báo cáo tình hình thực hiện đấu thầu  
+**Ngày:** 2026-07-06  
+**Trạng thái:** ✅ **IMPLEMENTED** (06/07/2026)  
+**Pattern tham chiếu:** `GoiThauGetTinhHinhDauThauQuery` (list), `DuAnGetDanhSachQuery` (#9121 `namDuAn`)
+
+---
+
+## 0. Trạng thái implement
+
+| Hạng mục | Trạng thái | Ghi chú |
+|----------|------------|---------|
+| `GoiThauTinhHinhDauThauQueryableExtensions.cs` | ✅ Done | Helper filter dùng chung |
+| `TinhHinhThucHienDauThauPrintSearchDto` | ✅ Done | `NamDuAn`, `GiaiDoanId`, `DuAnId` |
+| `GoiThauGetTinhHinhDauThauPrintQuery` | ✅ Done | Filter trước tab, multi-sheet |
+| `GoiThauGetTinhHinhDauThauQuery` | ✅ Done | Refactor dùng helper |
+| `GoiThauTinhHinhDauThauQueryableExtensionsTests` | ✅ Done | 6 unit tests |
+| `TinhHinhThucHienDauThauExportTests` | ✅ Done | +3 integration test filter |
+| `PrintController.cs` | ✅ Không sửa | Bind DTO đủ |
+| Migration | ✅ Không cần | Chỉ query/filter |
+| `task-export-tinh-hinh-thuc-hien-dau-thau.md` | ⏳ Pending | Cập nhật as-built feature |
+| QA manual / so sánh Excel vs grid | ⏳ Pending | Sau restart WebApi |
+
+---
+
+## Mục lục
+
+1. [Trạng thái implement](#0-trạng-thái-implement)
+2. [Hiện trạng lỗi](#1-hiện-trạng-lỗi)
+3. [Luồng code (sau fix)](#2-luồng-code-sau-fix)
+4. [So sánh List vs Print](#3-so-sánh-list-vs-print)
+5. [Root cause](#4-root-cause)
+6. [Thiết kế fix (as-built)](#5-thiết-kế-fix-as-built)
+7. [Files đã sửa](#6-files-đã-sửa)
+8. [Tóm tắt code as-built](#7-tóm-tắt-code-as-built)
+9. [Test plan](#8-test-plan)
+10. [Checklist nghiệm thu](#9-checklist-nghiệm-thu)
+11. [Ghi chú / rủi ro](#10-ghi-chú--rủi-ro)
+
+---
+## 1. Hiện trạng lỗi
+
+### 1.1. Case báo cáo (trước fix)
+
+| Khía cạnh | Chi tiết |
+|-----------|----------|
+| **Màn hình** | Báo cáo tình hình thực hiện đấu thầu (`/quan-ly-du-an/bao-cao/tinh-hinh-lua-thau`) |
+| **API list** | `GET /api/goi-thau/tinh-hinh-thuc-hien-dau-thau` — grid có filter, phân trang |
+| **API print** | `GET /api/print/tinh-hinh-thuc-hien-dau-thau` — export Excel |
+| **Filter UI truyền** | `namDuAn=2026`, `giaiDoanId=22`, `duAnId=08dec1fd-...`, `loai=1` |
+| **Kết quả trước fix** | Excel chứa gói thầu **ngoài** subset grid (chỉ lọc tab `loai`) |
+
+### 1.2. Acceptance Criteria
+
+| # | Tiêu chí | Pass khi |
+|---|----------|----------|
+| AC-1 | Lọc năm (print) | `namDuAn` > 0 → logic **#9121** (`ThoiGianKhoiCong` / `ThoiGianHoanThanh`); null hoặc ≤ 0 → không lọc |
+| AC-1b | Lọc năm (list) | `nam` có giá trị → `DuAn.NgayBatDau` trong khoảng năm (giữ behavior cũ) |
+| AC-2 | Lọc giai đoạn | `giaiDoanId` > 0 → `DuAn.GiaiDoanHienTaiId == giaiDoanId` |
+| AC-3 | Bỏ lọc giai đoạn | `giaiDoanId = -1` hoặc null → không WHERE giai đoạn |
+| AC-4 | Lọc dự án | `duAnId` có giá trị → `GoiThau.DuAnId == duAnId` |
+| AC-5 | Giữ tab | `loai` 1/2/3 giữ logic KetQuaTrungThau/HopDong |
+| AC-6 | Multi-sheet | `loai` null/0 → 3 sheet, mỗi sheet cùng bộ filter |
+| AC-7 | Không regression | Không truyền filter → export toàn bộ theo tab |
+| AC-8 | Khớp subset | Excel chỉ chứa gói thầu thỏa filter (không phân trang) |
+
+---
+
+## 2. Luồng code (sau fix)
+
+```mermaid
+sequenceDiagram
+    participant FE as FE (báo cáo)
+    participant List as GoiThauController
+    participant Print as PrintController
+    participant ListQ as GoiThauGetTinhHinhDauThauQuery
+    participant PrintQ as GoiThauGetTinhHinhDauThauPrintQuery
+    participant Ext as GoiThauTinhHinhDauThauQueryableExtensions
+    participant DB as GoiThau (EF)
+
+    FE->>List: GET ...?nam=&giaiDoanId=&duAnId=&trangThai=
+    List->>ListQ: TinhHinhDauThauSearchDto
+    ListQ->>Ext: Filters + NamFilter + TabFilter
+    Ext->>DB: WHERE duAn/giaiDoan/nam + tab
+    ListQ-->>FE: PaginatedList
+
+    FE->>Print: GET .../print?namDuAn=&giaiDoanId=&duAnId=&loai=
+    Print->>PrintQ: TinhHinhThucHienDauThauPrintSearchDto
+    PrintQ->>Ext: Filters + NamDuAnFilter
+    Ext->>DB: WHERE duAn/giaiDoan/namDuAn + tab
+    PrintQ-->>Print: ExportDto[]
+    Print-->>FE: .xlsx (đúng subset)
+```
+
+### 2.1. Files liên quan
+
+| File | Vai trò |
+|------|---------|
+| `QLDA.WebApi/Controllers/PrintController.cs` | `InTinhHinhThucHienDauThau` — bind `TinhHinhThucHienDauThauPrintSearchDto` |
+| `QLDA.WebApi/Controllers/GoiThauController.cs` | `GetTinhHinhThucHienDauThau` — bind `TinhHinhDauThauSearchDto` |
+| `QLDA.Application/GoiThaus/GoiThauTinhHinhDauThauQueryableExtensions.cs` | Helper filter — dùng chung list + print |
+| `QLDA.Application/GoiThaus/DTOs/TinhHinhThucHienDauThauPrintSearchDto.cs` | DTO print |
+| `QLDA.Domain/DTOs/TinhHinhDauThauSearchDto.cs` | DTO list |
+| `QLDA.Application/GoiThaus/Queries/GoiThauGetTinhHinhDauThauQuery.cs` | Handler list |
+| `QLDA.Application/GoiThaus/Queries/GoiThauGetTinhHinhDauThauPrintQuery.cs` | Handler print |
+| `QLDA.Tests/Unit/GoiThauTinhHinhDauThauQueryableExtensionsTests.cs` | Unit test helper |
+| `QLDA.Tests/Integration/TinhHinhThucHienDauThauExportTests.cs` | Integration test export |
+
+---
+## 3. So sánh List vs Print
+
+### 3.1. Query params
+
+| Query param (FE print) | Query param (FE list) | Property list | Property print | Extension / WHERE |
+|------------------------|----------------------|---------------|----------------|-------------------|
+| `namDuAn` | `nam` | `Nam` | `NamDuAn` | Print: `ApplyTinhHinhDauThauNamDuAnFilter` (#9121). List: `ApplyTinhHinhDauThauNamFilter` (`NgayBatDau`) |
+| `giaiDoanId` | `giaiDoanId` | `GiaiDoanId` | `GiaiDoanId` | `ApplyTinhHinhDauThauFilters` — chỉ khi `> 0`; `-1` bỏ qua |
+| `duAnId` | `duAnId` | `DuAnId` | `DuAnId` | `GoiThau.DuAnId` (bỏ `Guid.Empty`) |
+| `loai` | `trangThai` | `TrangThai` | `Loai` | Print: switch enum; List: `ApplyTinhHinhDauThauTabFilter` |
+| `hiddenColumns` | — | — | `HiddenColumns` | Chỉ Aspose, không query |
+
+> **Quan trọng:** `nam` (list) và `namDuAn` (print) **không dùng cùng logic năm**. Nhiều dự án có `NgayBatDau = null` nhưng `ThoiGianKhoiCong = 2026` — nếu print lọc theo `NgayBatDau` sẽ ra Excel trống.
+
+### 3.2. Helper as-built
+
+```csharp
+// Chung list + print
+ApplyTinhHinhDauThauFilters(duAnId, giaiDoanId)
+
+// Chỉ list — param nam
+ApplyTinhHinhDauThauNamFilter(nam)
+// → DuAn.NgayBatDau ∈ [01/01/Y, 01/01/Y+1)
+
+// Chỉ print — param namDuAn (#9121)
+ApplyTinhHinhDauThauNamDuAnFilter(namDuAn)
+// → namDuAn >= ThoiGianKhoiCong
+//   AND ((ThoiGianHoanThanh IS NULL AND ThoiGianKhoiCong = namDuAn) OR namDuAn <= ThoiGianHoanThanh)
+
+// Chỉ list — param trangThai
+ApplyTinhHinhDauThauTabFilter(trangThai)
+```
+
+### 3.3. Print handler as-built
+
+```csharp
+var queryable = _goiThau.GetOrderedSet()
+    .Include(e => e.KetQuaTrungThau)
+    .Include(e => e.HopDong)
+    .AsQueryable()
+    .ApplyTinhHinhDauThauFilters(searchDto.DuAnId, searchDto.GiaiDoanId)
+    .ApplyTinhHinhDauThauNamDuAnFilter(searchDto.NamDuAn);
+
+queryable = loai switch { /* tab 1/2/3 */ };
+```
+
+### 3.4. List handler as-built
+
+```csharp
+var queryable = GoiThau.GetOrderedSet()
+    .Include(e => e.KetQuaTrungThau)
+    .Include(e => e.HopDong)
+    .AsQueryable()
+    .ApplyTinhHinhDauThauFilters(request.SearchDto.DuAnId, request.SearchDto.GiaiDoanId)
+    .ApplyTinhHinhDauThauNamFilter(request.SearchDto.Nam)
+    .ApplyTinhHinhDauThauTabFilter(request.SearchDto.TrangThai);
+```
+
+---
+
+## 4. Root cause
+
+| # | Nguyên nhân | Bằng chứng |
+|---|-------------|------------|
+| RC-1 | Print SearchDto không khai báo filter fields | `TinhHinhThucHienDauThauPrintSearchDto` chỉ 2 property |
+| RC-2 | Handler không đọc filter từ request | `GetExportItemsAsync(loai)` không nhận `SearchDto` |
+| RC-3 | Thiết kế #103 cố ý bỏ filter | `task-export-tinh-hinh-thuc-hien-dau-thau.md` |
+| RC-4 | Chỉ sửa DTO sẽ không đủ | Phải áp dụng vào `IQueryable` trước `.Select()` |
+| RC-5 | Lần implement đầu copy `NgayBatDau` cho `namDuAn` | Excel trống — đã sửa sang #9121 |
+
+**Không phải lỗi:** Controller, Aspose template, multi-sheet.
+
+### 4.1. Bug phụ đã gặp khi QA
+
+| Triệu chứng | Nguyên nhân | Fix |
+|-------------|-------------|-----|
+| Excel chỉ có header, 0 dòng | `namDuAn` lọc `NgayBatDau` nhưng dự án `NgayBatDau = null` | Tách `ApplyTinhHinhDauThauNamDuAnFilter` (#9121) |
+| SQL verify lỗi `Invalid column name 'false'` | Doc dùng cú pháp PostgreSQL trên SQL Server | Sửa §8.2 — `IsDeleted = 0` |
+
+---
+## 5. Thiết kế fix (as-built)
+
+### 5.1. Nguyên tắc đã áp dụng
+
+1. **Helper dùng chung** — `GoiThauTinhHinhDauThauQueryableExtensions`.
+2. **Tách logic năm** — `nam` (list) ≠ `namDuAn` (print).
+3. **Chỉ WHERE khi param có giá trị** — `namDuAn` null hoặc ≤ 0 → không lọc năm.
+4. **`giaiDoanId = -1`** → bỏ qua (list + print qua helper).
+5. **Filter trước tab** — `duAnId` → `giaiDoanId` → năm → `loai`/`trangThai`.
+6. **Multi-sheet** — mỗi tab gọi `GetExportItemsAsync(tab, searchDto)` với cùng `searchDto`.
+
+### 5.2. API print — query params
+
+| Query param | Kiểu | Bắt buộc | Mô tả |
+|-------------|------|----------|-------|
+| `loai` | `int?` | Không | `1`/`2`/`3` = 1 sheet; null/0 = 3 sheet |
+| `namDuAn` | `int?` | Không | Năm dự án (#9121); null/≤0 = không lọc |
+| `giaiDoanId` | `int?` | Không | Giai đoạn hiện tại; null hoặc `-1` = không lọc |
+| `duAnId` | `Guid?` | Không | Dự án; null = không lọc |
+| `hiddenColumns` | `string[]` | Không | Ẩn cột Excel |
+
+```http
+GET /api/print/tinh-hinh-thuc-hien-dau-thau?loai=1&namDuAn=2026&giaiDoanId=22&duAnId=08dec1fd-220c-da70-687a-7b47980360c9
+
+# Không lọc năm — bỏ namDuAn
+GET /api/print/tinh-hinh-thuc-hien-dau-thau?loai=1&giaiDoanId=22&duAnId=08dec1fd-220c-da70-687a-7b47980360c9
+```
+
+---
+
+## 6. Files đã sửa
+
+| File | Thay đổi | Trạng thái |
+|------|----------|------------|
+| `GoiThauTinhHinhDauThauQueryableExtensions.cs` | Tạo mới — 4 extension methods | ✅ |
+| `TinhHinhThucHienDauThauPrintSearchDto.cs` | Thêm `NamDuAn`, `GiaiDoanId`, `DuAnId` | ✅ |
+| `GoiThauGetTinhHinhDauThauPrintQuery.cs` | `GetExportItemsAsync(loai, searchDto)` + filter | ✅ |
+| `GoiThauGetTinhHinhDauThauQuery.cs` | Gọi helper thay inline `if` | ✅ |
+| `GoiThauTinhHinhDauThauQueryableExtensionsTests.cs` | Tạo mới — 6 tests | ✅ |
+| `TinhHinhThucHienDauThauExportTests.cs` | +3 test có filter | ✅ |
+| `task-export-tinh-hinh-thuc-hien-dau-thau.md` | Cập nhật as-built | ⏳ |
+
+### Không sửa
+
+| File | Lý do |
+|------|-------|
+| `PrintController.cs` | Đã bind DTO — thêm property là đủ |
+| `GoiThauController.cs` | List giữ param `nam` |
+| Migration / DB | Không đổi schema |
+| Template Excel | Không đổi cột |
+
+---
+
+## 7. Tóm tắt code as-built
+
+> Source truth: các file trong §6. Chi tiết logic: §3.2–3.4.
+
+### Bước 0 — Helper
+
+| Method | Dùng cho | Logic |
+|--------|----------|-------|
+| `ApplyTinhHinhDauThauFilters` | List + Print | `duAnId` (≠ Empty), `giaiDoanId` (> 0) |
+| `ApplyTinhHinhDauThauNamFilter` | List (`nam`) | `NgayBatDau` trong khoảng năm |
+| `ApplyTinhHinhDauThauNamDuAnFilter` | Print (`namDuAn`) | #9121 `ThoiGianKhoiCong` / `ThoiGianHoanThanh` |
+| `ApplyTinhHinhDauThauTabFilter` | List (`trangThai`) | Tab 1/2/3 KetQuaTrungThau/HopDong |
+
+### Bước 1 — Print DTO
+
+`TinhHinhThucHienDauThauPrintSearchDto`: `Loai`, `NamDuAn`, `GiaiDoanId`, `DuAnId`, `HiddenColumns`.
+
+### Bước 2 — Print handler
+
+- `Handle`: truyền `request.SearchDto` vào mỗi `GetExportItemsAsync(tab.Loai, request.SearchDto, ct)`.
+- `GetExportItemsAsync`: `.ApplyTinhHinhDauThauFilters` → `.ApplyTinhHinhDauThauNamDuAnFilter` → `switch loai`.
+
+### Bước 3 — List handler
+
+Thay block `if` inline bằng chuỗi extension (§3.4).
+
+### Bước 4–5 — Tests
+
+- Unit: `GoiThauTinhHinhDauThauQueryableExtensionsTests` (6 tests, gồm case `NgayBatDau = null` + `namDuAn`).
+- Integration: `ExportTinhHinhThucHienDauThau_WithFilters_*` (3 tests).
+
+### Bước 6 — Build
+
+```bash
+dotnet build QLDA.Application/QLDA.Application.csproj
+# Restart WebApi nếu process đang lock DLL
+dotnet build QLDA.WebApi/QLDA.WebApi.csproj
+dotnet test QLDA.Tests/QLDA.Tests.csproj --filter "FullyQualifiedName~TinhHinhThucHienDauThau|FullyQualifiedName~GoiThauTinhHinhDauThauQueryableExtensions"
+```
+
+---
+## 8. Test plan
+
+### 8.1. Smoke test manual
+
+| # | Request | Kỳ vọng |
+|---|---------|---------|
+| T1 | Chỉ `loai=1` (không filter) | 200, số dòng ≥ T2 |
+| T2 | `loai=1&namDuAn=2026&giaiDoanId=22&duAnId={guid}` | 200, số dòng ≤ T1, khớp grid |
+| T3 | `giaiDoanId=-1&loai=1&namDuAn=2026&duAnId={guid}` | 200, không lọc giai đoạn |
+| T4 | Không `loai` + filter đầy đủ | 200, 3 sheet, mỗi sheet đã lọc |
+| T5 | `loai=4` | 400 |
+| T6 | `loai=1&giaiDoanId=22&duAnId={guid}` (không `namDuAn`) | 200, không lọc năm |
+
+### 8.2. SQL verify (SQL Server)
+
+> Dùng `0`/`1` cho `bit`, không dùng `false`/`true` hay dấu `"` kiểu PostgreSQL.
+
+**Tab "Chưa có KQ" + filter print (`namDuAn` = logic #9121):**
+
+```sql
+SELECT
+    gt.Id,
+    gt.Ten,
+    da.TenDuAn,
+    da.ThoiGianKhoiCong,
+    da.ThoiGianHoanThanh,
+    da.NgayBatDau,
+    da.GiaiDoanHienTaiId
+FROM GoiThau gt
+INNER JOIN DuAn da ON da.Id = gt.DuAnId AND da.IsDeleted = 0
+LEFT JOIN KetQuaTrungThau kq
+    ON kq.GoiThauId = gt.Id AND kq.IsDeleted = 0
+LEFT JOIN HopDong hd
+    ON hd.GoiThauId = gt.Id AND hd.IsDeleted = 0
+WHERE gt.IsDeleted = 0
+  AND gt.DuAnId = '08DEC1FD-220C-DA70-687A-7B47980360C9'
+  AND da.GiaiDoanHienTaiId = 22
+  AND 2026 >= da.ThoiGianKhoiCong
+  AND (
+        (da.ThoiGianHoanThanh IS NULL AND da.ThoiGianKhoiCong = 2026)
+        OR 2026 <= da.ThoiGianHoanThanh
+      )
+  AND kq.Id IS NULL
+  AND hd.Id IS NULL;
+```
+
+**Không lọc năm** — bỏ 2 dòng `ThoiGianKhoiCong` / `ThoiGianHoanThanh`.
+
+**So với API list (param `nam` — theo `NgayBatDau`):**
+
+```sql
+  AND da.NgayBatDau >= '2026-01-01'
+  AND da.NgayBatDau <  '2027-01-01'
+```
+
+### 8.3. Regression
+
+| Hạng mục | Kiểm tra |
+|----------|----------|
+| `hiddenColumns` | Vẫn ẩn cột đúng |
+| STT | Vẫn đánh từ 1 mỗi sheet |
+| Tên sheet multi-export | Không đổi |
+| Phân quyền role | Vẫn `GroupTinhHinhThucHienDauThauExport` |
+
+---
+
+## 9. Checklist nghiệm thu
+
+- [x] `TinhHinhThucHienDauThauPrintSearchDto` có đủ 3 field filter
+- [x] `GetExportItemsAsync` áp dụng WHERE trên `IQueryable`
+- [x] `giaiDoanId=-1` không gây WHERE giai đoạn (list + print)
+- [x] Export 3 sheet: filter áp dụng cho cả 3
+- [x] `namDuAn` dùng #9121 (không `NgayBatDau`)
+- [x] Không truyền filter: hành vi như trước fix
+- [x] Unit + integration test pass
+- [ ] QA manual: Excel khớp grid
+- [ ] Doc feature as-built cập nhật
+
+---
+
+## 10. Ghi chú / rủi ro
+
+### 10.1. `nam` vs `namDuAn`
+
+- List: query param `nam` → `NgayBatDau`
+- Print: query param `namDuAn` → #9121
+- Không alias chéo trừ khi BA yêu cầu đồng bộ tuyệt đối list/print
+
+### 10.2. `giaiDoanId = -1`
+
+Sau fix, **cả list và print** bỏ qua qua helper (`giaiDoanId is > 0`).
+
+### 10.3. Phân quyền
+
+Cả list và print **không** gọi `_authManager.FilterVisible()` (theo thiết kế #103). Fix filter không thay đổi phạm vi quyền.
+
+### 10.4. Thay đổi so với thiết kế #103
+
+Doc `task-export-tinh-hinh-thuc-hien-dau-thau.md` ghi export cố ý full data. Ticket này đảo quyết định đó theo yêu cầu BA mới — cần cập nhật doc sau merge.
+
+### 10.5. `pageSize` trên URL print
+
+Query param `pageSize` không có trên PrintSearchDto → ASP.NET bỏ qua. Không ảnh hưởng bug.
+
+### 10.6. Encoding file doc
+
+Lưu file `.md` tiếng Việt bằng **UTF-8**. Tránh PowerShell `Set-Content` không chỉ định encoding (gây mojibake như `ká»¹ thuáº­t` thay vì `kỹ thuật`).


### PR DESCRIPTION
## Summary

- **Tình hình THĐT (Excel print):** API `GET /api/print/tinh-hinh-thuc-hien-dau-thau` áp dụng filter `namDuAn`, `giaiDoanId`, `duAnId` (trước đó chỉ lọc tab `loai`). `namDuAn` dùng logic #9121 (`ThoiGianKhoiCong` / `ThoiGianHoanThanh`), tách riêng với `nam` trên API list.
- **Phiếu trình KH triển khai (Word):** Fix dòng `Dự án:` trống (`EnsureDuAnLoadedAsync` + `DuAnDisplay`) và thứ tự giai đoạn/hạng mục theo quy trình dự án (`DuAnBuoc.Buoc.Stt`), đồng bộ Excel export.
- Thêm unit/integration tests và issue docs: `docs/issues/tinh-hinh-thuc-hien-dau-thau-print-filter/`, `docs/issues/phieu-trinh-ke-hoach-print-duan-order/`.

## Test plan

- [x] Export tình hình THĐT với `loai=1&namDuAn=2026&giaiDoanId=22&duAnId={guid}` → số dòng khớp grid (≤ export không filter)
- [x] Export không truyền `namDuAn` → không lọc năm
- [x] In phiếu trình KH triển khai → dòng `Dự án:` có `MaDuAn — TenDuAn`
- [x] Thứ tự giai đoạn/hạng mục trên Word khớp UI (Xin chủ trương trước CB THĐT)
- [x] `dotnet test --filter "GoiThauTinhHinhDauThauQueryableExtensions|KeHoachTrienKhaiHangMucExportMapper"`
- [x] Restart WebApi sau deploy rồi QA manual