### PR TITLE
QLDA: docs(uc63): update use-case documentation in Vietnamese (#9644)

### DIFF
--- a/docs/use-cases/uc63/uc63.md
+++ b/docs/use-cases/uc63/uc63.md
@@ -1,34 +1,233 @@
 # Use Case 63: Nghiệm thu, thanh lý hợp đồng, thỏa thuận giao việc khi có Quyết định phê duyệt dự toán/dự án
 
 <!-- region:nội-dung-gốc -->
+
 ## Thông tin gốc
 
-**Tên Use case:** Nghiệm thu, thanh lý hợp đồng, thỏa thuận giao việc khi có Quyết định phê duyệt dự toán/dự án
+| Trường | Giá trị |
+|--------|---------|
+| Tên Use case | Nghiệm thu, thanh lý hợp đồng, thỏa thuận giao việc khi có Quyết định phê duyệt dự toán/dự án |
+| Số Use case | 63 |
+| Tác nhân | CB.PCM, LĐ.PCM, GĐ/PGĐ, CB.PKH-TC, LĐ.PKH-TC, P.HC-TH, HĐTĐ |
 
-**Số Use case:** 63
+### Mô tả nghiệp vụ
 
-**Tên tác nhân:** CB.PCM, LĐ.PCM, GĐ/PGĐ, CB.PKH-TC, LĐ.PKH-TC, P.HC-TH, HĐTĐ
-
-**Mô tả:**
-- Ban QLDA/PCM có thể cập nhật thông tin phiếu trình nghiệm thu hợp đồng, thỏa thuận giao việc và đính kèm dự thảo Hồ sơ nghiệm thu, thanh lý hợp đồng, thỏa thuận giao việc
-- Ban QLDA/PCM có thể kết xuất mẫu phiếu trình nghiệm thu hoặc đính kèm file
-- Ban QLDA/PCM có thể ký số/chuyển trình Ban GĐ nghiệm thu
-- GĐ/PGĐ có thể duyệt hồ sơ nghiệm thu
-- Ban QLDA/PCM có thể cập nhật thông tin nghiệm thu, thanh lý hợp đồng, thỏa thuận giao việc và đính kèm file
-- CB.PCM, LĐ.PCM, GĐ/PGĐ, CB.PKH-TC, LĐ.PKH-TC, Ban QLDA có thể xem hồ sơ kết quả nghiệm thu hợp đồng, thỏa thuận giao việc
+- Ban QLDA/PCM có thể cập nhật thông tin phiếu trình nghiệm thu hợp đồng, thỏa thuận giao việc và đính kèm dự thảo Hồ sơ nghiệm thu, thanh lý hợp đồng, thỏa thuận giao việc.
+- Ban QLDA/PCM có thể kết xuất mẫu phiếu trình nghiệm thu hoặc đính kèm file.
+- Ban QLDA/PCM có thể ký số / chuyển trình Ban GĐ nghiệm thu.
+- GĐ/PGĐ có thể duyệt hồ sơ nghiệm thu.
+- Ban QLDA/PCM có thể cập nhật thông tin nghiệm thu, thanh lý hợp đồng, thỏa thuận giao việc và đính kèm file.
+- CB.PCM, LĐ.PCM, GĐ/PGĐ, CB.PKH-TC, LĐ.PKH-TC, Ban QLDA có thể xem hồ sơ kết quả nghiệm thu hợp đồng, thỏa thuận giao việc.
 
 <!-- endregion -->
 
 <!-- region:phân-tích-nghiệp-vụ -->
 
+## Phân tích nghiệp vụ
+
 ### Issues thuộc UC63
-[9644](https://pmis.vietinfo.tech:8080/issues/9644)
+
+| Issue | Tiêu đề | Trạng thái |
+|-------|---------|------------|
+| [#9644](https://pmis.vietinfo.tech:8080/issues/9644) | Nghiệm thu thanh lý hợp đồng | Implemented |
+
+### Quy trình tổng quan
+
+```
+PCM tạo phiếu trình ──► Ký số / Trình phê duyệt ──► GĐ/PGĐ duyệt ──► Cập nhật kết quả NT/TL ──► Phát hành số
+```
+
+### Các bước chính
+
+1. **Tạo / cập nhật phiếu trình nghiệm thu** — PCM nhập thông tin, đính kèm dự thảo hồ sơ.
+2. **Trình phê duyệt** — ký số và gửi phiếu trình cho cấp trên duyệt.
+3. **Duyệt / Trả lại / Từ chối** — GĐ/PGĐ xem xét và ra quyết định.
+4. **Cập nhật kết quả nghiệm thu, thanh lý** — PCM cập nhật thông tin sau duyệt.
+5. **Phát hành số văn bản** — P.HC-TH cấp số cho hồ sơ nghiệm thu.
+
+### Phân quyền
+
+| Tác nhân | Quyền |
+|----------|-------|
+| CB.PCM, LĐ.PCM | Tạo, cập nhật, trình phê duyệt, xem |
+| GĐ/PGĐ | Duyệt, trả lại, từ chối, xem |
+| CB.PKH-TC, LĐ.PKH-TC | Xem |
+| P.HC-TH | Phát hành số |
+| HĐTĐ | Xem kết quả |
+
 <!-- endregion -->
 
 <!-- region:thiết-kế-database -->
 
+## Thiết kế database
+
+### Bảng mới
+
+| Bảng | Mục đích |
+|------|----------|
+| `ThanhLyHopDong` | Phiếu trình nghiệm thu / thanh lý hợp đồng |
+| `ThanhLyHopDongNghiemThu` | Quan hệ nhiều-nhiều giữa thanh lý và bản ghi nghiệm thu |
+
+### Bảng `ThanhLyHopDong`
+
+| Cột | Kiểu | Mô tả |
+|-----|------|-------|
+| `Id` | uniqueidentifier | PK |
+| `DuAnId` | uniqueidentifier | FK → Dự án |
+| `BuocId` | int | FK → Bước dự án (optional) |
+| `HopDongId` | uniqueidentifier | FK → Hợp đồng (optional) |
+| `So` | nvarchar | Số phiếu trình |
+| `Ngay` | datetime | Ngày trình |
+| `TrichYeu` | nvarchar(max) | Trích yếu nội dung |
+| `TrangThaiId` | int | FK → Trạng thái phê duyệt |
+| `CreatedBy`, `CreatedAt`, `UpdatedBy`, `UpdatedAt`, `IsDeleted` | audit | Audit fields chuẩn |
+
+### Bảng `ThanhLyHopDongNghiemThu` (join table)
+
+| Cột | Kiểu | Mô tả |
+|-----|------|-------|
+| `LeftId` | uniqueidentifier | FK → ThanhLyHopDong |
+| `RightId` | uniqueidentifier | FK → Nghiệm thu |
+
+### Migration
+
+- `20260706045852_AddThanhLyHopDongTables` — tạo 2 bảng trên
+- `20260706091551_AddThanhLyHopDongTrangThaiPheDuyet` — cập nhật trạng thái phê duyệt + seed `DanhMucTrangThaiPheDuyet`
+
 <!-- endregion -->
 
 <!-- region:api-spec -->
+
+## API Mapping cho Frontend
+
+> File JSON đầy đủ: [`docs/api/QLDA/thanh-ly-hop-dong.mapping.json`](../../api/QLDA/thanh-ly-hop-dong.mapping.json)
+
+### 1. CRUD phiếu thanh lý hợp đồng
+
+| Method | Endpoint | Mục đích |
+|--------|----------|---------|
+| `GET` | `/api/thanh-ly-hop-dong/danh-sach-tien-do` | Danh sách theo bước (phân trang, bắt buộc `duAnId` + `buocId`) |
+| `GET` | `/api/thanh-ly-hop-dong/danh-sach` | Danh sách chung (phân trang) |
+| `GET` | `/api/thanh-ly-hop-dong/{id}/chi-tiet` | Chi tiết 1 phiếu (kèm file đính kèm) |
+| `POST` | `/api/thanh-ly-hop-dong/them-moi` | Tạo mới phiếu |
+| `PUT` | `/api/thanh-ly-hop-dong/cap-nhat` | Cập nhật phiếu |
+| `DELETE` | `/api/thanh-ly-hop-dong/{id}/xoa` | Xóa phiếu |
+
+### 2. Luồng phê duyệt (dùng chung endpoint dispatch)
+
+> Tất cả đi qua `QuanLyPheDuyetController`, truyền `{type} = "ThanhLyHopDong"`.
+
+| Bước | Method | Endpoint | Body | Bắt buộc |
+|------|--------|----------|------|----------|
+| Trình | `POST` | `/api/phe-duyet/ThanhLyHopDong/{id}/trinh` | `{ noiDung?: string }` | |
+| Duyệt | `POST` | `/api/phe-duyet/ThanhLyHopDong/{id}/duyet` | `?noiDung=...` (query) | |
+| Trả lại | `POST` | `/api/phe-duyet/ThanhLyHopDong/{id}/tra-lai` | `{ noiDung: string }` | Lý do |
+| Từ chối | `POST` | `/api/phe-duyet/ThanhLyHopDong/{id}/tu-choi` | `{ noiDung: string }` | Lý do |
+| Chuyển | `POST` | `/api/phe-duyet/ThanhLyHopDong/{id}/chuyen` | `{ noiDung?: string }` | |
+| Phát hành số | `POST` | `/api/phe-duyet/ThanhLyHopDong/{id}/chuyen-phat-hanh` | `{ soPhatHanh?: string }` | |
+| Lịch sử | `GET` | `/api/phe-duyet/lich-su?type=ThanhLyHopDong&entityId={id}` | — | |
+| Chi tiết PD | `GET` | `/api/phe-duyet/ThanhLyHopDong/{id}/chi-tiet` | — | |
+
+### 3. Tra cứu hỗ trợ
+
+| Method | Endpoint | Mục đích |
+|--------|----------|---------|
+| `GET` | `/api/phe-duyet/types` | Lấy danh sách loại phê duyệt (dropdown cho FE) |
+
+### DTO chính
+
+**`ThanhLyHopDongDto`** (response)
+
+```json
+{
+  "id": "guid",
+  "duAnId": "guid",
+  "buocId": 0,
+  "hopDongId": "guid",
+  "hopDongTen": "string",
+  "so": "string",
+  "ngay": "2026-07-06T00:00:00Z",
+  "trichYeu": "string",
+  "trangThaiId": 0,
+  "trangThaiTen": "string",
+  "nghiemThuIds": ["guid"],
+  "danhSachTepDinhKem": []
+}
+```
+
+**`ThanhLyHopDongInsertDto`** / **`ThanhLyHopDongUpdateDto`** (request body)
+
+```json
+{
+  "id": "guid",
+  "duAnId": "guid",
+  "buocId": 0,
+  "hopDongId": "guid",
+  "so": "string",
+  "ngay": "2026-07-06T00:00:00Z",
+  "trichYeu": "string",
+  "trangThaiId": 0,
+  "nghiemThuIds": ["guid"],
+  "danhSachTepDinhKem": []
+}
+```
+
+### Hằng số FE cần biết
+
+| Tên | Giá trị | Dùng cho |
+|-----|---------|----------|
+| `PheDuyetType.ThanhLyHopDong` | `"ThanhLyHopDong"` | Truyền vào URL `/api/phe-duyet/{type}/...` |
+| Label hiển thị | `"Thanh lý hợp đồng"` | Dropdown chọn loại phê duyệt (lấy từ `/api/phe-duyet/types`) |
+
+<!-- endregion -->
+
+<!-- region:workflow -->
+
+## Workflow mẫu (FE flow)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. Màn hình tiến độ                                         │
+│    GET /api/thanh-ly-hop-dong/danh-sach-tien-do?duAnId&buocId│
+└──────────────────────────────┬──────────────────────────────┘
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 2. PCM chọn "Tạo phiếu mới"                                 │
+│    POST /api/thanh-ly-hop-dong/them-moi                     │
+│    → trả về { id }                                          │
+└──────────────────────────────┬──────────────────────────────┘
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 3. PCM cập nhật nội dung + đính kèm file                    │
+│    PUT  /api/thanh-ly-hop-dong/cap-nhat                     │
+└──────────────────────────────┬──────────────────────────────┘
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 4. PCM bấm "Trình phê duyệt"                                │
+│    POST /api/phe-duyet/ThanhLyHopDong/{id}/trinh             │
+└──────────────────────────────┬──────────────────────────────┘
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 5. GĐ/PGĐ duyệt / trả lại / từ chối                         │
+│    POST /api/phe-duyet/ThanhLyHopDong/{id}/duyet             │
+│    POST /api/phe-duyet/ThanhLyHopDong/{id}/tra-lai           │
+│    POST /api/phe-duyet/ThanhLyHopDong/{id}/tu-choi           │
+└──────────────────────────────┬──────────────────────────────┘
+                               ▼
+┌─────────────────────────────────────────────────────────────┐
+│ 6. Sau duyệt: chuyển phát hành số                           │
+│    POST /api/phe-duyet/ThanhLyHopDong/{id}/chuyen-phat-hanh  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+<!-- endregion -->
+
+<!-- region:lich-su-cap-nhat -->
+
+## Lịch sử cập nhật
+
+| Ngày | Phiên bản | Thay đổi |
+|------|-----------|----------|
+| 2026-07-06 | 1.0 | Khởi tạo UC63 — ThanhLyHopDong + ThanhLyHopDongNghiemThu + luồng phê duyệt |
 
 <!-- endregion -->


### PR DESCRIPTION
## Summary
Follow-up to #134 - adds the full Vietnamese documentation for UC63 NghiemThu ThanhLy HopDong.

### Files changed
- `docs/use-cases/uc63/uc63.md` - structured Vietnamese docs (thong-tin-goc, phan-tich-nghiep-vu, thiet-ke-database, api-spec, workflow, lich-su-cap-nhat) + link to FE API mapping JSON

### Context
- PR #134 was merged but the docs commit `cbe31a9` was pushed after the merge.
- This PR brings that commit into `main`.
- Because `origin/main` has advanced with unrelated changes (PR #135), this PR uses a cherry-pick of the original commit to avoid merge conflicts.

Closes #9644 (docs portion)