### PR TITLE
QLDA: fix HoSoMoiThauDienTu attachment grouping and signed-file loading

### DIFF
--- a/QLDA.Application/HoSoMoiThauDienTus/Queries/HoSoMoiThauDienTuGetDanhSachQuery.cs
+++ b/QLDA.Application/HoSoMoiThauDienTus/Queries/HoSoMoiThauDienTuGetDanhSachQuery.cs
@@ -51,10 +51,12 @@ internal class HoSoMoiThauDienTuGetDanhSachQueryHandler : IRequestHandler<HoSoMo
             queryable = queryable.Where(e => e.GoiThauId == request.SearchDto.GoiThauId);
         }
 
-        // Gốc + KySo_* — khớp API chi tiết (GetAttachmentsQuery ExpandGroupTypes)
+        // Dữ liệu mới lưu toàn bộ file theo HoSo.Id; vẫn giữ nhánh Id cũ để đọc bản ghi legacy.
         var groupTypesOnEntityId = AttachmentSubquery.ExpandGroupTypes(
             includeSigned: true,
             nameof(EGroupType.HoSoMoiThauDienTu),
+            nameof(EGroupType.HoSoMoiThauDienTuToTrinh),
+            nameof(EGroupType.HoSoMoiThauDienTuQuyetDinh),
             nameof(EGroupType.HoSoMoiThauDienTuQuyetDinhTD),
             nameof(EGroupType.HoSoMoiThauDienTuCamKetTD),
             nameof(EGroupType.HoSoMoiThauDienTuBaoCaoTD));

--- a/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetGetDanhSachQuery.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetGetDanhSachQuery.cs
@@ -25,6 +25,12 @@ public record PheDuyetGetDanhSachQuery : AggregateRootPagination, IMayHaveGlobal
     /// Đặt <c>false</c> chỉ khi caller chắc chắn không cần file (tối ưu).
     /// </summary>
     public bool IncludeAttachments { get; set; } = true;
+
+    /// <summary>
+    /// Mặc định <c>true</c> — lấy cả file gốc và <c>KySo_*</c> (qua ExpandGroupTypes).
+    /// Chỉ đặt <c>false</c> khi caller tường minh không cần file ký số.
+    /// </summary>
+    public bool IncludeSigned { get; set; } = true;
 }
 
 internal class PheDuyetGetDanhSachQueryHandler : IRequestHandler<PheDuyetGetDanhSachQuery, PaginatedList<PheDuyetListItemDto>>
@@ -100,7 +106,8 @@ internal class PheDuyetGetDanhSachQueryHandler : IRequestHandler<PheDuyetGetDanh
             request.IncludeAttachments ? _tepDinhKemRepo : null,
             _authContext,
             userId,
-            includeAttachments: request.IncludeAttachments);
+            includeAttachments: request.IncludeAttachments,
+            includeSigned: request.IncludeSigned);
 
         // PageSize=0 / Take()=0 → lấy hết (dùng cho export Excel)
         var pagiList = PaginatedList<PheDuyetListItemDto>.Create(finalQuery, request.Skip(), request.Take());

--- a/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetQueryableExtensions.cs
+++ b/QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetQueryableExtensions.cs
@@ -1,8 +1,10 @@
+using BuildingBlocks.Application.Attachments.Common;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Authorization;
 using QLDA.Application.QuanLyPheDuyet.DTOs;
 using QLDA.Application.TepDinhKems.DTOs;
 using QLDA.Domain.Constants;
+using QLDA.Domain.Enums;
 
 namespace QLDA.Application.QuanLyPheDuyet.Queries;
 
