### PR TITLE
feat(#170): bổ sung thông tin Kế hoạch lựa chọn nhà thầu

### DIFF
--- a/QLDA.Application/KeHoachLuaChonNhaThaus/Commands/KeHoachLuaChonNhaThauInsertCommand.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/Commands/KeHoachLuaChonNhaThauInsertCommand.cs
@@ -48,9 +48,18 @@ internal class KeHoachLuaChonNhaThauInsertCommandHandler : IRequestHandler<KeHoa
     private async Task ValidateAsync(KeHoachLuaChonNhaThauInsertCommand request, CancellationToken cancellationToken) {
         ManagedException.ThrowIf(!await DuAn.GetQueryableSet().AnyAsync(e => e.Id == request.Dto.DuAnId, cancellationToken: cancellationToken),
            "Không tồn tại dự án");
+        ManagedException.ThrowIf(!request.Dto.TongDuToan.HasValue, "Tổng dự toán là bắt buộc");
+        ManagedException.ThrowIf(
+            when: request.Dto.NguonVonId > 0 &&
+                  !await DuAn.GetQueryableSet().AnyAsync(
+                      e => e.Id == request.Dto.DuAnId &&
+                           e.DuAnNguonVons!.Any(nv => nv.RightId == request.Dto.NguonVonId),
+                      cancellationToken),
+            message: "Nguồn vốn không thuộc dự án"
+        );
         ManagedException.ThrowIf(
             when: await KeHoachLuaChonNhaThau.GetQueryableSet().AnyAsync(e => e.DuAnId == request.Dto.DuAnId && e.So == request.Dto.SoQuyetDinh && !e.IsDeleted, cancellationToken: cancellationToken),
-            message: "Số quyết định đã tồn tại"
+            message: "Số tờ trình đã tồn tại"
         );
     }
 

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/Commands/KeHoachLuaChonNhaThauUpdateCommand.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/Commands/KeHoachLuaChonNhaThauUpdateCommand.cs
@@ -9,12 +9,14 @@ public record KeHoachLuaChonNhaThauUpdateCommand(KeHoachLuaChonNhaThauUpdateDto 
 
 internal class KeHoachLuaChonNhaThauUpdateCommandHandler : IRequestHandler<KeHoachLuaChonNhaThauUpdateCommand, KeHoachLuaChonNhaThau> {
     private readonly IRepository<KeHoachLuaChonNhaThau, Guid> KeHoachLuaChonNhaThau;
+    private readonly IRepository<DuAn, Guid> DuAn;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IAuthorizationManager _authManager;
     private readonly IAuthorizationContext _authContext;
 
     public KeHoachLuaChonNhaThauUpdateCommandHandler(IServiceProvider serviceProvider) {
         KeHoachLuaChonNhaThau = serviceProvider.GetRequiredService<IRepository<KeHoachLuaChonNhaThau, Guid>>();
+        DuAn = serviceProvider.GetRequiredService<IRepository<DuAn, Guid>>();
         _unitOfWork = KeHoachLuaChonNhaThau.UnitOfWork;
         _authManager = serviceProvider.GetRequiredService<IAuthorizationManager>();
         _authContext = serviceProvider.GetRequiredService<IAuthorizationContext>();
@@ -26,6 +28,8 @@ internal class KeHoachLuaChonNhaThauUpdateCommandHandler : IRequestHandler<KeHoa
         ManagedException.ThrowIfNull(entity);
 
         await _authManager.EnsureCanExecuteAsync(entity.BuocId, entity.DuAnId, _authContext, cancellationToken);
+
+        await ValidateAsync(request, entity.DuAnId, cancellationToken);
 
         entity.Update(request.Dto);
 
@@ -40,6 +44,18 @@ internal class KeHoachLuaChonNhaThauUpdateCommandHandler : IRequestHandler<KeHoa
         return entity!;
     }
     #region  Private helper methods
+
+    private async Task ValidateAsync(KeHoachLuaChonNhaThauUpdateCommand request, Guid duAnId, CancellationToken cancellationToken) {
+        ManagedException.ThrowIf(!request.Dto.TongDuToan.HasValue, "Tổng dự toán là bắt buộc");
+        ManagedException.ThrowIf(
+            when: request.Dto.NguonVonId > 0 &&
+                  !await DuAn.GetQueryableSet().AnyAsync(
+                      e => e.Id == duAnId &&
+                           e.DuAnNguonVons!.Any(nv => nv.RightId == request.Dto.NguonVonId),
+                      cancellationToken),
+            message: "Nguồn vốn không thuộc dự án"
+        );
+    }
 
     private async Task UpdateAsync(KeHoachLuaChonNhaThau entity, CancellationToken cancellationToken) {
         await KeHoachLuaChonNhaThau.UpdateAsync(entity, cancellationToken);

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauDto.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauDto.cs
@@ -21,5 +21,9 @@ public class KeHoachLuaChonNhaThauDto : IHasKey<Guid?>, IMustHaveId<Guid>, ITien
     public string? TrichYeu { get; set; }
     public DateTimeOffset? NgayKy { get; set; }
     public string? NguoiKy { get; set; }
+    public long TongDuToan { get; set; }
+    public long? DuToanThamDinh { get; set; }
+    public int? NguonVonId { get; set; }
+    public int? ThoiGianThucHien { get; set; }
     public List<TepDinhKemDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauInsertDto.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauInsertDto.cs
@@ -13,5 +13,9 @@ public class KeHoachLuaChonNhaThauInsertDto : IMayHaveTepDinhKemInsertDto, ITien
     public string? TrichYeu { get; set; }
     public DateTimeOffset? NgayKy { get; set; }
     public string? NguoiKy { get; set; }
+    public long? TongDuToan { get; set; }
+    public long? DuToanThamDinh { get; set; }
+    public int? NguonVonId { get; set; }
+    public int? ThoiGianThucHien { get; set; }
     public List<TepDinhKemInsertDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauUpdateDto.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauUpdateDto.cs
@@ -12,5 +12,9 @@ public class KeHoachLuaChonNhaThauUpdateDto : IMayHaveTepDinhKemInsertOrUpdateDt
     public string? TrichYeu { get; set; }
     public DateTimeOffset? NgayKy { get; set; }
     public string? NguoiKy { get; set; }
+    public long? TongDuToan { get; set; }
+    public long? DuToanThamDinh { get; set; }
+    public int? NguonVonId { get; set; }
+    public int? ThoiGianThucHien { get; set; }
     public List<TepDinhKemInsertOrUpdateDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/KeHoachLuaChonNhaThauMappings.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/KeHoachLuaChonNhaThauMappings.cs
@@ -14,7 +14,11 @@ public static class KeHoachLuaChonNhaThauMappings {
             Ngay = dto.NgayQuyetDinh,
             TrichYeu = dto.TrichYeu,
             NgayKy = dto.NgayKy,
-            NguoiKy = dto.NguoiKy
+            NguoiKy = dto.NguoiKy,
+            TongDuToan = dto.TongDuToan!.Value,
+            DuToanThamDinh = dto.DuToanThamDinh,
+            NguonVonId = dto.NguonVonId,
+            ThoiGianThucHien = dto.ThoiGianThucHien
         };
     }
 
@@ -29,6 +33,10 @@ public static class KeHoachLuaChonNhaThauMappings {
             TrichYeu = entity.TrichYeu,
             NgayKy = entity.NgayKy,
             NguoiKy = entity.NguoiKy,
+            TongDuToan = entity.TongDuToan,
+            DuToanThamDinh = entity.DuToanThamDinh,
+            NguonVonId = entity.NguonVonId,
+            ThoiGianThucHien = entity.ThoiGianThucHien,
             DanhSachTepDinhKem = [.. files?.ToDtos() ?? []]
         };
     }
@@ -39,5 +47,9 @@ public static class KeHoachLuaChonNhaThauMappings {
         entity.TrichYeu = dto.TrichYeu;
         entity.NgayKy = dto.NgayKy;
         entity.NguoiKy = dto.NguoiKy;
+        entity.TongDuToan = dto.TongDuToan!.Value;
+        entity.DuToanThamDinh = dto.DuToanThamDinh;
+        entity.NguonVonId = dto.NguonVonId;
+        entity.ThoiGianThucHien = dto.ThoiGianThucHien;
     }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs
@@ -51,6 +51,10 @@ internal class
                 TrichYeu = e.TrichYeu,
                 NgayKy = e.NgayKy,
                 NguoiKy = e.NguoiKy,
+                TongDuToan = e.TongDuToan,
+                DuToanThamDinh = e.DuToanThamDinh,
+                NguonVonId = e.NguonVonId,
+                ThoiGianThucHien = e.ThoiGianThucHien,
                 DanhSachTepDinhKem = TepDinhKem.GetQueryableSet()
                     .Where(i => i.GroupId == e.Id.ToString())
                     .Select(i => i.ToDto()).ToList(),

--- a/QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs
+++ b/QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs
@@ -1,4 +1,5 @@
 using QLDA.Domain.Constants;
+using QLDA.Domain.Entities.DanhMuc;
 
 namespace QLDA.Domain.Entities;
 
@@ -13,11 +14,32 @@ public class KeHoachLuaChonNhaThau : VanBanQuyetDinh {
     public string? Ten { get; set; }
     public KeHoachLuaChonNhaThauLoai? LoaiKeHoach { get; set; }
 
+    /// <summary>
+    /// Tổng dự toán
+    /// </summary>
+    public long TongDuToan { get; set; }
+
+    /// <summary>
+    /// Dự toán thẩm định
+    /// </summary>
+    public long? DuToanThamDinh { get; set; }
+
+    /// <summary>
+    /// Nguồn vốn (theo nguồn vốn của dự án)
+    /// </summary>
+    public int? NguonVonId { get; set; }
+
+    /// <summary>
+    /// Thời gian thực hiện (năm)
+    /// </summary>
+    public int? ThoiGianThucHien { get; set; }
+
     #region Navigation Properties
 
+    public DanhMucNguonVon? NguonVon { get; set; }
     public QuyetDinhDuyetKHLCNT? QuyetDinhDuyetKHLCNT { get; set; }
     public ICollection<GoiThau>? GoiThaus { get; set; }
-    public DangTaiKeHoachLcntLenMang? DangTaiKeHoachLcntLenMang { get; set; } 
+    public DangTaiKeHoachLcntLenMang? DangTaiKeHoachLcntLenMang { get; set; }
 
     #endregion
 }

--- a/QLDA.Migrator/Migrations/20260810095922_AddKeHoachLuaChonNhaThauBoSungThongTin.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260810095922_AddKeHoachLuaChonNhaThauBoSungThongTin.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260810095922_AddKeHoachLuaChonNhaThauBoSungThongTin")]
+    partial class AddKeHoachLuaChonNhaThauBoSungThongTin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -8769,9 +8772,6 @@ namespace QLDA.Migrator.Migrations
                 {
                     b.HasBaseType("QLDA.Domain.Entities.VanBanQuyetDinh");
 
-                    b.Property<long?>("DuToanThamDinh")
-                        .HasColumnType("bigint");
-
                     b.Property<string>("LoaiKeHoach")
                         .HasColumnType("varchar(500)");
 
@@ -8785,6 +8785,9 @@ namespace QLDA.Migrator.Migrations
                         .HasColumnType("int");
 
                     b.Property<long>("TongDuToan")
+                        .HasColumnType("bigint");
+
+                    b.Property<long?>("TongDuToanThamDinhGia")
                         .HasColumnType("bigint");
 
                     b.HasIndex("NguonVonId");

--- a/QLDA.Migrator/Migrations/20260810095922_AddKeHoachLuaChonNhaThauBoSungThongTin.cs
+++ b/QLDA.Migrator/Migrations/20260810095922_AddKeHoachLuaChonNhaThauBoSungThongTin.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddKeHoachLuaChonNhaThauBoSungThongTin : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "NguonVonId",
+                table: "KeHoachLuaChonNhaThau",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "ThoiGianThucHien",
+                table: "KeHoachLuaChonNhaThau",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "TongDuToan",
+                table: "KeHoachLuaChonNhaThau",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<long>(
+                name: "TongDuToanThamDinhGia",
+                table: "KeHoachLuaChonNhaThau",
+                type: "bigint",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_KeHoachLuaChonNhaThau_NguonVonId",
+                table: "KeHoachLuaChonNhaThau",
+                column: "NguonVonId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_KeHoachLuaChonNhaThau_DmNguonVon_NguonVonId",
+                table: "KeHoachLuaChonNhaThau",
+                column: "NguonVonId",
+                principalTable: "DmNguonVon",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_KeHoachLuaChonNhaThau_DmNguonVon_NguonVonId",
+                table: "KeHoachLuaChonNhaThau");
+
+            migrationBuilder.DropIndex(
+                name: "IX_KeHoachLuaChonNhaThau_NguonVonId",
+                table: "KeHoachLuaChonNhaThau");
+
+            migrationBuilder.DropColumn(
+                name: "NguonVonId",
+                table: "KeHoachLuaChonNhaThau");
+
+            migrationBuilder.DropColumn(
+                name: "ThoiGianThucHien",
+                table: "KeHoachLuaChonNhaThau");
+
+            migrationBuilder.DropColumn(
+                name: "TongDuToan",
+                table: "KeHoachLuaChonNhaThau");
+
+            migrationBuilder.DropColumn(
+                name: "TongDuToanThamDinhGia",
+                table: "KeHoachLuaChonNhaThau");
+        }
+    }
+}

