### PR TITLE
QLDA: tạm tắt TuChoi dispatch cho PheDuyetDuToan, HSMTĐT, PhanKhaiKinhPhi, QuyetDinhDieuChinh

### DIFF
--- a/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchTuChoiCommand.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Commands/PheDuyetDispatchTuChoiCommand.cs
@@ -27,10 +27,10 @@ internal class PheDuyetDispatchTuChoiCommandHandler(IServiceProvider serviceProv
         await _auth.EnsureCanApproveDuAnAsync(duAnId ?? Guid.Empty, cancellationToken);
 
         IRequest<int> command = request.Type switch {
-            PheDuyetEntityNames.PheDuyetDuToan => new PheDuyetDuToanTuChoiCommand(request.Id, request.NoiDung),
-            PheDuyetEntityNames.HoSoMoiThauDienTu => new HoSoMoiThauDienTuTuChoiCommand(request.Id, request.NoiDung),
-            PheDuyetEntityNames.PhanKhaiKinhPhi => new PhanKhaiKinhPhiTuChoiCommand(request.Id, request.NoiDung),
-            PheDuyetEntityNames.QuyetDinhDieuChinh => new QuyetDinhDieuChinhTuChoiCommand(request.Id, request.NoiDung),
+            // PheDuyetEntityNames.PheDuyetDuToan => new PheDuyetDuToanTuChoiCommand(request.Id, request.NoiDung),
+            // PheDuyetEntityNames.HoSoMoiThauDienTu => new HoSoMoiThauDienTuTuChoiCommand(request.Id, request.NoiDung),
+            // PheDuyetEntityNames.PhanKhaiKinhPhi => new PhanKhaiKinhPhiTuChoiCommand(request.Id, request.NoiDung),
+            // PheDuyetEntityNames.QuyetDinhDieuChinh => new QuyetDinhDieuChinhTuChoiCommand(request.Id, request.NoiDung),
             //PheDuyetEntityNames.PheDuyetKhaoSat => new ToTrinhPheDuyetTuChoiCommand(request.Id, PheDuyetEntityNames.PheDuyetKhaoSat, request.NoiDung),
             PheDuyetEntityNames.DeXuatNhuCauKinhPhiNam => new DeXuatKinhPhiNamTuChoiCommand(request.Id, request.NoiDung),
             PheDuyetEntityNames.KeHoachLuaChonNhaThauRutGon => new KeHoachLuaChonNhaThauRutGonTuChoiCommand(request.Id, request.NoiDung),


### PR DESCRIPTION
## Summary
- Comment out 4 case trong `PheDuyetDispatchTuChoiCommand`: `PheDuyetDuToan`, `HoSoMoiThauDienTu`, `PhanKhaiKinhPhi`, `QuyetDinhDieuChinh`.
- Vẫn dispatch Từ chối cho: `DeXuatNhuCauKinhPhiNam`, `KeHoachLuaChonNhaThauRutGon`, `ThoaThuanGiaoViec`.
- Các type bị tắt sẽ trả lỗi loại phê duyệt không hợp lệ (không gọi `*TuChoiCommand` tương ứng).

## Test plan
- [ ] Từ chối `DeXuatNhuCauKinhPhiNam` / `KeHoachLuaChonNhaThauRutGon` / `ThoaThuanGiaoViec` vẫn OK
- [ ] Từ chối `PheDuyetDuToan` / HSMTĐT / `PhanKhaiKinhPhi` / `QuyetDinhDieuChinh` → báo type không hợp lệ