@@ -10,6 +12,20 @@ internal record PheDuyetDanhSachFilter(string? Type, string? TrangThai);
 internal static class PheDuyetQueryableExtensions
 
 {
+    /// <summary>
+    /// Base GroupType của HSMTĐT — khớp API chi tiết / danh sách hồ sơ.
+    /// ExpandGroupTypes thêm KySo_* khi IncludeSigned = true.
+    /// </summary>
+    private static readonly string[] HoSoMoiThauDienTuBaseGroupTypes =
+    [
+        nameof(EGroupType.HoSoMoiThauDienTu),
+        nameof(EGroupType.HoSoMoiThauDienTuToTrinh),
+        nameof(EGroupType.HoSoMoiThauDienTuQuyetDinh),
+        nameof(EGroupType.HoSoMoiThauDienTuQuyetDinhTD),
+        nameof(EGroupType.HoSoMoiThauDienTuCamKetTD),
+        nameof(EGroupType.HoSoMoiThauDienTuBaoCaoTD),
+    ];
+
     public static List<PheDuyetListItemDto> ApplyDanhSachFilters(
         PheDuyetDanhSachFilter filter,
         IRepository<PheDuyet, Guid> pheDuyetRepo,
@@ -18,7 +34,8 @@ internal static class PheDuyetQueryableExtensions
         IRepository<Attachment, Guid>? tepDinhKemRepo,
         IAuthorizationContext authContext,
         long userId,
-        bool includeAttachments)
+        bool includeAttachments,
+        bool includeSigned = true)
     {
         var pheDuyetQuery = pheDuyetRepo.GetQueryableSet().AsNoTracking()
             .Where(e => !e.IsDeleted)
@@ -59,7 +76,7 @@ internal static class PheDuyetQueryableExtensions
         .OrderByDescending(i => i.NgayXuLyMoiNhat ?? DateTimeOffset.MinValue)
         .ToList();
         if (includeAttachments && tepDinhKemRepo != null && items.Count > 0) {
-            AttachTepDinhKem(items, tepDinhKemRepo);
+            AttachTepDinhKem(items, tepDinhKemRepo, includeSigned);
         }
         else {
             EnsureEmptyAttachments(items);
@@ -69,6 +86,7 @@ internal static class PheDuyetQueryableExtensions
     /// <summary>
     /// Gán tệp đính kèm theo GroupId == EntityId (chuỗi từ Guid/long.ToString()).
     /// Không có file → [] (không null) — tương thích API cũ.
+    /// Không lọc bỏ vì ParentId / KySo — file ký số vẫn được gán.
     /// </summary>
     internal static void AssignAttachments(
         List<PheDuyetListItemDto> items,
@@ -79,7 +97,10 @@ internal static class PheDuyetQueryableExtensions
             .GroupBy(f => f.GroupId!, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 g => g.Key,
-                g => g.Select(i => i.ToDto()).ToList(),
+                g => g
+                    .DistinctBy(f => f.Id)
+                    .Select(i => i.ToDto())
+                    .ToList(),
                 StringComparer.OrdinalIgnoreCase);
         foreach (var item in items) {
             item.DanhSachTepDinhKem = !string.IsNullOrEmpty(item.EntityId)
@@ -90,7 +111,8 @@ internal static class PheDuyetQueryableExtensions
     }
     private static void AttachTepDinhKem(
         List<PheDuyetListItemDto> items,
-        IRepository<Attachment, Guid> tepDinhKemRepo)
+        IRepository<Attachment, Guid> tepDinhKemRepo,
+        bool includeSigned = true)
     {
         var groupIds = items
             .Select(i => i.EntityId)
@@ -102,9 +124,31 @@ internal static class PheDuyetQueryableExtensions
             EnsureEmptyAttachments(items);
             return;
         }
-        var files = tepDinhKemRepo.GetQueryableSet()
+        var query = tepDinhKemRepo.GetQueryableSet()
             .AsNoTracking()
-            .Where(i => groupIds.Contains(i.GroupId))
+            .Where(i => groupIds.Contains(i.GroupId));
+
+        // HSMTĐT: scope GroupType qua ExpandGroupTypes (gốc + KySo_*) — khớp GetAttachmentsQuery / list hồ sơ.
+        // Loại phê duyệt khác: giữ load theo GroupId (mọi GroupType) để không đổi hành vi.
+        var hsmtGroupIds = items
+            .Where(i => i.EntityName == PheDuyetEntityNames.HoSoMoiThauDienTu
+                        && !string.IsNullOrEmpty(i.EntityId))
+            .Select(i => i.EntityId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (hsmtGroupIds.Count > 0) {
+            var hsmtGroupTypes = AttachmentSubquery.ExpandGroupTypes(
+                includeSigned,
+                HoSoMoiThauDienTuBaseGroupTypes);
+            query = query.Where(i =>
+                !hsmtGroupIds.Contains(i.GroupId!)
+                || hsmtGroupTypes.Contains(i.GroupType));
+        }
+
+        var files = query
+            .ToList()
+            .DistinctBy(f => f.Id)
             .ToList();
         AssignAttachments(items, files);
     }

--- a/QLDA.Tests/Unit/PheDuyetQueryableExtensionsAttachmentTests.cs
+++ b/QLDA.Tests/Unit/PheDuyetQueryableExtensionsAttachmentTests.cs
@@ -112,5 +112,83 @@ public class PheDuyetQueryableExtensionsAttachmentTests
 
         query.IncludeAttachments.Should().BeTrue();
     }
+
+    [Fact]
+    public void IncludeSigned_DefaultsToTrue_OnQuery()
+    {
+        var query = new PheDuyetGetDanhSachQuery();
+
+        query.IncludeSigned.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AssignAttachments_IncludesSignedFiles_WithParentId()
+    {
+        var entityId = Guid.Parse("08dee930-5abe-25bd-687a-7b4630000f5a");
+        var parentId = Guid.NewGuid();
+        var items = new List<PheDuyetListItemDto>
+        {
+            new()
+            {
+                EntityId = entityId.ToString(),
+                EntityName = "HoSoMoiThauDienTu",
+            },
+        };
+        var files = new List<Attachment>
+        {
+            new()
+            {
+                Id = parentId,
+                GroupId = entityId.ToString(),
+                GroupType = "HoSoMoiThauDienTu",
+                FileName = "goc.pdf",
+                ParentId = null,
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                GroupId = entityId.ToString(),
+                GroupType = "KySo_HoSoMoiThauDienTu",
+                FileName = "goc.signed.pdf",
+                ParentId = parentId,
+            },
+            new()
+            {
+                Id = Guid.NewGuid(),
+                GroupId = entityId.ToString(),
+                GroupType = "HoSoMoiThauDienTu",
+                FileName = "goc2.pdf",
+                ParentId = null,
+            },
+        };
+
+        PheDuyetQueryableExtensions.AssignAttachments(items, files);
+
+        items[0].DanhSachTepDinhKem.Should().HaveCount(3);
+        items[0].DanhSachTepDinhKem.Should().Contain(f => f.GroupType == "KySo_HoSoMoiThauDienTu");
+        items[0].DanhSachTepDinhKem.Should().Contain(f => f.ParentId == parentId);
+    }
+
+    [Fact]
+    public void AssignAttachments_DeduplicatesById()
+    {
+        var entityId = Guid.NewGuid();
+        var fileId = Guid.NewGuid();
+        var items = new List<PheDuyetListItemDto>
+        {
+            new() { EntityId = entityId.ToString() },
+        };
+        var dup = new Attachment
+        {
+            Id = fileId,
+            GroupId = entityId.ToString(),
+            GroupType = "HoSoMoiThauDienTu",
+            FileName = "a.pdf",
+        };
+
+        PheDuyetQueryableExtensions.AssignAttachments(items, [dup, dup]);
+
+        items[0].DanhSachTepDinhKem.Should().HaveCount(1);
+    }
 }
 

--- a/QLDA.WebApi/Controllers/HoSoMoiThauDienTuController.cs
+++ b/QLDA.WebApi/Controllers/HoSoMoiThauDienTuController.cs
@@ -17,32 +17,36 @@ public class HoSoMoiThauDienTuController(IServiceProvider sp) : AggregateRootCon
     [HttpGet("{id}")]
     public async Task<ResultApi> Get(Guid id) {
         var entity = await Mediator.Send(new HoSoMoiThauDienTuGetQuery { Id = id });
+        var groupId = entity.Id.ToString();
         var files = (await Mediator.Send(new GetAttachmentsQuery(
-            GroupIds: [entity.Id.ToString()],
+            GroupIds: [groupId],
             BaseGroupTypes: [EGroupType.HoSoMoiThauDienTu.ToString()]
         ))).ToAttachmentEntities();
-        var filesToTrinh = new  List<Attachment>();
-        if(entity.ToTrinh!= null)
+
+        // Dữ liệu mới lưu theo HoSo.Id; giữ thêm Id cũ để đọc bản ghi legacy.
+        var filesToTrinh = new List<Attachment>();
+        if (entity.ToTrinh != null)
             filesToTrinh = (await Mediator.Send(new GetAttachmentsQuery(
-            GroupIds: [entity.ToTrinh != null ? entity.ToTrinh.Id.ToString() : ""],
+            GroupIds: [groupId, entity.ToTrinh.Id.ToString()],
             BaseGroupTypes: [EGroupType.HoSoMoiThauDienTuToTrinh.ToString()]
         ))).ToAttachmentEntities();
-        var filesQuyetDinh = new  List<Attachment>();
+
+        var filesQuyetDinh = new List<Attachment>();
         if (entity.QuyetDinh != null)
             filesQuyetDinh = (await Mediator.Send(new GetAttachmentsQuery(
-            GroupIds: [entity.QuyetDinh != null ? entity.QuyetDinh.Id.ToString() : ""],
+            GroupIds: [groupId, entity.QuyetDinh.Id.ToString()],
             BaseGroupTypes: [EGroupType.HoSoMoiThauDienTuQuyetDinh.ToString()]
         ))).ToAttachmentEntities();
         var fileCamKets = (await Mediator.Send(new GetAttachmentsQuery(
-            GroupIds: [entity.Id.ToString()],
+            GroupIds: [groupId],
             BaseGroupTypes: [EGroupType.HoSoMoiThauDienTuCamKetTD.ToString()]
         ))).ToAttachmentEntities();
         var fileThamDinhs = (await Mediator.Send(new GetAttachmentsQuery(
-            GroupIds: [entity.Id.ToString()],
+            GroupIds: [groupId],
             BaseGroupTypes: [EGroupType.HoSoMoiThauDienTuQuyetDinhTD.ToString()]
         ))).ToAttachmentEntities();
         var fileBaoCaos = (await Mediator.Send(new GetAttachmentsQuery(
-            GroupIds: [entity.Id.ToString()],
+            GroupIds: [groupId],
             BaseGroupTypes: [EGroupType.HoSoMoiThauDienTuBaoCaoTD.ToString()]
         ))).ToAttachmentEntities();
         return ResultApi.Ok(entity.ToModel(files, fileCamKets, fileThamDinhs, fileBaoCaos, filesToTrinh, filesQuyetDinh));
@@ -91,45 +95,45 @@ public class HoSoMoiThauDienTuController(IServiceProvider sp) : AggregateRootCon
         return ResultApi.Ok(1);
     }
     private async Task SaveDanhSachTepDinhKemAsync(HoSoMoiThauDienTuModel model, HoSoMoiThauDienTu entity, HoSoMoiThauDienTu? entityOld, CancellationToken cancellationToken) {
+        // Tất cả tệp HSMTĐT dùng chung GroupId = HoSoMoiThauDienTu.Id.
         var entityId = entity.Id;
+        var groupId = entityId.ToString();
 
         await SyncTepDinhKemAsync(
-            entityId.ToString(),
+            groupId,
             model.GetDanhSachTepDinhKem(entityId),
             EGroupType.HoSoMoiThauDienTu.ToString(),
             cancellationToken);
 
         if (entity.ToTrinh != null || entityOld?.ToTrinh != null) {
-            var toTrinhId = entity.ToTrinh != null  ? entity.ToTrinh.Id : entityOld?.ToTrinh?.Id;
             await SyncTepDinhKemAsync(
-                (toTrinhId??0).ToString(),
-                model.ToTrinh?.GetDanhSachTepDinhKemToTrinh(toTrinhId??0) ?? [],
+                groupId,
+                model.ToTrinh?.GetDanhSachTepDinhKemToTrinh(entityId) ?? [],
                 EGroupType.HoSoMoiThauDienTuToTrinh.ToString(),
                 cancellationToken);
         }
         if (entity.QuyetDinh != null || entityOld?.QuyetDinh != null) {
-            var quyetDinhId = entity.QuyetDinh != null ? entity.QuyetDinh.Id : entityOld?.QuyetDinh?.Id;
             await SyncTepDinhKemAsync(
-                (quyetDinhId ?? 0).ToString(),
-                model.QuyetDinh?.GetDanhSachTepDinhKemQuyetDinh(quyetDinhId??0) ?? [],
+                groupId,
+                model.QuyetDinh?.GetDanhSachTepDinhKemQuyetDinh(entityId) ?? [],
                 EGroupType.HoSoMoiThauDienTuQuyetDinh.ToString(),
                 cancellationToken);
         }
 
         await SyncTepDinhKemAsync(
-                   entityId.ToString(),
+                   groupId,
                     model.HoSoMoiThauThamDinh?.GetDanhSachTepDinhKemQuyetDinhThamDinh(entityId) ?? [],
                    EGroupType.HoSoMoiThauDienTuQuyetDinhTD.ToString(),
                    cancellationToken) ;
 
         await SyncTepDinhKemAsync(
-            entityId.ToString(),
+            groupId,
             model.HoSoMoiThauThamDinh?.GetDanhSachTepDinhKemCamKetThamDinh(entityId)??[],
             EGroupType.HoSoMoiThauDienTuCamKetTD.ToString(),
             cancellationToken);
 
         await SyncTepDinhKemAsync(
-            entityId.ToString(),
+            groupId,
             model.HoSoMoiThauThamDinh?.GetDanhSachTepDinhKemBaoCaoThamDinh(entityId) ?? [],
             EGroupType.HoSoMoiThauDienTuBaoCaoTD.ToString(),
             cancellationToken);

--- a/QLDA.WebApi/Models/HoSoMoiThauDienTus/HoSoMoiThauDienTuMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/HoSoMoiThauDienTus/HoSoMoiThauDienTuMappingConfiguration.cs
@@ -161,12 +161,19 @@ public static class HoSoMoiThauDienTuMappingConfiguration
        this HoSoMoiThauThamDinhModel model, Guid groupId)
        => model.DinhKemQuyetDinh?.ToEntities(groupId, EGroupType.HoSoMoiThauDienTuQuyetDinhTD).ToList() ?? [];
 
+    /// <summary>
+    /// groupId = HoSoMoiThauDienTu.Id, không dùng ToTrinh.Id.
+    /// </summary>
     public static List<Attachment> GetDanhSachTepDinhKemToTrinh(
-       this ToTrinhQuyetDinhModel model, long groupId)
-       => model.DanhSachTepDinhKem?.ToEntities(groupId.ToString(), EGroupType.HoSoMoiThauDienTuToTrinh).ToList() ?? [];
+       this ToTrinhQuyetDinhModel model, Guid groupId)
+       => model.DanhSachTepDinhKem?.ToEntities(groupId, EGroupType.HoSoMoiThauDienTuToTrinh).ToList() ?? [];
+
+    /// <summary>
+    /// groupId = HoSoMoiThauDienTu.Id, không dùng QuyetDinh.Id.
+    /// </summary>
     public static List<Attachment> GetDanhSachTepDinhKemQuyetDinh(
-      this ToTrinhQuyetDinhModel model, long groupId)
-      => model.DanhSachTepDinhKem?.ToEntities(groupId.ToString(), EGroupType.HoSoMoiThauDienTuQuyetDinh).ToList() ?? [];
+      this ToTrinhQuyetDinhModel model, Guid groupId)
+      => model.DanhSachTepDinhKem?.ToEntities(groupId, EGroupType.HoSoMoiThauDienTuQuyetDinh).ToList() ?? [];
 
     public static List<Attachment> GetDanhSachTepDinhKem(
         this HoSoMoiThauDienTuModel model, Guid groupId)

