### PR TITLE
fix(export): dung chung filter nam giua API print va API danh sach tinh hinh dau thau

### DIFF
--- a/QLDA.Application/GoiThaus/DTOs/TinhHinhThucHienDauThauPrintSearchDto.cs
+++ b/QLDA.Application/GoiThaus/DTOs/TinhHinhThucHienDauThauPrintSearchDto.cs
@@ -13,6 +13,9 @@ public record TinhHinhThucHienDauThauPrintSearchDto
 
     /// <summary>
     /// Năm dự án — bind query param <c>namDuAn</c>. Null hoặc &lt;= 0 = không lọc.
+    /// Cùng logic với param <c>nam</c> của API danh sách
+    /// (<see cref="QLDA.Application.GoiThaus.GoiThauTinhHinhDauThauQueryableExtensions.ApplyTinhHinhDauThauNamFilter"/>,
+    /// theo <c>DuAn.NgayBatDau</c>) để Excel khớp dữ liệu grid.
     /// </summary>
     public int? NamDuAn { get; set; }
 

--- a/QLDA.Application/GoiThaus/GoiThauTinhHinhDauThauQueryableExtensions.cs
+++ b/QLDA.Application/GoiThaus/GoiThauTinhHinhDauThauQueryableExtensions.cs
@@ -24,13 +24,14 @@ internal static class GoiThauTinhHinhDauThauQueryableExtensions
     }
 
     /// <summary>
-    /// Lọc theo query param <c>nam</c> trên API list — theo <c>DuAn.NgayBatDau</c>.
+    /// Lọc theo năm — dùng chung cho cả API list (param <c>nam</c>) và API print
+    /// (param <c>namDuAn</c>), theo <c>DuAn.NgayBatDau</c>. Null hoặc &lt;= 0 → bỏ qua.
     /// </summary>
     public static IQueryable<GoiThau> ApplyTinhHinhDauThauNamFilter(
         this IQueryable<GoiThau> queryable,
         int? nam)
     {
-        if (!nam.HasValue)
+        if (nam is not > 0)
             return queryable;
 
         var firstDayOfYear = new DateTimeOffset(nam.Value, 1, 1, 0, 0, 0, TimeSpan.Zero);
@@ -39,23 +40,6 @@ internal static class GoiThauTinhHinhDauThauQueryableExtensions
             && e.DuAn.NgayBatDau.HasValue
             && e.DuAn.NgayBatDau >= firstDayOfYear
             && e.DuAn.NgayBatDau < firstDayOfNextYear);
-    }
-
-    /// <summary>
-    /// Lọc theo query param <c>namDuAn</c> trên API print — logic #9121
-    /// (<c>ThoiGianKhoiCong</c> / <c>ThoiGianHoanThanh</c>).
-    /// </summary>
-    public static IQueryable<GoiThau> ApplyTinhHinhDauThauNamDuAnFilter(
-        this IQueryable<GoiThau> queryable,
-        int? namDuAn)
-    {
-        if (namDuAn is not > 0)
-            return queryable;
-
-        return queryable.Where(e => e.DuAn != null
-            && namDuAn >= e.DuAn.ThoiGianKhoiCong
-            && ((e.DuAn.ThoiGianHoanThanh == null && e.DuAn.ThoiGianKhoiCong == namDuAn)
-                || namDuAn <= e.DuAn.ThoiGianHoanThanh));
     }
 
     /// <summary>

--- a/QLDA.Application/GoiThaus/Queries/GoiThauGetTinhHinhDauThauPrintQuery.cs
+++ b/QLDA.Application/GoiThaus/Queries/GoiThauGetTinhHinhDauThauPrintQuery.cs
@@ -76,7 +76,7 @@ internal class GoiThauGetTinhHinhDauThauPrintQueryHandler(IServiceProvider servi
             .Include(e => e.HopDong)
             .AsQueryable()
             .ApplyTinhHinhDauThauFilters(searchDto.DuAnId, searchDto.GiaiDoanId)
-            .ApplyTinhHinhDauThauNamDuAnFilter(searchDto.NamDuAn);
+            .ApplyTinhHinhDauThauNamFilter(searchDto.NamDuAn);
 
         queryable = loai switch
         {

--- a/QLDA.Tests/Unit/GoiThauTinhHinhDauThauQueryableExtensionsTests.cs
+++ b/QLDA.Tests/Unit/GoiThauTinhHinhDauThauQueryableExtensionsTests.cs
@@ -19,9 +19,7 @@ public class GoiThauTinhHinhDauThauQueryableExtensionsTests
                 DuAn = new DuAn
                 {
                     GiaiDoanHienTaiId = 22,
-                    ThoiGianKhoiCong = 2026,
-                    ThoiGianHoanThanh = 2028,
-                    NgayBatDau = null,
+                    NgayBatDau = new DateTimeOffset(2026, 3, 1, 0, 0, 0, TimeSpan.Zero),
                 },
             },
             new()
@@ -31,8 +29,17 @@ public class GoiThauTinhHinhDauThauQueryableExtensionsTests
                 DuAn = new DuAn
                 {
                     GiaiDoanHienTaiId = 10,
-                    ThoiGianKhoiCong = 2025,
-                    ThoiGianHoanThanh = 2025,
+                    NgayBatDau = new DateTimeOffset(2025, 6, 1, 0, 0, 0, TimeSpan.Zero),
+                },
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                DuAnId = Guid.NewGuid(),
+                DuAn = new DuAn
+                {
+                    GiaiDoanHienTaiId = 22,
+                    NgayBatDau = null,
                 },
             },
         }.AsQueryable();