--- a/QLDA.Migrator/Migrations/20260811022108_RenameTongDuToanThamDinhGiaToDuToanThamDinh.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260811022108_RenameTongDuToanThamDinhGiaToDuToanThamDinh.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811022108_RenameTongDuToanThamDinhGiaToDuToanThamDinh")]
+    partial class RenameTongDuToanThamDinhGiaToDuToanThamDinh
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260811022108_RenameTongDuToanThamDinhGiaToDuToanThamDinh.cs
+++ b/QLDA.Migrator/Migrations/20260811022108_RenameTongDuToanThamDinhGiaToDuToanThamDinh.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameTongDuToanThamDinhGiaToDuToanThamDinh : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/QLDA.Migrator/Migrations/20260811023400_FixRenameTongDuToanThamDinhGiaToDuToanThamDinh.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260811023400_FixRenameTongDuToanThamDinhGiaToDuToanThamDinh.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811023400_FixRenameTongDuToanThamDinhGiaToDuToanThamDinh")]
+    partial class FixRenameTongDuToanThamDinhGiaToDuToanThamDinh
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260811023400_FixRenameTongDuToanThamDinhGiaToDuToanThamDinh.cs
+++ b/QLDA.Migrator/Migrations/20260811023400_FixRenameTongDuToanThamDinhGiaToDuToanThamDinh.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixRenameTongDuToanThamDinhGiaToDuToanThamDinh : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "TongDuToanThamDinhGia",
+                table: "KeHoachLuaChonNhaThau",
+                newName: "DuToanThamDinh");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DuToanThamDinh",
+                table: "KeHoachLuaChonNhaThau",
+                newName: "TongDuToanThamDinhGia");
+        }
+    }
+}