--- a/docs/feature/HoSoMoiThauDienTu/bug-groupid-tep-totrinh-quyetdinh.md
+++ b/docs/feature/HoSoMoiThauDienTu/bug-groupid-tep-totrinh-quyetdinh.md
@@ -1,0 +1,604 @@
+# Bug: `GroupId` tệp tờ trình / quyết định Hồ sơ mời thầu điện tử
+
+Tài liệu mô tả **chỗ sai**, **vì sao sai**, và **cách sửa chi tiết** (sửa tại nguồn lưu dữ liệu).
+
+> **Không migration.** Không đổi Id thật của entity `ToTrinh` / `QuyetDinh`. Chỉ đổi `Attachment.GroupId` (bảng `TepDinhKem`).
+>
+> **Không** workaround bằng cách ghép file thủ công trong vòng `foreach` ở màn phê duyệt.
+
+---
+
+## 1. Triệu chứng
+
+Khi một Hồ sơ mời thầu điện tử có:
+
+- tệp hồ sơ
+- tệp tờ trình
+- tệp quyết định
+- (và các phiên bản ký số tương ứng)
+
+thì trên **danh sách phê duyệt** (`PheDuyet`), `DanhSachTepDinhKem` **thiếu** tệp tờ trình / quyết định (chỉ còn tệp gắn đúng `GroupId = HoSoMoiThauDienTu.Id`).
+
+---
+
+## 2. Chuỗi dữ liệu liên quan
+
+```text
+Create/Update HSMTĐT
+  → SaveDanhSachTepDinhKemAsync
+    → SyncTepDinhKemAsync(GroupId, GroupType, Entities)
+      → AttachmentBulkInsertOrUpdateCommand  (lưu TepDinhKem)
+
+Danh sách phê duyệt
+  → AttachTepDinhKem / AssignAttachments
+    → filesByGroupId.TryGetValue(item.EntityId, ...)
+      → EntityId = HoSoMoiThauDienTu.Id.ToString()
+```
+
+**Quy ước đúng (mục tiêu):** mọi tệp thuộc một hồ sơ dùng **cùng một `GroupId` = `HoSoMoiThauDienTu.Id`**; phân loại bằng `GroupType`.
+
+| Loại tệp        | GroupId đúng              | GroupType                      |
+|-----------------|---------------------------|--------------------------------|
+| Tệp hồ sơ       | `HoSoMoiThauDienTu.Id`    | `HoSoMoiThauDienTu`            |
+| Tệp tờ trình    | `HoSoMoiThauDienTu.Id`    | `HoSoMoiThauDienTuToTrinh`     |
+| Tệp quyết định  | `HoSoMoiThauDienTu.Id`    | `HoSoMoiThauDienTuQuyetDinh`   |
+
+---
+
+## 3. Chỗ sai (chi tiết)
+
+### 3.1. Nguyên nhân gốc — lưu sai `GroupId` khi Create/Update
+
+**File:** `QLDA.WebApi/Controllers/HoSoMoiThauDienTuController.cs`  
+**Method:** `SaveDanhSachTepDinhKemAsync` (được gọi từ `Create` và `Update`)
+
+**Code hiện tại (sai):**
+
+```csharp
+// Tệp hồ sơ — ĐÚNG: GroupId = entity.Id
+await SyncTepDinhKemAsync(
+    entityId.ToString(),
+    model.GetDanhSachTepDinhKem(entityId),
+    EGroupType.HoSoMoiThauDienTu.ToString(),
+    cancellationToken);
+
+// Tệp tờ trình — SAI: GroupId = ToTrinh.Id
+if (entity.ToTrinh != null || entityOld?.ToTrinh != null) {
+    var toTrinhId = entity.ToTrinh != null ? entity.ToTrinh.Id : entityOld?.ToTrinh?.Id;
+    await SyncTepDinhKemAsync(
+        (toTrinhId ?? 0).ToString(),                                    // ← SAI
+        model.ToTrinh?.GetDanhSachTepDinhKemToTrinh(toTrinhId ?? 0) ?? [], // ← SAI (truyền Id tờ trình)
+        EGroupType.HoSoMoiThauDienTuToTrinh.ToString(),
+        cancellationToken);
+}
+
+// Tệp quyết định — SAI: GroupId = QuyetDinh.Id
+if (entity.QuyetDinh != null || entityOld?.QuyetDinh != null) {
+    var quyetDinhId = entity.QuyetDinh != null ? entity.QuyetDinh.Id : entityOld?.QuyetDinh?.Id;
+    await SyncTepDinhKemAsync(
+        (quyetDinhId ?? 0).ToString(),                                      // ← SAI
+        model.QuyetDinh?.GetDanhSachTepDinhKemQuyetDinh(quyetDinhId ?? 0) ?? [], // ← SAI
+        EGroupType.HoSoMoiThauDienTuQuyetDinh.ToString(),
+        cancellationToken);
+}
+```
+
+**Vì sao sai:**
+
+1. `SyncTepDinhKemAsync` ghi `Attachment.GroupId` = tham số `groupId` truyền vào.
+2. Tệp tờ trình / quyết định bị lưu với `GroupId` là **Id của `ToTrinhQuyetDinh`** (kiểu `long`), không phải Id hồ sơ.
+3. `GroupType` vẫn đúng (`HoSoMoiThauDienTuToTrinh` / `HoSoMoiThauDienTuQuyetDinh`) — phân loại loại tệp ổn — nhưng **khóa gom nhóm** (`GroupId`) lệch khỏi Id hồ sơ.
+4. Các nhóm thẩm định (`CamKetTD`, `QuyetDinhTD`, `BaoCaoTD`) đã dùng `entityId` — **đúng**; chỉ nhánh tờ trình / quyết định lệch.
+
+**Kết quả trong DB (ví dụ):**
+
+| File           | GroupId (sai)     | GroupType                    |
+|----------------|-------------------|------------------------------|
+| file_hoso.pdf  | `{guid-hoso}`     | `HoSoMoiThauDienTu`          |
+| file_totrinh.pdf | `12345` (ToTrinh.Id) | `HoSoMoiThauDienTuToTrinh` |
+| file_qd.pdf    | `67890` (QuyetDinh.Id) | `HoSoMoiThauDienTuQuyetDinh` |
+
+Ba tệp thuộc **một** hồ sơ nhưng nằm dưới **ba** `GroupId` khác nhau.
+
+---
+
+### 3.2. Mapping cũng gắn `GroupId` theo Id tờ trình / quyết định
+
+**File:** `QLDA.WebApi/Models/HoSoMoiThauDienTus/HoSoMoiThauDienTuMappingConfiguration.cs`
+
+```csharp
+public static List<Attachment> GetDanhSachTepDinhKemToTrinh(
+    this ToTrinhQuyetDinhModel model, long groupId)
+    => model.DanhSachTepDinhKem?.ToEntities(
+        groupId.ToString(),                          // ← mỗi Attachment.GroupId = groupId truyền vào
+        EGroupType.HoSoMoiThauDienTuToTrinh).ToList() ?? [];
+
+public static List<Attachment> GetDanhSachTepDinhKemQuyetDinh(
+    this ToTrinhQuyetDinhModel model, long groupId)
+    => model.DanhSachTepDinhKem?.ToEntities(
+        groupId.ToString(),
+        EGroupType.HoSoMoiThauDienTuQuyetDinh).ToList() ?? [];
+```
+
+**Vì sao sai (bổ sung cho 3.1):**
+
+- Tham số tên `groupId` nhưng caller đang truyền `toTrinhId` / `quyetDinhId`.
+- `ToEntities(...)` gán `Attachment.GroupId` trên từng entity trước khi bulk sync.
+- Dù có sửa `SyncTepDinhKemAsync(..., groupId: entity.Id)` mà vẫn gọi `GetDanhSachTepDinhKemToTrinh(toTrinhId)`, **Entities** vẫn mang `GroupId` cũ của tờ trình → có thể lệch so với `GroupId` trên command (tùy handler resolve). Phải sửa cả phía mapping / tham số truyền vào.
+
+---
+
+### 3.3. Triệu chứng lộ ra ở gán tệp danh sách phê duyệt
+
+**File:** `QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetQueryableExtensions.cs`  
+**Methods:** `AttachTepDinhKem` + `AssignAttachments`
+
+```csharp
+// Chỉ lấy file có GroupId ∈ danh sách EntityId của item phê duyệt
+var groupIds = items.Select(i => i.EntityId)...;
+var files = tepDinhKemRepo.GetQueryableSet()
+    .Where(i => groupIds.Contains(i.GroupId))
+    .ToList();
+
+// Gán theo đúng một khóa: EntityId (= Id hồ sơ / entity được phê duyệt)
+foreach (var item in items) {
+    item.DanhSachTepDinhKem =
+        !string.IsNullOrEmpty(item.EntityId)
+        && filesByGroupId.TryGetValue(item.EntityId, out var matched)
+            ? matched
+            : [];
+}
+```
+
+**Vì sao “thiếu file”:**
+
+1. Với HSMTĐT, `item.EntityId` = `HoSoMoiThauDienTu.Id.ToString()`.
+2. Query chỉ nạp file có `GroupId` trùng `EntityId` đó.
+3. File tờ trình (`GroupId = ToTrinh.Id`) và quyết định (`GroupId = QuyetDinh.Id`) **không nằm trong** `groupIds` → không vào `files` → không vào `filesByGroupId`.
+4. `TryGetValue(item.EntityId, ...)` chỉ thấy tệp hồ sơ (+ thẩm định nếu có), **không** thấy tờ trình / quyết định.
+
+Đây là **hệ quả** của dữ liệu lưu sai — **không** phải chỗ cần “vá” bằng cách join thêm `ToTrinh.Id` / `QuyetDinh.Id` trong `foreach`. Sửa đúng là chỉnh nguồn lưu (mục 4).
+
+> Ghi chú: `HoSoMoiThauDienTuGetDanhSachQuery` đã subquery theo cả `e.Id`, `e.ToTrinh.Id`, `e.QuyetDinh.Id` nên **màn danh sách HSMTĐT** vẫn thấy đủ file (kể cả dữ liệu cũ). Màn **phê duyệt** thì không — vì chỉ lookup theo `EntityId`.
+
+---
+
+### 3.4. Đọc chi tiết Get cũng đang theo Id tờ trình / quyết định
+
+**File:** `QLDA.WebApi/Controllers/HoSoMoiThauDienTuController.cs` — method `Get`
+
+```csharp
+filesToTrinh = (await Mediator.Send(new GetAttachmentsQuery(
+    GroupIds: [entity.ToTrinh.Id.ToString()],   // đọc theo ToTrinh.Id
+    BaseGroupTypes: [EGroupType.HoSoMoiThauDienTuToTrinh.ToString()]
+))).ToAttachmentEntities();
+
+filesQuyetDinh = (await Mediator.Send(new GetAttachmentsQuery(
+    GroupIds: [entity.QuyetDinh.Id.ToString()], // đọc theo QuyetDinh.Id
+    BaseGroupTypes: [EGroupType.HoSoMoiThauDienTuQuyetDinh.ToString()]
+))).ToAttachmentEntities();
+```
+
+Sau khi sửa **lưu** sang `GroupId = entity.Id`, nếu **không** sửa `Get` thì màn chi tiết sẽ không thấy tệp tờ trình / quyết định mới. Cần đọc theo `entity.Id` (có thể giữ thêm lookup Id cũ nếu cần tương thích dữ liệu cũ — tùy chọn, ngoài phạm vi tối thiểu nếu chỉ yêu cầu dữ liệu mới).
+
+---
+
+## 4. Cách sửa (chi tiết từng chỗ)
+
+### Nguyên tắc
+
+- Tất cả tệp thuộc HSMTĐT: `GroupId = HoSoMoiThauDienTu.Id.ToString()`.
+- Phân biệt loại bằng `GroupType` (giữ nguyên enum hiện có).
+- Không đổi PK / Id của `ToTrinh`, `QuyetDinh`.
+- Không migration; không refactor ngoài phạm vi.
+
+---
+
+### 4.1. Sửa `SaveDanhSachTepDinhKemAsync`
+
+**File:** `QLDA.WebApi/Controllers/HoSoMoiThauDienTuController.cs`
+
+**Hướng sửa:**
+
+```csharp
+private async Task SaveDanhSachTepDinhKemAsync(...) {
+    var groupId = entity.Id.ToString();   // chung cho mọi loại tệp của hồ sơ
+
+    await SyncTepDinhKemAsync(
+        groupId,
+        model.GetDanhSachTepDinhKem(entity.Id),
+        EGroupType.HoSoMoiThauDienTu.ToString(),
+        cancellationToken);
+
+    if (entity.ToTrinh != null || entityOld?.ToTrinh != null) {
+        await SyncTepDinhKemAsync(
+            groupId,   // KHÔNG còn toTrinhId.ToString()
+            model.ToTrinh?.GetDanhSachTepDinhKemToTrinh(groupId) ?? [],
+            EGroupType.HoSoMoiThauDienTuToTrinh.ToString(),
+            cancellationToken);
+    }
+
+    if (entity.QuyetDinh != null || entityOld?.QuyetDinh != null) {
+        await SyncTepDinhKemAsync(
+            groupId,   // KHÔNG còn quyetDinhId.ToString()
+            model.QuyetDinh?.GetDanhSachTepDinhKemQuyetDinh(groupId) ?? [],
+            EGroupType.HoSoMoiThauDienTuQuyetDinh.ToString(),
+            cancellationToken);
+    }
+
+    // Thẩm định: giữ nguyên (đã dùng entity.Id)
+    ...
+}
+```
+
+**Chi tiết thay đổi:**
+
+| Trước | Sau |
+|-------|-----|
+| `Sync(..., toTrinhId.ToString(), Get...ToTrinh(toTrinhId), ...)` | `Sync(..., groupId, Get...ToTrinh(groupId), ...)` |
+| `Sync(..., quyetDinhId.ToString(), Get...QuyetDinh(quyetDinhId), ...)` | `Sync(..., groupId, Get...QuyetDinh(groupId), ...)` |
+
+`Create` / `Update` không cần đổi signature — chỉ cần sửa helper vì cả hai đều gọi `SaveDanhSachTepDinhKemAsync`.
+
+**Lưu ý khi Update bản ghi cũ:** lần Update sau sẽ sync với `GroupId = entity.Id` + `AutoDeleteMissing = true` theo `GroupTypes` tương ứng → file mới gắn đúng Id hồ sơ. File cũ còn `GroupId = ToTrinh.Id` **không** tự xóa bởi sync mới (khác GroupId). Có thể:
+
+- chấp nhận orphan dữ liệu cũ + query list HSMTĐT vẫn đọc được nhờ nhánh `ToTrinh.Id` / `QuyetDinh.Id`, hoặc
+- (ngoài phạm vi tối thiểu) thêm bước migrate/soft-delete orphan theo Id cũ khi Update.
+
+---
+
+### 4.2. Sửa mapping `GetDanhSachTepDinhKemToTrinh` / `GetDanhSachTepDinhKemQuyetDinh`
+
+**File:** `QLDA.WebApi/Models/HoSoMoiThauDienTus/HoSoMoiThauDienTuMappingConfiguration.cs`
+
+**Hướng sửa (đổi tham số nhận `string`/`Guid` của hồ sơ, không còn `long` Id tờ trình):**
+
+```csharp
+public static List<Attachment> GetDanhSachTepDinhKemToTrinh(
+    this ToTrinhQuyetDinhModel model, string groupId)  // = HoSoMoiThauDienTu.Id.ToString()
+    => model.DanhSachTepDinhKem?.ToEntities(
+        groupId,
+        EGroupType.HoSoMoiThauDienTuToTrinh).ToList() ?? [];
+
+public static List<Attachment> GetDanhSachTepDinhKemQuyetDinh(
+    this ToTrinhQuyetDinhModel model, string groupId)
+    => model.DanhSachTepDinhKem?.ToEntities(
+        groupId,
+        EGroupType.HoSoMoiThauDienTuQuyetDinh).ToList() ?? [];
+```
+
+Hoặc overload nhận `Guid groupId` rồi `.ToString()` bên trong — miễn caller truyền **Id hồ sơ**.
+
+**Không** đổi Id entity `ToTrinh` / `QuyetDinh` trong DTO insert/update.
+
+---
+
+### 4.3. Sửa `Get` (đọc chi tiết) cho khớp dữ liệu mới
+
+**File:** cùng controller — method `Get`
+
+Đổi `GroupIds` tờ trình / quyết định sang `entity.Id.ToString()`:
+
+```csharp
+GroupIds: [entity.Id.ToString()],
+BaseGroupTypes: [EGroupType.HoSoMoiThauDienTuToTrinh.ToString()]
+
+GroupIds: [entity.Id.ToString()],
+BaseGroupTypes: [EGroupType.HoSoMoiThauDienTuQuyetDinh.ToString()]
+```
+
+(Tuỳ chọn tương thích cũ: truyền cả `entity.Id` và `ToTrinh.Id` / `QuyetDinh.Id` trong `GroupIds`.)
+
+---
+
+### 4.4. Việc **không** làm
+
+| Không làm | Lý do |
+|-----------|--------|
+| Vá `AssignAttachments` để merge thêm file theo `ToTrinh.Id` / `QuyetDinh.Id` | Workaround; lệch chuẩn “một GroupId = một hồ sơ” |
+| Đổi Id `ToTrinh` / `QuyetDinh` | Ngoài phạm vi; không liên quan liên kết file |
+| Migration DB schema | Không đổi schema; chỉ đổi giá trị `GroupId` lúc ghi |
+| Refactor lớn ngoài Create/Update/Save/mapping/(Get) | Phạm vi yêu cầu |
+
+Giữ logic query theo `ToTrinh.Id` / `QuyetDinh.Id` trong `HoSoMoiThauDienTuGetDanhSachQuery` là **ổn** để đọc dữ liệu cũ.
+
+---
+
+## 5. Kết quả mong muốn sau khi sửa
+
+Sau Create hoặc Update:
+
+| Loại tệp       | GroupId                 | GroupType                    |
+|----------------|-------------------------|------------------------------|
+| Hồ sơ          | `HoSoMoiThauDienTu.Id`  | `HoSoMoiThauDienTu` (+ KySo_*) |
+| Tờ trình       | `HoSoMoiThauDienTu.Id`  | `HoSoMoiThauDienTuToTrinh` (+ KySo_*) |
+| Quyết định     | `HoSoMoiThauDienTu.Id`  | `HoSoMoiThauDienTuQuyetDinh` (+ KySo_*) |
+
+→ `filesByGroupId.TryGetValue(item.EntityId, ...)` lấy **đủ** toàn bộ tệp của hồ sơ trên màn phê duyệt.
+
+---
+
+## 6. Checklist kiểm thử
+
+- [ ] **Create** hồ sơ có tệp hồ sơ + tờ trình + quyết định → DB: cả ba `GroupId` = Id hồ sơ, `GroupType` khác nhau đúng.
+- [ ] **Update** đổi/thêm/xóa từng nhóm tệp → sync đúng theo `GroupType`, không xóa nhầm nhóm khác.
+- [ ] **Get** chi tiết → thấy đủ tệp tờ trình / quyết định sau khi lưu mới.
+- [ ] **Danh sách phê duyệt** (có attachments) → `DanhSachTepDinhKem` gồm cả hồ sơ + tờ trình + quyết định (+ ký số nếu có).
+- [ ] **Danh sách HSMTĐT** vẫn ổn với bản ghi cũ (GroupId = ToTrinh/QuyetDinh Id) nhờ query tương thích.
+- [ ] Không tạo migration; Id `ToTrinh` / `QuyetDinh` không đổi.
+
+Chi tiết bước Postman: mục **§8**.
+
+---
+
+## 7. File cần đụng tới
+
+| File | Việc |
+|------|------|
+| `QLDA.WebApi/Controllers/HoSoMoiThauDienTuController.cs` | `SaveDanhSachTepDinhKemAsync` (+ `Get` đọc theo `entity.Id`) |
+| `QLDA.WebApi/Models/HoSoMoiThauDienTus/HoSoMoiThauDienTuMappingConfiguration.cs` | `GetDanhSachTepDinhKemToTrinh` / `GetDanhSachTepDinhKemQuyetDinh` nhận GroupId hồ sơ |
+
+**Không sửa (trong phạm vi bug này):** `PheDuyetQueryableExtensions.AssignAttachments` — giữ lookup theo `EntityId`; sẽ đúng sau khi dữ liệu lưu đúng.
+
+---
+
+## 8. Cách test Postman
+
+### 8.1. Chuẩn bị
+
+| Item | Giá trị |
+|------|---------|
+| Base URL | `{{baseUrl}}` (vd: `https://localhost:7xxx` hoặc env đang dùng) |
+| Auth | Header `Authorization: Bearer {{token}}` (user đủ quyền HSMTĐT + xem phê duyệt) |
+| Prefetch | Có sẵn `duAnId`, `buocId`, `goiThauId`, `hinhThucLuaChonNhaThauId` hợp lệ |
+| File | Đã upload trước (có `path`, `fileName`, `originalName`, `size`) — hoặc copy metadata file từ GET hồ sơ khác |
+
+**Environment variables gợi ý:**
+
+| Variable | Sau bước nào |
+|----------|----------------|
+| `hosoId` | Response `POST them-moi` → `data` (Guid) |
+| `duAnId` | Prefetch |
+| `filePathHoso` / `filePathToTrinh` / `filePathQd` | File đã upload |
+
+### 8.2. Endpoints dùng
+
+| # | Method | URL | Mục đích |
+|---|--------|-----|----------|
+| 1 | `POST` | `/api/ho-so-moi-thau-dien-tu/them-moi` | Create + lưu 3 nhóm tệp |
+| 2 | `GET` | `/api/ho-so-moi-thau-dien-tu/{{hosoId}}` | Chi tiết + kiểm tra file trả về |
+| 3 | `PUT` | `/api/ho-so-moi-thau-dien-tu/cap-nhat` | Update + sync lại tệp |
+| 4 | `GET` | `/api/ho-so-moi-thau-dien-tu/danh-sach?duAnId={{duAnId}}` | List HSMTĐT (tương thích dữ liệu cũ) |
+| 5 | `GET` | `/api/phe-duyet/danh-sach?type=HoSoMoiThauDienTu&duAnId={{duAnId}}` | **Bug lộ ở đây** — `DanhSachTepDinhKem` |
+
+> `type` phải đúng literal: `HoSoMoiThauDienTu`.  
+> Danh sách phê duyệt chỉ có dòng nếu đã có bản ghi `PheDuyet` với `EntityId = hosoId` (thường sau khi trình / có luồng tạo PheDuyet). Nếu chưa có dòng → kiểm chứng GroupId bằng SQL (§8.6) vẫn đủ chứng minh fix lưu.
+
+### 8.3. Test A — Create (quan trọng nhất)
+
+**Request**
+
+```http
+POST {{baseUrl}}/api/ho-so-moi-thau-dien-tu/them-moi
+Content-Type: application/json
+Authorization: Bearer {{token}}
+```
+
+**Body mẫu** (điền Id dự án / gói thầu / path file thật):
+
+```json
+{
+  "duAnId": "{{duAnId}}",
+  "buocId": 1,
+  "thamDinh": false,
+  "hinhThucLuaChonNhaThauId": 1,
+  "goiThauId": "{{goiThauId}}",
+  "giaTri": 1000000,
+  "thoiGianThucHien": "30 ngày",
+  "trangThaiDangTai": false,
+  "danhSachTepDinhKem": [
+    {
+      "id": null,
+      "fileName": "hoso.pdf",
+      "originalName": "hoso.pdf",
+      "path": "{{filePathHoso}}",
+      "size": 1024,
+      "type": null
+    }
+  ],
+  "toTrinh": {
+    "so": "TT-001",
+    "ngay": "2026-07-27T00:00:00+07:00",
+    "trichYeu": "Tờ trình HSMTĐT test GroupId",
+    "nguoiKy": "Nguyễn A",
+    "chucVu": 1,
+    "danhSachTepDinhKem": [
+      {
+        "id": null,
+        "fileName": "totrinh.pdf",
+        "originalName": "totrinh.pdf",
+        "path": "{{filePathToTrinh}}",
+        "size": 2048
+      }
+    ]
+  },
+  "quyetDinh": {
+    "so": "QD-001",
+    "ngay": "2026-07-27T00:00:00+07:00",
+    "trichYeu": "Quyết định HSMTĐT test GroupId",
+    "nguoiKy": "Nguyễn B",
+    "chucVu": 1,
+    "danhSachTepDinhKem": [
+      {
+        "id": null,
+        "fileName": "quyetdinh.pdf",
+        "originalName": "quyetdinh.pdf",
+        "path": "{{filePathQd}}",
+        "size": 3072
+      }
+    ]
+  }
+}
+```
+
+**Tests tab (Postman):**
+
+```js
+pm.test("Create 200 + có Id", function () {
+  pm.response.to.have.status(200);
+  const json = pm.response.json();
+  pm.expect(json.data).to.be.ok;
+  pm.environment.set("hosoId", json.data);
+});
+```
+
+**Kỳ vọng sau Create**
+
+| Trước fix (bug) | Sau fix |
+|-----------------|---------|
+| DB: 1 file `GroupId = hosoId` + 2 file `GroupId = ToTrinh.Id` / `QuyetDinh.Id` | DB: **cả 3** file `GroupId = hosoId` |
+| `GroupType` vẫn đúng từng loại | `GroupType` vẫn đúng từng loại |
+
+### 8.4. Test B — Get chi tiết
+
+```http
+GET {{baseUrl}}/api/ho-so-moi-thau-dien-tu/{{hosoId}}
+Authorization: Bearer {{token}}
+```
+
+**Tests tab:**
+
+```js
+pm.test("Có đủ 3 nhóm tệp", function () {
+  const d = pm.response.json().data;
+  pm.expect(d.danhSachTepDinhKem, "tệp hồ sơ").to.be.an("array").that.is.not.empty;
+  pm.expect(d.toTrinh.danhSachTepDinhKem, "tệp tờ trình").to.be.an("array").that.is.not.empty;
+  pm.expect(d.quyetDinh.danhSachTepDinhKem, "tệp quyết định").to.be.an("array").that.is.not.empty;
+});
+
+pm.test("GroupId tờ trình / QĐ = Id hồ sơ (sau fix)", function () {
+  const d = pm.response.json().data;
+  const hosoId = String(d.id);
+  d.toTrinh.danhSachTepDinhKem.forEach(f => {
+    pm.expect(String(f.groupId), f.fileName).to.eql(hosoId);
+  });
+  d.quyetDinh.danhSachTepDinhKem.forEach(f => {
+    pm.expect(String(f.groupId), f.fileName).to.eql(hosoId);
+  });
+  d.danhSachTepDinhKem.forEach(f => {
+    pm.expect(String(f.groupId), f.fileName).to.eql(hosoId);
+  });
+});
+```
+
+**Lưu ý:**
+
+- **Trước khi sửa `Get`:** nếu chỉ sửa Save, Get vẫn query theo `ToTrinh.Id` → `toTrinh.danhSachTepDinhKem` có thể **rỗng** dù DB đã lưu đúng `GroupId = hosoId`. Phải sửa Get theo §4.3 rồi mới assert được qua API.
+- Khi đó dùng SQL (§8.6) để xác nhận Save đúng trước.
+
+### 8.5. Test C — Update
+
+1. `GET {{hosoId}}` → copy body response `data` làm base.
+2. Giữ nguyên file cũ (có `id`, `groupId`, `groupType`) + thêm 1 file mới `id: null` vào `toTrinh.danhSachTepDinhKem` (hoặc xóa 1 file để test soft-delete).
+3. `PUT /api/ho-so-moi-thau-dien-tu/cap-nhat` với body đó (đảm bảo có `"id": "{{hosoId}}"`).
+
+**Kỳ vọng:**
+
+- File tờ trình / quyết định sau sync: `GroupId = hosoId`.
+- Không xóa nhầm nhóm khác (`HoSoMoiThauDienTu` vs `...ToTrinh` vs `...QuyetDinh`).
+- `toTrinh.id` / `quyetDinh.id` (long) **không đổi** — chỉ `TepDinhKem.GroupId` đổi theo quy ước mới.
+
+### 8.6. Xác nhận DB (bắt buộc để chứng minh root cause / fix)
+
+Chạy sau Create/Update (thay `@hosoId`):
+
+```sql
+SELECT Id, GroupId, GroupType, FileName, IsDeleted
+FROM TepDinhKem   -- hoặc tên bảng Attachment map tới
+WHERE GroupId = @hosoId
+   OR GroupType IN (
+        'HoSoMoiThauDienTu',
+        'HoSoMoiThauDienTuToTrinh',
+        'HoSoMoiThauDienTuQuyetDinh',
+        'KySo_HoSoMoiThauDienTu',
+        'KySo_HoSoMoiThauDienTuToTrinh',
+        'KySo_HoSoMoiThauDienTuQuyetDinh'
+      )
+ORDER BY GroupType, FileName;
+```
+
+**Pass sau fix:** mọi row tờ trình / quyết định của hồ sơ này có `GroupId = @hosoId` (Guid string), **không** còn `GroupId` = số long Id tờ trình/QĐ.
+
+**Fail trước fix (repro bug):**
+
+```text
+GroupId = '{guid}'     GroupType = HoSoMoiThauDienTu
+GroupId = '12345'      GroupType = HoSoMoiThauDienTuToTrinh   ← sai
+GroupId = '67890'      GroupType = HoSoMoiThauDienTuQuyetDinh ← sai
+```
+
+### 8.7. Test D — Danh sách phê duyệt (nơi bug lộ)
+
+```http
+GET {{baseUrl}}/api/phe-duyet/danh-sach?type=HoSoMoiThauDienTu&duAnId={{duAnId}}&pageIndex=0&pageSize=50
+Authorization: Bearer {{token}}
+```
+
+**Tests tab:**
+
+```js
+pm.test("Item hồ sơ có đủ tệp theo EntityId", function () {
+  const hosoId = pm.environment.get("hosoId");
+  const items = pm.response.json().data?.data ?? pm.response.json().data;
+  const item = (Array.isArray(items) ? items : []).find(
+    x => String(x.entityId).toLowerCase() === String(hosoId).toLowerCase()
+  );
+  pm.expect(item, "tìm thấy item phê duyệt của hồ sơ").to.be.ok;
+
+  const files = item.danhSachTepDinhKem || [];
+  const types = files.map(f => f.groupType);
+
+  pm.expect(files.length, "phải có > 1 file (hoso + totrinh + qd)").to.be.above(1);
+  pm.expect(types.some(t => t === "HoSoMoiThauDienTu" || t === "KySo_HoSoMoiThauDienTu")).to.be.true;
+  pm.expect(types.some(t => t === "HoSoMoiThauDienTuToTrinh" || t === "KySo_HoSoMoiThauDienTuToTrinh")).to.be.true;
+  pm.expect(types.some(t => t === "HoSoMoiThauDienTuQuyetDinh" || t === "KySo_HoSoMoiThauDienTuQuyetDinh")).to.be.true;
+
+  files.forEach(f => {
+    pm.expect(String(f.groupId).toLowerCase()).to.eql(String(hosoId).toLowerCase());
+  });
+});
+```
+
+| Trước fix | Sau fix |
+|-----------|---------|
+| `danhSachTepDinhKem` chỉ có tệp `GroupType = HoSoMoiThauDienTu` (thiếu tờ trình / QĐ) | Có đủ 3 `GroupType` (và KySo_* nếu có), cùng `groupId = entityId` |
+
+### 8.8. Test E — List HSMTĐT (tương thích cũ)
+
+```http
+GET {{baseUrl}}/api/ho-so-moi-thau-dien-tu/danh-sach?duAnId={{duAnId}}
+Authorization: Bearer {{token}}
+```
+
+- Bản ghi **mới** (sau fix): `danhSachTepDinhKem` vẫn đủ (subquery theo `e.Id`).
+- Bản ghi **cũ** (GroupId = ToTrinh/QuyetDinh Id): vẫn đủ nhờ nhánh `e.ToTrinh.Id` / `e.QuyetDinh.Id` — regression check, không được phá.
+
+### 8.9. Thứ tự chạy nhanh (Collection folder)
+
+1. Login / set `token`
+2. **A** Create 3 nhóm tệp → set `hosoId`
+3. **SQL** §8.6 (pass/fail GroupId)
+4. **B** Get chi tiết (sau khi đã sửa Get)
+5. **C** Update (optional)
+6. Trình / đảm bảo có dòng `PheDuyet` nếu cần
+7. **D** `phe-duyet/danh-sach` — assert đủ 3 GroupType
+8. **E** `ho-so-moi-thau-dien-tu/danh-sach` — không regress
+
+### 8.10. Checklist Postman
+
+- [ ] A Create → `hosoId` lưu env
+- [ ] SQL: 3 GroupType cùng `GroupId = hosoId`
+- [ ] B Get: `toTrinh` / `quyetDinh` / hồ sơ đều có file; `groupId` = `hosoId`
+- [ ] C Update: sync đúng, không xóa nhầm nhóm
+- [ ] D Phê duyệt: đủ tệp tờ trình + quyết định trong `danhSachTepDinhKem`
+- [ ] E List HSMTĐT: bản ghi cũ vẫn thấy file

