### PR TITLE
QLDA: fix export tổng hợp nhu cầu kinh phí năm — đồng bộ thứ tự grid và ngày VN

### DIFF
--- a/QLDA.Application/DeXuatKinhPhiNam/Queries/DeXuatNhuCauKinhPhiNamGetExportQuery.cs
+++ b/QLDA.Application/DeXuatKinhPhiNam/Queries/DeXuatNhuCauKinhPhiNamGetExportQuery.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using BuildingBlocks.CrossCutting.ExtensionMethods;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common.Interfaces;
 using QLDA.Application.DeXuatNhuCauKinhPhiNams.DTOs;
@@ -44,9 +45,8 @@ internal class DeXuatNhuCauKinhPhiNamGetExportQueryHandler(IServiceProvider serv
             .WhereIf(tuNgayDto != null, e => e.NgayKeHoach >= tuNgayDto)
             .WhereIf(denNgayExclusiveDto != null, e => e.NgayKeHoach < denNgayExclusiveDto);
 
+        // Same order as DeXuatNhuCauKinhPhiNamQuery (GetQueryableSet → Index DESC).
         var rows = await queryable
-            .OrderBy(e => e.CreatedAt)
-            .ThenBy(e => e.Id)
             .Select(e => new {
                 e.So,
                 e.TrichYeu,
@@ -65,7 +65,7 @@ internal class DeXuatNhuCauKinhPhiNamGetExportQueryHandler(IServiceProvider serv
             SoKeHoach = row.So,
             TrichYeu = row.TrichYeu,
             TongHopChiPhi = row.TongKinhPhiDeXuat,
-            Ngay = row.NgayKeHoach?.ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
+            Ngay = row.NgayKeHoach?.ToDateOnlyVn().ToString("dd/MM/yyyy", CultureInfo.InvariantCulture),
             TrangThai = row.TenTrangThai,
             SoLuongTepDinhKem = row.SoLuongTepDinhKem,
         }).ToList();


### PR DESCRIPTION
## Summary

- Export Excel `GET /api/print/tong-hop-nhu-cau-kinh-phi-nam` dùng thứ tự `Index DESC` từ `GetQueryableSet()`, đồng bộ với `GET /api/tong-hop-kinh-phi/danh-sach-tien-do`
- Bỏ `OrderBy(CreatedAt)` gây đảo thứ tự so với grid
- Format `NgayKeHoach` qua `ToDateOnlyVn()` trước khi ghi Excel, tránh ngày bị lùi 1 ngày do UTC

## Root cause

| Lỗi | Nguyên nhân |
|-----|-------------|
| Thứ tự ngược UI | Export sort `CreatedAt ASC`, grid sort `Index DESC` |
| Ngày lùi 1 ngày | `NgayKeHoach` lưu UTC, export format trực tiếp `.ToString()` |

## Test plan

- [x] Gọi `GET /api/tong-hop-kinh-phi/danh-sach-tien-do` và `GET /api/print/tong-hop-nhu-cau-kinh-phi-nam` cùng filter
- [x] Dòng đầu Excel = dòng đầu grid (vd: `50`, `1023`, `333`…)
- [x] Ngày Excel khớp UI (`10/07/2026` không thành `09/07/2026`)
- [x] STT tăng liên tục từ 1
- [x] Filter, trạng thái, số tệp đính kèm không đổi