--- a/QLDA.Persistence/Configurations/KeHoachLuaChonNhaThauConfiguration.cs
+++ b/QLDA.Persistence/Configurations/KeHoachLuaChonNhaThauConfiguration.cs
@@ -8,6 +8,11 @@ public class KeHoachLuaChonNhaThauConfiguration : AggregateRootConfiguration<KeH
         builder.ToTable(nameof(KeHoachLuaChonNhaThau));
         builder.Property(e => e.LoaiKeHoach)
             .HasColumnType("varchar(500)");
-           
+
+        builder.HasOne(e => e.NguonVon)
+            .WithMany()
+            .HasForeignKey(e => e.NguonVonId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .IsRequired(false);
     }
 }

--- a/docs/issues/170/index.md
+++ b/docs/issues/170/index.md
@@ -1,0 +1,368 @@
+# Issue #170 — Bổ sung field Kế hoạch lựa chọn nhà thầu
+
+**Issue:** #170
+
+**Branch đề xuất:** `feature/ke-hoach-lua-chon-nha-thau-bo-sung-thong-tin`
+
+**API:** `api/ke-hoach-lua-chon-nha-thau`
+
+**Phạm vi flow:** Thêm mới · Cập nhật · Chi tiết · Danh sách
+
+**Trạng thái:** Code done — chờ user tạo migration + apply DB
+
+---
+
+## 1. Yêu cầu nghiệp vụ
+
+| # | Nghiệp vụ | Hành động |
+|---|-----------|-----------|
+| 1 | Đổi hiển thị "Số QĐ" → "Số tờ trình" | Reuse field số hiện có; không đổi DB column |
+| 2 | Tổng dự toán | Thêm mới; bắt buộc; nhập tay |
+| 3 | Tổng dự toán thẩm định giá | Thêm mới; không bắt buộc; nhập tay |
+| 4 | Nguồn vốn | Thêm mới; CBB từ nguồn vốn của Dự án đang chọn |
+| 5 | Thời gian thực hiện (năm) | Thêm mới; lưu số năm |
+
+---
+
+## 2. Survey source
+
+### 2.1. Files hiện tại (module chính — không gồm RutGon)
+
+| Layer | File |
+|-------|------|
+| Controller | `QLDA.WebApi/Controllers/KeHoachLuaChonNhaThauController.cs` |
+| Insert | `QLDA.Application/KeHoachLuaChonNhaThaus/Commands/KeHoachLuaChonNhaThauInsertCommand.cs` |
+| Update | `QLDA.Application/KeHoachLuaChonNhaThaus/Commands/KeHoachLuaChonNhaThauUpdateCommand.cs` |
+| Delete | `QLDA.Application/KeHoachLuaChonNhaThaus/Commands/KeHoachLuaChonNhaThauDeleteCommand.cs` |
+| Chi tiết | `QLDA.Application/KeHoachLuaChonNhaThaus/Queries/KeHoachLuaChonNhaThauQuery.cs` |
+| Danh sách | `QLDA.Application/KeHoachLuaChonNhaThaus/Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs` |
+| DTO | `DTOs/KeHoachLuaChonNhaThauDto.cs`, `InsertDto.cs`, `UpdateDto.cs` |
+| Mapping | `KeHoachLuaChonNhaThauMappings.cs` |
+| Entity | `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs` |
+| Base | `QLDA.Domain/Entities/VanBanQuyetDinh.cs` |
+| EF Config | `QLDA.Persistence/Configurations/KeHoachLuaChonNhaThauConfiguration.cs` |
+
+Endpoints:
+
+- `POST them-moi`
+- `PUT cap-nhat`
+- `GET {id}/chi-tiet`
+- `GET danh-sach-tien-do`
+
+### 2.2. Entity / DB hiện có
+
+`KeHoachLuaChonNhaThau` kế thừa `VanBanQuyetDinh` (TPT — table riêng `KeHoachLuaChonNhaThau`).
+
+**Trên KHLCNT:** `Ten`, `LoaiKeHoach` (+ navigation `GoiThaus`, `QuyetDinhDuyetKHLCNT`, `DangTaiKeHoachLcntLenMang`).
+
+**Từ base `VanBanQuyetDinh`:** `DuAnId`, `BuocId`, `So`, `Ngay`, `TrichYeu`, `NguoiKy`, `NgayKy`, `CoQuanQuyetDinh`, `Loai`, …
+
+**Chưa có trên entity/DB:**
+
+- `TongDuToan`
+- `DuToanThamDinh`
+- `NguonVonId`
+- `ThoiGianThucHien`
+
+→ **Cần migration mới.**
+
+### 2.3. DTO Insert / Update / Detail / List hiện tại
+
+| Property DTO | Entity | Ghi chú |
+|--------------|--------|---------|
+| `DuAnId` | `DuAnId` | Insert + Detail/List |
+| `BuocId` | `BuocId` | |
+| `Ten` | `Ten` | |
+| `SoQuyetDinh` | `So` | FE đang hiểu là "Số QĐ" |
+| `NgayQuyetDinh` | `Ngay` | |
+| `TrichYeu` | `TrichYeu` | |
+| `NgayKy` / `NguoiKy` | tương ứng | |
+| `DanhSachTepDinhKem` | Attachment | |
+
+DTO implements `IQuyetDinh` (`SoQuyetDinh`, `NgayQuyetDinh`, `TrichYeu`).
+
+Validate insert hiện tại: trùng `So` theo `DuAnId` → message *"Số quyết định đã tồn tại"*.
+
+### 2.4. Nguồn vốn của Dự án (reuse)
+
+| Thành phần | Chi tiết |
+|------------|----------|
+| Junction | `DuAnNguonVon` (`LeftId` = DuAnId, `RightId` = NguonVonId) |
+| Danh mục | `DanhMucNguonVon` |
+| DuAn DTO | `DanhSachNguonVon: List<int>?` |
+| CBB API sẵn có | `GET api/danh-muc-nguon-von/danh-sach?duAnId={guid}` |
+| Query filter | `DanhMucNguonVonGetDanhSachQuery` — filter `DuAnNguonVons` theo `LeftId` |
+| Pattern lưu child | `GoiThau.NguonVonId`, `DuToanDauTu.NguonVonId` → `int?` |
+
+**Không tạo** danh mục / API nguồn vốn mới.
+
+### 2.5. Pattern kiểu dữ liệu tham chiếu trong project
+
+| Field | Tham chiếu | Kiểu |
+|-------|-----------|------|
+| Tiền / dự toán | `DuToanDauTu.TongDuToan` | `long?` / DB `bigint` |
+| Năm thực hiện | `GoiThau.ThoiGianThucHienGoiThau` | `int?` |
+| Nguồn vốn FK | nhiều entity | `int?` + nav `DanhMucNguonVon` |
+
+---
+
+## 3. Quyết định thiết kế
+
+### 3.1. "Số QĐ" → "Số tờ trình"
+
+| Layer | Quyết định |
+|-------|------------|
+| DB column `VanBanQuyetDinh.So` | **Giữ nguyên** — không rename / không migration cho field này |
+| DTO property `SoQuyetDinh` | **Giữ nguyên** — thuộc `IQuyetDinh`; đổi tên sẽ phá FE + nhiều module dùng chung interface |
+| Mapping `SoQuyetDinh` ↔ `So` | Giữ |
+| FE / Swagger label | Đổi hiển thị thành **"Số tờ trình"** |
+| Message validate trùng | Cập nhật copy: *"Số tờ trình đã tồn tại"* (optional, cùng commit nếu sửa InsertCommand) |
+
+**Lý do:** Task yêu cầu không rename DB nếu không cần; property API đang map đúng dữ liệu số văn bản.
+
+### 3.2. Field mới trên `KeHoachLuaChonNhaThau`
+
+| Nghiệp vụ | Property | Kiểu C# | Required | DB |
+|-----------|----------|---------|----------|-----|
+| Tổng dự toán | `TongDuToan` | `long` | **Có** | `bigint` NOT NULL (hoặc nullable + validate app — ưu tiên validate app với `long` / `long?` + ThrowIf null/≤0 theo convention hiện tại) |
+| Tổng DT thẩm định giá | `DuToanThamDinh` | `long?` | Không | `bigint` NULL |
+| Nguồn vốn | `NguonVonId` | `int?` | Không bắt buộc trừ khi BA yêu cầu thêm | `int` NULL + FK `DanhMucNguonVon` |
+| Thời gian thực hiện (năm) | `ThoiGianThucHien` | `int?` | Không bắt buộc trừ khi BA yêu cầu thêm | `int` NULL |
+
+**Ghi chú validate `TongDuToan`:** bắt buộc ở Insert/Update handler (`ManagedException.ThrowIf`).
+
+**Ghi chú `NguonVonId`:** khi có giá trị, validate thuộc `DuAnNguonVon` của `DuAnId` đang lập KHLCNT (Insert lấy từ DTO; Update lấy từ entity.DuAnId).
+
+### 3.3. Response Nguồn vốn (chi tiết / danh sách)
+
+Follow pattern `GoiThau`: trả `NguonVonId` trên DTO.
+
+Tên nguồn vốn: FE lấy từ CBB / `api/danh-muc-nguon-von`. Nếu list cần hiển thị tên ngay, bổ sung `TenNguonVon` trong projection (`e.NguonVon!.Ten`) — **chỉ khi** list UI cần; mặc định đủ `NguonVonId`.
+
+### 3.4. Migration
+
+- **Có** — migration mới sau khi sửa Domain + EF Configuration.
+- Không sửa migration cũ.
+- Không sửa tay `AppDbContextModelSnapshot.cs`.
+- Không drop DB / column ngoài scope.
+
+Tạo qua convention project: `ef.bat add ...` (sau khi entity + configuration xong).
+
+### 3.5. Phạm vi ngoài task (không làm)
+
+- `KeHoachLuaChonNhaThauRutGon` và module liên quan khác
+- Refactor `IQuyetDinh` / rename `SoQuyetDinh` toàn solution
+- Đổi schema `VanBanQuyetDinh`
+- Tạo danh mục nguồn vốn mới
+- FE (chỉ ghi chú contract cho FE)
+
+---
+
+## 4. Đồng bộ 4 API
+
+### Thêm mới (`POST them-moi`)
+
+Request nhận thêm:
+
+- `SoQuyetDinh` (nghiệp vụ: Số tờ trình)
+- `TongDuToan` (required)
+- `DuToanThamDinh` (optional)
+- `NguonVonId` (optional; CBB từ dự án)
+- `ThoiGianThucHien` (optional; năm)
+
+Persist qua `InsertDto.ToEntity()` + validate.
+
+### Cập nhật (`PUT cap-nhat`)
+
+Cho phép cập nhật các field trên; `Update()` mapping + validate `TongDuToan` / `NguonVonId`.
+
+### Chi tiết (`GET {id}/chi-tiet`)
+
+`ToDto()` trả đủ field mới (+ `NguonVonId`).
+
+### Danh sách (`GET danh-sach-tien-do`)
+
+Bổ sung projection trong `KeHoachLuaChonNhaThauGetDanhSachQuery`.
+
+Controller: **không đổi signature** nếu chỉ mở rộng DTO.
+
+---
+
+## 5. Chỗ còn thiếu cần bổ sung (gap)
+
+### 5.1. Domain / DB — thiếu hoàn toàn
+
+| Property | Có trên entity hiện tại? | Có trên DB? | Cần làm |
+|----------|--------------------------|-------------|---------|
+| `TongDuToan` | Không | Không | Thêm entity + migration |
+| `DuToanThamDinh` | Không | Không | Thêm entity + migration |
+| `NguonVonId` (+ nav `NguonVon`) | Không | Không | Thêm entity + FK config + migration |
+| `ThoiGianThucHien` | Không | Không | Thêm entity + migration |
+
+`So` / `SoQuyetDinh`: **đã có** — chỉ đổi label FE + (optional) message validate.
+
+### 5.2. Application — thiếu trên mọi luồng
+
+| Chỗ | Insert | Update | Detail (`ToDto`) | List (projection) |
+|-----|--------|--------|------------------|-------------------|
+| `TongDuToan` | thiếu | thiếu | thiếu | thiếu |
+| `DuToanThamDinh` | thiếu | thiếu | thiếu | thiếu |
+| `NguonVonId` | thiếu | thiếu | thiếu | thiếu |
+| `ThoiGianThucHien` | thiếu | thiếu | thiếu | thiếu |
+| Validate `TongDuToan` required | thiếu | thiếu | — | — |
+| Validate `NguonVonId` thuộc dự án | thiếu | thiếu | — | — |
+| Message trùng số → "Số tờ trình…" | message cũ *"Số quyết định…"* | — | — | — |
+
+### 5.3. Không thiếu / không đụng
+
+| Hạng mục | Ghi chú |
+|----------|---------|
+| Controller endpoints | Giữ nguyên; DTO mở rộng là đủ |
+| CBB nguồn vốn API | Đã có `GET api/danh-muc-nguon-von/danh-sach?duAnId=` |
+| `KeHoachLuaChonNhaThauRutGon` | Ngoài scope |
+| Rename DB `VanBanQuyetDinh.So` | Không làm |
+| Rename `IQuyetDinh.SoQuyetDinh` | Không làm |
+
+### 5.4. Files cần sửa
+
+1. `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs`
+2. `QLDA.Persistence/Configurations/KeHoachLuaChonNhaThauConfiguration.cs`
+3. Migration mới `QLDA.Migrator/Migrations/` (EF sinh snapshot)
+4. `…/DTOs/KeHoachLuaChonNhaThauDto.cs`
+5. `…/DTOs/KeHoachLuaChonNhaThauInsertDto.cs`
+6. `…/DTOs/KeHoachLuaChonNhaThauUpdateDto.cs`
+7. `…/KeHoachLuaChonNhaThauMappings.cs`
+8. `…/Commands/KeHoachLuaChonNhaThauInsertCommand.cs`
+9. `…/Commands/KeHoachLuaChonNhaThauUpdateCommand.cs`
+10. `…/Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs`
+11. Docs: cập nhật `report.md` / `journal.md` sau khi xong
+
+Controller: **không sửa** (trừ khi cần XML comment / không bắt buộc).
+
+---
+
+## 6. Các bước code (implementation plan)
+
+> Agent/dev làm theo thứ tự. Mỗi bước xong thì tick. Không refactor ngoài scope.
+
+### Bước 0 — Chuẩn bị
+
+- [ ] Checkout / tạo branch `feature/ke-hoach-lua-chon-nha-thau-bo-sung-thong-tin`
+- [ ] Đọc lại §3 quyết định thiết kế trong file này
+- [ ] (GitNexus) `impact` trước khi sửa symbol chính nếu MCP available
+
+### Bước 1 — Domain entity
+
+File: `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs`
+
+- [ ] Thêm:
+  - `public long TongDuToan { get; set; }` — required ở app layer
+  - `public long? DuToanThamDinh { get; set; }`
+  - `public int? NguonVonId { get; set; }`
+  - `public int? ThoiGianThucHien { get; set; }`
+  - `public DanhMucNguonVon? NguonVon { get; set; }` (nav)
+- [ ] `using` namespace `DanhMuc` nếu cần
+
+### Bước 2 — EF Configuration
+
+File: `QLDA.Persistence/Configurations/KeHoachLuaChonNhaThauConfiguration.cs`
+
+- [ ] Giữ config `LoaiKeHoach` hiện có
+- [ ] Thêm FK `NguonVon` giống `DuToanDauTuConfiguration`:
+
+```csharp
+builder.HasOne(e => e.NguonVon)
+    .WithMany()
+    .HasForeignKey(e => e.NguonVonId)
+    .OnDelete(DeleteBehavior.Restrict)
+    .IsRequired(false);
+```
+
+- [ ] Không cần config đặc biệt cho `long` / `int?` trừ khi project chỗ khác gắn `HasPrecision` — follow snapshot các entity tiền `bigint` hiện có
+
+### Bước 3 — Migration
+
+- [ ] `ef.bat QLDA add AddKeHoachLuaChonNhaThauBoSungThongTin` (hoặc tên tương đương)
+- [ ] Review migration sinh ra: chỉ `AddColumn` trên `KeHoachLuaChonNhaThau` (+ FK nếu có)
+- [ ] **Không** sửa tay migration cũ / snapshot
+- [ ] Nếu migration sai: `ef.bat QLDA remove` rồi add lại
+
+### Bước 4 — DTO
+
+Files: `KeHoachLuaChonNhaThauDto`, `InsertDto`, `UpdateDto`
+
+- [ ] Thêm 4 property: `TongDuToan`, `DuToanThamDinh`, `NguonVonId`, `ThoiGianThucHien`
+- [ ] **Giữ** `SoQuyetDinh` (không rename)
+- [ ] Insert: `TongDuToan` kiểu `long` (hoặc `long?` + validate handler — chọn 1 và thống nhất)
+- [ ] Update: cùng shape field mới
+
+### Bước 5 — Mapping
+
+File: `KeHoachLuaChonNhaThauMappings.cs`
+
+- [ ] `ToEntity(InsertDto)`: map 4 field mới
+- [ ] `ToDto(entity)`: map 4 field mới (+ `NguonVonId`)
+- [ ] `Update(entity, UpdateDto)`: gán 4 field mới
+
+### Bước 6 — Insert command
+
+File: `KeHoachLuaChonNhaThauInsertCommand.cs`
+
+- [ ] Validate: `TongDuToan` bắt buộc (ThrowIf null/default theo convention đã chọn)
+- [ ] Validate: nếu `NguonVonId` có giá trị → phải thuộc `DuAnNguonVon` của `Dto.DuAnId`
+- [ ] Đổi message trùng số: *"Số tờ trình đã tồn tại"* (thay *"Số quyết định đã tồn tại"*)
+- [ ] Inject `IRepository<DuAnNguonVon, …>` hoặc query qua pattern sẵn có nếu cần
+
+### Bước 7 — Update command
+
+File: `KeHoachLuaChonNhaThauUpdateCommand.cs`
+
+- [ ] Validate `TongDuToan` required
+- [ ] Validate `NguonVonId` thuộc `entity.DuAnId` khi có giá trị
+- [ ] Mapping đã cover persist
+
+### Bước 8 — Danh sách projection
+
+File: `KeHoachLuaChonNhaThauGetDanhSachQuery.cs`
+
+- [ ] Trong `.Select(e => new KeHoachLuaChonNhaThauDto { … })` bổ sung 4 field
+- [ ] Không gọi Mediator trong projection
+
+### Bước 9 — Chi tiết
+
+- [ ] Không đổi Controller nếu `ToDto` đã map đủ (GetQuery trả entity → `ToDto`)
+- [ ] Smoke-check response chi tiết có đủ field mới
+
+### Bước 10 — Build + verify
+
+- [ ] `dotnet build` (solution / project liên quan) — hết compile error
+- [ ] Manual / API check 4 luồng theo §7
+- [ ] Cập nhật `report.md` (Files Changed, Status)
+- [ ] Cập nhật `journal.md`
+
+### Bước 11 — Commit / PR (khi user yêu cầu)
+
+- [ ] Domain + Persistence.Configuration + Migrator **cùng 1 commit group** (rule project)
+- [ ] Application/DTO/commands có thể cùng hoặc tách commit logic — nhưng migration không tách khỏi Domain/Config
+- [ ] `detect_changes` trước commit nếu GitNexus available
+
+---
+
+## 7. Expected result (acceptance)
+
+1. Thêm mới KHLCNT lưu đủ thông tin mới.
+2. `TongDuToan` bắt buộc.
+3. `DuToanThamDinh` cho phép null.
+4. Nguồn vốn chọn từ nguồn vốn của dự án (`NguonVonId` + CBB `duAnId`).
+5. Thời gian thực hiện lưu số năm (`int?`).
+6. Update đọc/ghi đúng.
+7. Chi tiết trả đủ field.
+8. Danh sách không thiếu field cần hiển thị.
+9. Không ảnh hưởng module khác / không đụng RutGon / không rename `VanBanQuyetDinh.So`.
+
+---
+
+## 8. Ghi chú mở (chốt khi implement nếu BA bổ sung)
+
+- `NguonVonId` / `ThoiGianThucHien` có bắt buộc không? → hiện **optional** theo mô tả task (chỉ nêu required cho Tổng dự toán).
+- Có cần `TenNguonVon` trên list/detail DTO không? → mặc định **không**; chỉ `NguonVonId`.