--- a/docs/feature/HoSoMoiThauDienTu/bug-phe-duyet-danh-sach-thieu-ky-so.md
+++ b/docs/feature/HoSoMoiThauDienTu/bug-phe-duyet-danh-sach-thieu-ky-so.md
@@ -1,0 +1,262 @@
+# Bug: API danh sách phê duyệt thiếu file ký số (Hồ sơ mời thầu điện tử)
+
+> Ngày: 2026-07-27  
+> API: `GET /api/phe-duyet/danh-sach?type=HoSoMoiThauDienTu&trangThai=ĐTr&...`  
+> Query/Handler: `PheDuyetGetDanhSachQuery` → `PheDuyetQueryableExtensions.AttachTepDinhKem`  
+> Phạm vi sửa: **chỉ** load tệp đính kèm trên danh sách phê duyệt — không migration, không refactor lan man.
+
+---
+
+## 1. Triệu chứng
+
+Với `type=HoSoMoiThauDienTu`, API danh sách phê duyệt:
+
+- Trả được **file gốc** (`GroupType = HoSoMoiThauDienTu`, …).
+- **Thiếu file ký số** (`GroupType = KySo_HoSoMoiThauDienTu`, `KySo_HoSoMoiThauDienTuToTrinh`, …).
+- Số lượng file trên UI / `danhSachTepDinhKem.length` **không khớp** tổng gốc + ký số.
+
+Ví dụ mong đợi: 2 file gốc + 1 file ký số → API phải trả **3** file; count trên màn hình = 3.
+
+---
+
+## 2. So sánh với API chi tiết / danh sách Hồ sơ mời thầu điện tử (đúng)
+
+### 2.1. Chi tiết — `HoSoMoiThauDienTuController.Get`
+
+```csharp
+var files = (await Mediator.Send(new GetAttachmentsQuery(
+    GroupIds: [groupId],
+    BaseGroupTypes: [EGroupType.HoSoMoiThauDienTu.ToString()]
+    // IncludeSigned = true (mặc định)
+))).ToAttachmentEntities();
+```
+
+`GetAttachmentsQuery` gọi:
+
+```csharp
+AttachmentSubquery.ExpandGroupTypes(baseGroupTypes, includeSigned: true)
+// → ["HoSoMoiThauDienTu", "KySo_HoSoMoiThauDienTu"]
+```
+
+→ Filter `GroupType IN (base, KySo_base)` — **có đủ file ký số**.
+
+### 2.2. Danh sách hồ sơ — `HoSoMoiThauDienTuGetDanhSachQuery`
+
+```csharp
+var groupTypesOnEntityId = AttachmentSubquery.ExpandGroupTypes(
+    includeSigned: true,
+    nameof(EGroupType.HoSoMoiThauDienTu),
+    nameof(EGroupType.HoSoMoiThauDienTuToTrinh),
+    // … các base HSMTĐT khác
+);
+// Where: groupTypesOnEntityId.Contains(i.GroupType)
+```
+
+→ Cũng mở rộng sang `KySo_*` trước khi filter.
+
+### 2.3. Helper chuẩn dự án
+
+| Helper | Vai trò |
+|--------|---------|
+| `AttachmentSubquery.ExpandGroupTypes` | base → `[base, KySo_base]` (mặc định includeSigned = true) |
+| `SignedGroupTypeHelper.WithSignedVariant` | `"X"` → `"KySo_X"` |
+| `GetAttachmentsQuery` | Hydration controller; mặc định IncludeSigned = true |
+
+**Quy ước:** mặc định luôn gồm file ký số; chỉ bỏ khi `IncludeSigned = false` tường minh.  
+**Không** loại file vì `ParentId != null` (file ký số thường trỏ ParentId về file gốc).
+
+---
+
+## 3. Chỗ sai (chi tiết)
+
+### 3.1. File / method
+
+| | |
+|--|--|
+| **File** | `QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetQueryableExtensions.cs` |
+| **Method** | `AttachTepDinhKem` (gọi từ `ApplyDanhSachFilters` sau khi materialize list) |
+| **Caller** | `PheDuyetGetDanhSachQueryHandler.Handle` |
+
+`PheDuyetGetDanhSachQueryHandler` **không** tự load file — ủy quyền cho `ApplyDanhSachFilters` → `AttachTepDinhKem`.
+
+### 3.2. Code trước khi sửa (sai / lệch chuẩn)
+
+```csharp
+private static void AttachTepDinhKem(
+    List<PheDuyetListItemDto> items,
+    IRepository<Attachment, Guid> tepDinhKemRepo)
+{
+    var groupIds = items.Select(i => i.EntityId)...;
+
+    var files = tepDinhKemRepo.GetQueryableSet()
+        .AsNoTracking()
+        .Where(i => groupIds.Contains(i.GroupId))   // ← chỉ GroupId
+        .ToList();                                    // ← không ExpandGroupTypes
+
+    AssignAttachments(items, files);
+}
+```
+
+### 3.3. Vì sao sai
+
+1. **Lệch pattern đọc file chuẩn của dự án**  
+   Chi tiết / list HSMTĐT dùng `ExpandGroupTypes` / `GetAttachmentsQuery` để luôn gồm `KySo_<base>`.  
+   Danh sách phê duyệt **không** gọi helper đó → không có contract rõ ràng “mặc định include ký số”.
+
+2. **Với `type = HoSoMoiThauDienTu` cần nhiều base GroupType**  
+   Không chỉ `HoSoMoiThauDienTu` mà còn `…ToTrinh`, `…QuyetDinh`, thẩm định, …  
+   Nếu sau này (hoặc FE / logic trung gian) scope exact `GroupType == EntityName` (`HoSoMoiThauDienTu`) **mà không** expand → **mọi** `KySo_*` bị loại, dù cùng `GroupId`.
+
+3. **Không có cờ `IncludeSigned`**  
+   Không opt-out tường minh; không đồng bộ với `GetAttachmentsQuery(IncludeSigned = true mặc định)`.
+
+4. **Không dedupe theo `Id`**  
+   Nếu join / batch trùng bản ghi, list + count có thể lệch (yêu cầu: không trả trùng).
+
+5. **Không liên quan lọc `ParentId`**  
+   `AttachTepDinhKem` cũ **không** `Where(ParentId == null)` — đúng về mặt này.  
+   Vẫn phải **giữ** nguyên khi sửa: file có `ParentId` / `KySo_*` vẫn trả về.
+
+> Ghi chú tách bug `GroupId` tờ trình/QĐ (lưu sai Id tờ trình): xem `docs/feature/HoSoMoiThauDienTu/bug-groupid-tep-totrinh-quyetdinh.md`.  
+> Bug **này** tập trung **GroupType / ExpandGroupTypes / IncludeSigned** trên màn phê duyệt.
+
+---
+
+## 4. Cách sửa (chi tiết từng chỗ)
+
+### Nguyên tắc
+
+- Dùng `AttachmentSubquery.ExpandGroupTypes` — **không** hard-code `OR GroupType == "KySo_..."`.
+- `IncludeSigned = true` mặc định; chỉ `false` khi caller truyền rõ.
+- HSMTĐT: expand **đủ** base GroupType nghiệp vụ + `KySo_*`.
+- Loại phê duyệt khác: **không** đổi (vẫn load theo `GroupId`, mọi GroupType).
+- Không lọc `ParentId`; dedupe theo `Attachment.Id`.
+- Không migration.
+
+---
+
+### 4.1. `PheDuyetGetDanhSachQuery` — thêm `IncludeSigned`
+
+**File:** `QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetGetDanhSachQuery.cs`
+
+```csharp
+/// <summary>
+/// Mặc định true — lấy cả file gốc và KySo_* (qua ExpandGroupTypes).
+/// Chỉ đặt false khi caller tường minh không cần file ký số.
+/// </summary>
+public bool IncludeSigned { get; set; } = true;
+```
+
+Trong `Handle`, truyền xuống:
+
+```csharp
+PheDuyetQueryableExtensions.ApplyDanhSachFilters(
+    ...,
+    includeAttachments: request.IncludeAttachments,
+    includeSigned: request.IncludeSigned);
+```
+
+---
+
+### 4.2. `ApplyDanhSachFilters` / `AttachTepDinhKem` — ExpandGroupTypes cho HSMTĐT
+
+**File:** `QLDA.Application/QuanLyPheDuyet/Queries/PheDuyetQueryableExtensions.cs`
+
+**Thêm danh sách base type** (khớp list/chi tiết hồ sơ):
+
+```csharp
+private static readonly string[] HoSoMoiThauDienTuBaseGroupTypes =
+[
+    nameof(EGroupType.HoSoMoiThauDienTu),
+    nameof(EGroupType.HoSoMoiThauDienTuToTrinh),
+    nameof(EGroupType.HoSoMoiThauDienTuQuyetDinh),
+    nameof(EGroupType.HoSoMoiThauDienTuQuyetDinhTD),
+    nameof(EGroupType.HoSoMoiThauDienTuCamKetTD),
+    nameof(EGroupType.HoSoMoiThauDienTuBaoCaoTD),
+];
+```
+
+**Sửa `AttachTepDinhKem`:**
+
+```csharp
+private static void AttachTepDinhKem(
+    List<PheDuyetListItemDto> items,
+    IRepository<Attachment, Guid> tepDinhKemRepo,
+    bool includeSigned = true)
+{
+    var groupIds = items.Select(i => i.EntityId)
+        .Where(id => !string.IsNullOrEmpty(id)).Distinct().ToList();
+    // ...
+
+    var query = tepDinhKemRepo.GetQueryableSet()
+        .AsNoTracking()
+        .Where(i => groupIds.Contains(i.GroupId));
+
+    var hsmtGroupIds = items
+        .Where(i => i.EntityName == PheDuyetEntityNames.HoSoMoiThauDienTu
+                    && !string.IsNullOrEmpty(i.EntityId))
+        .Select(i => i.EntityId)
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    if (hsmtGroupIds.Count > 0) {
+        var hsmtGroupTypes = AttachmentSubquery.ExpandGroupTypes(
+            includeSigned,
+            HoSoMoiThauDienTuBaseGroupTypes);
+        // HSMTĐT: GroupId đúng hồ sơ + GroupType ∈ (base ∪ KySo_base)
+        // Loại khác trong cùng batch: không áp filter GroupType
+        query = query.Where(i =>
+            !hsmtGroupIds.Contains(i.GroupId!)
+            || hsmtGroupTypes.Contains(i.GroupType));
+    }
+
+    var files = query.ToList().DistinctBy(f => f.Id).ToList();
+    AssignAttachments(items, files);
+}
+```
+
+**`AssignAttachments`:** thêm `.DistinctBy(f => f.Id)` trước `ToDto()` để list + count thống nhất, không trùng.
+
+---
+
+### 4.3. Việc **không** làm
+
+| Không làm | Lý do |
+|-----------|--------|
+| Hard-code `GroupType == "KySo_HoSoMoiThauDienTu"` | Đã có `ExpandGroupTypes` |
+| `Where(ParentId == null)` | Loại hết file ký số |
+| Sửa API chi tiết HSMTĐT | Đã đúng |
+| Migration / đổi snapshot | Ngoài phạm vi |
+| Đổi loại phê duyệt khác | Giữ load theo `GroupId` |
+
+---
+
+## 5. Kết quả mong đợi
+
+| Trường hợp | Kỳ vọng |
+|------------|---------|
+| 2 gốc + 1 `KySo_HoSoMoiThauDienTu` cùng `GroupId = EntityId` | `danhSachTepDinhKem` length = **3** |
+| `IncludeSigned = false` | Chỉ base GroupType, không `KySo_*` |
+| `type` khác HSMTĐT | Hành vi cũ (mọi GroupType theo GroupId) |
+| File có `ParentId != null` | Vẫn có trong list |
+
+---
+
+## 6. Checklist kiểm thử
+
+- [ ] `GET /api/phe-duyet/danh-sach?type=HoSoMoiThauDienTu&trangThai=ĐTr&pageIndex=1&pageSize=10` — đủ gốc + `KySo_*` cùng `groupId = entityId`
+- [ ] Count UI = `danhSachTepDinhKem.length`
+- [ ] So với `GET /api/ho-so-moi-thau-dien-tu/{id}`: cùng tập file gắn `GroupId = hồ sơ` (trừ nhánh legacy ToTrinh/QĐ Id nếu còn)
+- [ ] `type=BanGiaoHoSo` (hoặc loại khác) — không regress số file
+- [ ] Unit: `IncludeSigned` default true; `AssignAttachments` giữ file có `ParentId` + `KySo_*`; dedupe theo Id
+
+---
+
+## 7. File đụng tới
+
+| File | Thay đổi |
+|------|----------|
+| `QLDA.Application/.../PheDuyetGetDanhSachQuery.cs` | `IncludeSigned`; truyền vào filter |
+| `QLDA.Application/.../PheDuyetQueryableExtensions.cs` | `ExpandGroupTypes` cho HSMTĐT; dedupe |
+| `QLDA.Tests/Unit/PheDuyetQueryableExtensionsAttachmentTests.cs` | Assert signed + default IncludeSigned |
+| `docs/feature/HoSoMoiThauDienTu/bug-phe-duyet-danh-sach-thieu-ky-so.md` | Doc này |