@@ -42,7 +49,7 @@ public class GoiThauTinhHinhDauThauQueryableExtensionsTests
     {
         var result = CreateSampleData()
             .ApplyTinhHinhDauThauFilters(MatchingDuAnId, giaiDoanId: 22)
-            .ApplyTinhHinhDauThauNamDuAnFilter(2026)
+            .ApplyTinhHinhDauThauNamFilter(2026)
             .ToList();
 
         result.Should().HaveCount(1);
@@ -50,24 +57,34 @@ public class GoiThauTinhHinhDauThauQueryableExtensionsTests
     }
 
     [Fact]
-    public void ApplyNamDuAnFilter_MatchesThoiGianKhoiCong_WhenNgayBatDauNull()
+    public void ApplyNamFilter_MatchesNgayBatDau_ForGivenYear()
     {
+        // Đảm bảo API print (namDuAn) và API list (nam) trả cùng tập dữ liệu
+        // vì dùng chung ApplyTinhHinhDauThauNamFilter.
         var result = CreateSampleData()
-            .ApplyTinhHinhDauThauNamDuAnFilter(2026)
+            .ApplyTinhHinhDauThauNamFilter(2026)
             .ToList();
 
         result.Should().HaveCount(1);
-        result[0].DuAn!.NgayBatDau.Should().BeNull();
+        result[0].DuAnId.Should().Be(MatchingDuAnId);
     }
 
     [Fact]
-    public void ApplyNamFilter_RequiresNgayBatDau()
+    public void ApplyNamFilter_ExcludesEntitiesWithNullNgayBatDau()
     {
         var result = CreateSampleData()
             .ApplyTinhHinhDauThauNamFilter(2026)
             .ToList();
 
-        result.Should().BeEmpty();
+        result.Should().NotContain(e => e.DuAn!.NgayBatDau == null);
+    }
+
+    [Fact]
+    public void ApplyNamFilter_NullOrNonPositive_DoesNotFilter()
+    {
+        CreateSampleData().ApplyTinhHinhDauThauNamFilter(null).ToList().Should().HaveCount(3);
+        CreateSampleData().ApplyTinhHinhDauThauNamFilter(0).ToList().Should().HaveCount(3);
+        CreateSampleData().ApplyTinhHinhDauThauNamFilter(-1).ToList().Should().HaveCount(3);
     }
 
     [Fact]
@@ -77,7 +94,7 @@ public class GoiThauTinhHinhDauThauQueryableExtensionsTests
             .ApplyTinhHinhDauThauFilters(duAnId: null, giaiDoanId: -1)
             .ToList();
 
-        result.Should().HaveCount(2);
+        result.Should().HaveCount(3);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary
- `namDuAn` (API print) trước giờ lọc theo `ThoiGianKhoiCong`/`ThoiGianHoanThanh`, khác với `nam` (API danh sách) lọc theo `DuAn.NgayBatDau` → Excel bị lệch dữ liệu so với grid.
- Xóa `ApplyTinhHinhDauThauNamDuAnFilter`, API print dùng chung `ApplyTinhHinhDauThauNamFilter` với API danh sách để đảm bảo cùng tập kết quả.
- Cập nhật unit test xác nhận `namDuAn`/`nam` trả về cùng dữ liệu và các case null/`<=0`.

## Test plan
- [x] Unit test `GoiThauTinhHinhDauThauQueryableExtensionsTests` pass
- [x] Restart WebApi sau khi merge/deploy
- [x] So sánh số dòng API danh sách (`nam=2026&trangThai=2`) với API print (`namDuAn=2026&loai=2`) — phải khớp `totalRows`
- [x] Test thêm `giaiDoanId` và `duAnId` — Excel chỉ xuất đúng dự án/giai đoạn tương ứng