--- a/docs/issues/170/journal.md
+++ b/docs/issues/170/journal.md
@@ -1,0 +1,14 @@
+# Journal — Issue #170 Bổ sung field KHLCNT
+
+## 2026-08-10
+
+- Survey source `KeHoachLuaChonNhaThau` (Controller / CQRS / DTO / Entity / EF / snapshot).
+- Kết luận: thiếu 4 field mới trên entity → cần migration; `So`/`SoQuyetDinh` reuse không rename DB.
+- Nguồn vốn reuse `DuAnNguonVon` + `GET api/danh-muc-nguon-von/danh-sach?duAnId=`.
+- Viết `index.md` (survey + design). Chưa implement code.
+- Chuyển docs từ folder tạm sang `docs/issues/170/`.
+- Bổ sung `report.md` (skeleton — status DRAFT, điền files/PR sau khi implement).
+- Bổ sung `index.md` §5 gap (chỗ thiếu) + §6 các bước code; sync checklist vào `report.md`.
+- Implement code (Domain, Config, DTO, Mapping, Insert/Update, List). **Migration để user tự tạo.**
+- Build Application / Persistence / WebApi: succeeded, 0 error.
+- Rename `TongDuToanThamDinhGia` → `DuToanThamDinh` (API `duToanThamDinh`) + cập nhật migration chưa apply.