### PR DESCRIPTION
## Summary
- Nguyên nhân thiếu file trên `phe-duyet/danh-sach` (type=`HoSoMoiThauDienTu`):
  - File tờ trình/quyết định trước đây lưu `GroupId = ToTrinh.Id` / `QuyetDinh.Id`, trong khi phê duyệt chỉ lookup theo `EntityId = HoSoMoiThauDienTu.Id` → không khớp → thiếu file TT/QĐ.
  - Load tệp phê duyệt chưa dùng `ExpandGroupTypes` → thiếu file ký số `KySo_*` dù đã có trong DB.
- Cần sửa (đã làm trong PR):
  - Chỗ lưu (`HoSoMoiThauDienTuController` Create/Update + mapping): truyền `GroupId = HoSoMoiThauDienTu.Id` xuống `TepDinhKem` cho cả hồ sơ / tờ trình / quyết định (không dùng `toTrinhId` / `quyetDinhId`).
  - Chỗ load phê duyệt (`PheDuyetQueryableExtensions.AttachTepDinhKem`): dùng `ExpandGroupTypes` + `IncludeSigned=true` để lấy đủ file gốc + `KySo_*`.
- Không sửa: không workaround ghép file theo `ToTrinh.Id`/`QuyetDinh.Id` trong `AssignAttachments`; Id thật của entity TT/QĐ giữ nguyên.

## Test plan
- [ ] Create/Update HSMTĐT có file hồ sơ + tờ trình + quyết định → DB: cả 3 cùng `GroupId = hosoId`, `GroupType` khác nhau
- [ ] Ký số file TT/QĐ (`POST /api/quan-ly-ky-so/ky-so` với `parentId` = Id file gốc) → DB có `KySo_HoSoMoiThauDienTuToTrinh` / `KySo_HoSoMoiThauDienTuQuyetDinh`
- [ ] `GET /api/phe-duyet/danh-sach?type=HoSoMoiThauDienTu&trangThai=ĐTr` → `danhSachTepDinhKem` đủ file gốc + `KySo_*` (cùng `groupId = entityId`)
- [ ] Unit: `PheDuyetQueryableExtensionsAttachmentTests` pass