--- a/docs/issues/170/report.md
+++ b/docs/issues/170/report.md
@@ -1,0 +1,83 @@
+# Implementation Report — Bổ sung field Kế hoạch lựa chọn nhà thầu
+
+## Issue #170 | Branch: `170-9663---feature/ke-hoach-lua-chon-nha-thau-bo-sung-thong-tin`
+## Status: CODE DONE (migration do dev tự tạo — chưa PR)
+
+Chi tiết BA + survey + thiết kế + gap + bước code: xem [`index.md`](./index.md).
+
+## Summary
+
+Đã bổ sung field trên Domain / EF Config / DTO / Mapping / Insert·Update validate / List projection cho **Kế hoạch lựa chọn nhà thầu**.
+
+| Field nghiệp vụ | Cách xử lý | Status |
+|-----------------|------------|--------|
+| Số tờ trình | Reuse `So` / `SoQuyetDinh`; message trùng → *"Số tờ trình đã tồn tại"* | Done |
+| Tổng dự toán | `TongDuToan` (`long` entity; `long?` Insert/Update + validate required) | Done (chờ migration) |
+| Dự toán thẩm định | `DuToanThamDinh` (`long?`) | Done (chờ migration) |
+| Nguồn vốn | `NguonVonId` (`int?`) + FK; validate thuộc `DuAnNguonVon` | Done (chờ migration) |
+| Thời gian thực hiện (năm) | `ThoiGianThucHien` (`int?`) | Done (chờ migration) |
+
+## Architecture
+
+Không đổi Controller. CBB nguồn vốn: `GET api/danh-muc-nguon-von/danh-sach?duAnId=`.
+
+## Checklist bước code
+
+- [x] 0. Branch (đã có sẵn)
+- [x] 1. Domain entity
+- [x] 2. EF Configuration (FK `NguonVon`)
+- [ ] 3. Migration — **user tự tạo** (`ef.bat QLDA add …`)
+- [x] 4. DTO Insert/Update/Dto
+- [x] 5. Mappings
+- [x] 6. InsertCommand validate
+- [x] 7. UpdateCommand validate
+- [x] 8. List projection
+- [x] 9. Chi tiết qua `ToDto`
+- [x] 10. Build compile OK
+- [ ] 11. Commit / PR (khi user yêu cầu)
+
+## Files Changed
+
+| Layer | File | Thay đổi |
+|-------|------|----------|
+| Domain | `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs` | +4 field + nav `NguonVon` |
+| Persistence | `QLDA.Persistence/Configurations/KeHoachLuaChonNhaThauConfiguration.cs` | FK `NguonVon` |
+| Application | `DTOs/KeHoachLuaChonNhaThauDto.cs` | +4 field |
+| Application | `DTOs/KeHoachLuaChonNhaThauInsertDto.cs` | +4 field (`TongDuToan` nullable để validate) |
+| Application | `DTOs/KeHoachLuaChonNhaThauUpdateDto.cs` | +4 field |
+| Application | `KeHoachLuaChonNhaThauMappings.cs` | map 4 field |
+| Application | `Commands/KeHoachLuaChonNhaThauInsertCommand.cs` | validate TongDuToan / NguonVon / message số tờ trình |
+| Application | `Commands/KeHoachLuaChonNhaThauUpdateCommand.cs` | validate TongDuToan / NguonVon |
+| Application | `Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs` | projection 4 field |
+| Migrator | *(chưa)* | User tự `ef.bat QLDA add` |
+
+## Migration (user tự làm)
+
+Gợi ý:
+
+```bat
+ef.bat QLDA add AddKeHoachLuaChonNhaThauBoSungThongTin
+```
+
+Cần có trên table `KeHoachLuaChonNhaThau`:
+
+- `TongDuToan` `bigint` NOT NULL — **có data cũ thì set default / backfill trước khi NOT NULL**
+- `DuToanThamDinh` `bigint` NULL
+- `NguonVonId` `int` NULL + FK → `DanhMucNguonVon`
+- `ThoiGianThucHien` `int` NULL
+
+Không sửa migration cũ / không sửa tay snapshot.
+
+## Test / Verify
+
+- [x] Build Application / Persistence / WebApi — 0 error
+- [ ] Thêm mới lưu đủ field (sau khi apply migration)
+- [ ] `TongDuToan` bắt buộc
+- [ ] `DuToanThamDinh` null được
+- [ ] `NguonVonId` chọn theo nguồn vốn dự án
+- [ ] `ThoiGianThucHien` lưu số năm
+- [ ] Update / Chi tiết / Danh sách đồng bộ
+
+## PR
+
+- PR: *(chưa có)*

--- a/docs/issues/170/test-workflow.md
+++ b/docs/issues/170/test-workflow.md
@@ -1,0 +1,74 @@
+# Test workflow — Issue #170 KHLCNT bổ sung field
+
+## Điều kiện trước khi test API
+
+1. Đã tạo + apply migration cột mới trên `KeHoachLuaChonNhaThau` (user tự làm).
+2. Chạy WebApi (Swagger): thường `https://localhost:7130/swagger` hoặc profile trong `launchSettings.json`.
+3. Có token user có quyền thao tác bước tiến độ KHLCNT của 1 dự án.
+4. Dự án test đã có ≥1 nguồn vốn (`DanhSachNguonVon`) — CBB:
+
+```http
+GET /api/danh-muc-nguon-von/danh-sach?duAnId={duAnId}
+```
+
+## Endpoint
+
+Base: `/api/ke-hoach-lua-chon-nha-thau`
+
+| Flow | Method | Path |
+|------|--------|------|
+| Thêm mới | POST | `/them-moi` |
+| Cập nhật | PUT | `/cap-nhat` |
+| Chi tiết | GET | `/{id}/chi-tiet` |
+| Danh sách | GET | `/danh-sach-tien-do?duAnId={duAnId}&buocId={buocId}` |
+
+## Sample body — Thêm mới
+
+```json
+{
+  "duAnId": "{guid-du-an}",
+  "buocId": 0,
+  "ten": "KHLCNT test #170",
+  "soQuyetDinh": "TT-170-001",
+  "ngayQuyetDinh": "2026-08-10T00:00:00+07:00",
+  "trichYeu": "Test bổ sung field",
+  "tongDuToan": 1500000000,
+  "duToanThamDinh": 1400000000,
+  "nguonVonId": 1,
+  "thoiGianThucHien": 3,
+  "danhSachTepDinhKem": []
+}
+```
+
+`buocId` / `nguonVonId`: lấy đúng ID thực tế trên môi trường của bạn.
+
+## Checklist
+
+### Happy path
+
+- [ ] **Thêm mới** đủ field → 200, có `id`
+- [ ] **Chi tiết** → có `tongDuToan`, `duToanThamDinh`, `nguonVonId`, `thoiGianThucHien`, `soQuyetDinh`
+- [ ] **Danh sách** (`duAnId`) → cùng các field trên
+- [ ] **Cập nhật** đổi `tongDuToan` / `thoiGianThucHien` / `nguonVonId` → chi tiết phản ánh đúng
+- [ ] `duToanThamDinh: null` (hoặc omit) → lưu null OK
+
+### Validate / lỗi
+
+- [ ] Thiếu `tongDuToan` (null / không gửi) → lỗi *"Tổng dự toán là bắt buộc"*
+- [ ] `nguonVonId` không thuộc dự án → *"Nguồn vốn không thuộc dự án"*
+- [ ] Trùng `soQuyetDinh` cùng dự án → *"Số tờ trình đã tồn tại"*
+
+### CBB nguồn vốn
+
+- [ ] `GET /api/danh-muc-nguon-von/danh-sach?duAnId=...` chỉ trả nguồn vốn của dự án đó
+- [ ] Chọn 1 id từ CBB → insert/update OK
+
+## Không có automated test sẵn
+
+Module này chưa có test file trong `QLDA.Tests`. Hiện test bằng **Swagger / Postman** sau khi apply migration.
+
+Compile-only (đã chạy lúc implement):
+
+```bat
+dotnet build QLDA.WebApi/QLDA.WebApi.csproj
+```


### PR DESCRIPTION
## Summary
- Bổ sung field KHLCNT: `TongDuToan` (bắt buộc), `DuToanThamDinh` (optional), `NguonVonId` (CBB theo nguồn vốn dự án), `ThoiGianThucHien` (năm)
- Reuse `So` / `soQuyetDinh` làm Số tờ trình (không rename DB); message trùng số cập nhật tương ứng
- Đồng bộ Insert / Update / Chi tiết / Danh sách + migration (add cột + rename `TongDuToanThamDinhGia` → `DuToanThamDinh`)

## Test plan
- [x] Apply migration trên môi trường test
- [x] `GET /api/danh-muc-nguon-von/danh-sach?duAnId=` lấy `nguonVonId` hợp lệ
- [x] `POST /api/ke-hoach-lua-chon-nha-thau/them-moi` với đủ field mới (dùng `duToanThamDinh`)
- [x] Chi tiết / danh sách trả đủ field
- [ ] Update đọc/ghi đúng
- [ ] Thiếu `tongDuToan` → lỗi bắt buộc
- [ ] `nguonVonId` không thuộc dự án → lỗi tương ứng