### PR TITLE
feat(#175): cập nhật Trình duyệt dự toán — Ten, Công văn bắt buộc, Khác

### DIFF
--- a/QLDA.Application/DuToanDauTu/Commands/DuToanDauTuInsertCommand.cs
+++ b/QLDA.Application/DuToanDauTu/Commands/DuToanDauTuInsertCommand.cs
@@ -29,6 +29,8 @@ internal class DuToanDauTuInsertCommandHandler : IRequestHandler<DuToanDauTuInse
 
     public async Task<DuToanDauTu> Handle(DuToanDauTuInsertCommand request, CancellationToken cancellationToken = default)
     {
+        ManagedException.ThrowIf(string.IsNullOrWhiteSpace(request.Dto.Ten), "Tên dự toán là bắt buộc");
+
         await _authManager.EnsureCanExecuteAsync(request.Dto.BuocId, request.Dto.DuAnId, _authContext, cancellationToken);
         await _auth.EnsureCanExecuteStepAsync(request.Dto.BuocId, _authContext, cancellationToken);
 

--- a/QLDA.Application/DuToanDauTu/Commands/DuToanDauTuUpdateCommand.cs
+++ b/QLDA.Application/DuToanDauTu/Commands/DuToanDauTuUpdateCommand.cs
@@ -49,6 +49,9 @@ internal class DuToanDauTuUpdateCommandHandler : IRequestHandler<DuToanDauTuUpda
             throw new ManagedException("Trạng thái không thể cập nhật!");
         }
 
+        ManagedException.ThrowIf(string.IsNullOrWhiteSpace(request.Dto.Ten), "Tên dự toán là bắt buộc");
+
+        entity.Ten = request.Dto.Ten?.Trim();
         entity.SoToTrinh = request.Dto.SoToTrinh;
         entity.NgayTrinh = request.Dto.NgayTrinh;
         entity.TrichYeu = request.Dto.TrichYeu;

--- a/QLDA.Application/DuToanDauTu/DTOs/DuToanDauTuDto.cs
+++ b/QLDA.Application/DuToanDauTu/DTOs/DuToanDauTuDto.cs
@@ -15,6 +15,7 @@ public class DuToanDauTuDto : IHasKey<Guid?>, IMustHaveId<Guid>, ITienDo, IMayHa
 
     public Guid DuAnId { get; set; }
     public int? BuocId { get; set; }
+    public string? Ten { get; set; }
     public DateTimeOffset? NgayTrinh { get; set; }
     public string SoToTrinh { get; set; } = string.Empty;
     public string? TrichYeu { get; set; }
@@ -35,4 +36,5 @@ public class DuToanDauTuDto : IHasKey<Guid?>, IMustHaveId<Guid>, ITienDo, IMayHa
     public string? MaTrangThai { get; set; }
     public string? TenTrangThai { get; set; }
     public List<TepDinhKemDto>? DanhSachTepDinhKem { get; set; }
+    public List<TepDinhKemDto>? DanhSachTepDinhKemKhac { get; set; }
 }

--- a/QLDA.Application/DuToanDauTu/DuToanDauTuMappings.cs
+++ b/QLDA.Application/DuToanDauTu/DuToanDauTuMappings.cs
@@ -9,6 +9,7 @@ public static class DuToanDauTuMappings {
             Id = dto.Id ?? Guid.NewGuid(),
             DuAnId = dto.DuAnId,
             BuocId = dto.BuocId,
+            Ten = dto.Ten?.Trim(),
             NgayTrinh = dto.NgayTrinh,
             TrichYeu = dto.TrichYeu,
             SoToTrinh = dto.SoToTrinh,
@@ -24,12 +25,16 @@ public static class DuToanDauTuMappings {
 
 
 
-    public static DuToanDauTuDto ToDto(this DuToanDauTu entity, List<Attachment>? files = null) {
+    public static DuToanDauTuDto ToDto(
+        this DuToanDauTu entity,
+        List<Attachment>? files = null,
+        List<Attachment>? filesKhac = null) {
         return new DuToanDauTuDto
         {
             Id = entity.Id,
             DuAnId = entity.DuAnId,
             BuocId = entity.BuocId,
+            Ten = entity.Ten,
             NgayTrinh = entity.NgayTrinh,
             TrichYeu = entity.TrichYeu ?? string.Empty,
             SoToTrinh = entity.SoToTrinh ?? string.Empty,
@@ -47,6 +52,7 @@ public static class DuToanDauTuMappings {
             TenTrangThai = entity.TrangThai?.Ten,
 
             DanhSachTepDinhKem = files?.Select(x => x.ToDto()).ToList(),
+            DanhSachTepDinhKemKhac = filesKhac?.Select(x => x.ToDto()).ToList(),
         };
     }
 }

--- a/QLDA.Application/DuToanDauTu/Queries/DuToanDauTuGetPaginatedQuery.cs
+++ b/QLDA.Application/DuToanDauTu/Queries/DuToanDauTuGetPaginatedQuery.cs
@@ -4,8 +4,11 @@ using QLDA.Application.Common.Mapping;
 using QLDA.Application.TepDinhKems.DTOs;
 using QLDA.Application.DuToanDauTus.DTOs;
 using QLDA.Domain.Constants;
+using QLDA.Domain.Enums;
+using BuildingBlocks.Application.Attachments.Common;
 
 namespace QLDA.Application.DuToanDauTus.Queries;
+
 
 public record DuToanDauTuGetPaginatedQuery : AggregateRootPagination, IMayHaveGlobalFilter, IFromDateToDate, IRequest<PaginatedList<DuToanDauTuDto>> {
     public int? BuocId { get; set; }
@@ -40,14 +43,21 @@ internal class
             .WhereIf(request.DenNgay.HasValue, e => e.NgayTrinh.HasValue && e.NgayTrinh.Value <= request.DenNgay!.Value.ToEndOfDayUtc())
             .WhereGlobalFilter(
                 request,
-                e => e.TrichYeu
+                e => e.TrichYeu,
+                e => e.Ten
             );
+
+        var groupTypesCongVan = AttachmentSubquery.ExpandGroupTypes(
+            includeSigned: true, nameof(EGroupType.DuToanDauTu));
+        var groupTypesKhac = AttachmentSubquery.ExpandGroupTypes(
+            includeSigned: true, nameof(EGroupType.DuToanDauTu_Khac));
 
         return await queryable
             .Select(e => new DuToanDauTuDto() {
                 Id = e.Id,
                 DuAnId = e.DuAnId,
                 BuocId = e.BuocId,
+                Ten = e.Ten,
                 SoToTrinh = e.SoToTrinh ?? string.Empty,
                 TrichYeu = e.TrichYeu,
                 NgayTrinh = e.NgayTrinh,
@@ -63,7 +73,10 @@ internal class
                 TenTrangThai = e.TrangThai != null && e.TrangThai!.Ma != "LEG" ? e.TrangThai!.Ten : TrangThaiPheDuyetCodes.Default.TenDuThao,
 
                 DanhSachTepDinhKem = TepDinhKem.GetQueryableSet()
-                    .Where(i => i.GroupId == e.Id.ToString())
+                    .Where(i => i.GroupId == e.Id.ToString() && groupTypesCongVan.Contains(i.GroupType))
+                    .Select(i => i.ToDto()).ToList(),
+                DanhSachTepDinhKemKhac = TepDinhKem.GetQueryableSet()
+                    .Where(i => i.GroupId == e.Id.ToString() && groupTypesKhac.Contains(i.GroupType))
                     .Select(i => i.ToDto()).ToList(),
             })
             .PaginatedListAsync(request.Skip(), request.Take(), cancellationToken: cancellationToken);

--- a/QLDA.Domain/Entities/DuToanDauTu.cs
+++ b/QLDA.Domain/Entities/DuToanDauTu.cs
@@ -10,6 +10,7 @@ public class DuToanDauTu : Entity<Guid>, IAggregateRoot, ITienDo
 {
     public Guid DuAnId { get; set; }
     public int? BuocId { get; set; }
+    public string? Ten { get; set; }
     public int? PhuongAnThietKeId { get; set; }
     public long? TongMucDauTu { get; set; }
     public long? TongDuToan { get; set; }

--- a/QLDA.Domain/Enums/EGroupType.cs
+++ b/QLDA.Domain/Enums/EGroupType.cs
@@ -78,6 +78,10 @@ public enum EGroupType {
     ThoaThuanGiaoViec,
     KeHoachLuaChonNhaThauRutGon,
     DuToanDauTu,
+    /// <summary>
+    /// File Khác của Dự toán CBĐT / Trình duyệt dự toán (Issue #175)
+    /// </summary>
+    DuToanDauTu_Khac,
     ThanhLyHopDong,
     ThanhLyHopDong_BienBanNghiemThu,
     ThanhLyHopDong_Khac,

--- a/QLDA.Migrator/Migrations/20260811041041_AddDuToanDauTuTen.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260811041041_AddDuToanDauTuTen.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811041041_AddDuToanDauTuTen")]
+    partial class AddDuToanDauTuTen
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260811041041_AddDuToanDauTuTen.cs
+++ b/QLDA.Migrator/Migrations/20260811041041_AddDuToanDauTuTen.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDuToanDauTuTen : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Ten",
+                table: "DuToanDauTu",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Ten",
+                table: "DuToanDauTu");
+        }
+    }
+}

--- a/QLDA.Persistence/Configurations/DuToanDauTuConfiguration.cs
+++ b/QLDA.Persistence/Configurations/DuToanDauTuConfiguration.cs
@@ -17,6 +17,7 @@ public class DuToanDauTuConfiguration : AggregateRootConfiguration<DuToanDauTu> 
                 toDb => toDb == 0 ? null : toDb,
                 fromDb => fromDb 
             );
+        builder.Property(x => x.Ten).HasMaxLength(500);
         builder.Property(x => x.SoToTrinh).HasMaxLength(30);
 
         builder.Property(e => e.NgayTrinh)

--- a/QLDA.WebApi/Controllers/DuToanDauTuController.cs
+++ b/QLDA.WebApi/Controllers/DuToanDauTuController.cs
@@ -8,6 +8,7 @@ using QLDA.Application.DuToanDauTus;
 using QLDA.Application.DuToanDauTus.Commands;
 using QLDA.Application.DuToanDauTus.DTOs;
 using QLDA.Application.DuToanDauTus.Queries;
+using QLDA.Domain.Enums;
 using System.Net.Mime;
 
 namespace QLDA.WebApi.Controllers;
@@ -29,10 +30,15 @@ public class DuToanDauTuController(IServiceProvider serviceProvider) : Aggregate
         });
 
         var danhSachTepDinhKem = (await Mediator.Send(new GetAttachmentsQuery(
-            GroupIds: [entity.Id.ToString()]
+            GroupIds: [entity.Id.ToString()],
+            BaseGroupTypes: [nameof(EGroupType.DuToanDauTu)]
+        ))).ToAttachmentEntities();
+        var danhSachTepDinhKemKhac = (await Mediator.Send(new GetAttachmentsQuery(
+            GroupIds: [entity.Id.ToString()],
+            BaseGroupTypes: [nameof(EGroupType.DuToanDauTu_Khac)]
         ))).ToAttachmentEntities();
 
-        return ResultApi.Ok(entity.ToDto(danhSachTepDinhKem.ToList()));
+        return ResultApi.Ok(entity.ToDto(danhSachTepDinhKem.ToList(), danhSachTepDinhKemKhac.ToList()));
     }
 
     [ProducesResponseType<ResultApi<IHasKey<Guid>>>(StatusCodes.Status200OK)]
@@ -53,19 +59,30 @@ public class DuToanDauTuController(IServiceProvider serviceProvider) : Aggregate
         [FromServices] IUnitOfWork unitOfWork,
         CancellationToken cancellationToken = default)
     {
+        ManagedException.ThrowIf(
+            dto.DanhSachTepDinhKem == null || dto.DanhSachTepDinhKem.Count == 0,
+            "Công văn đề nghị báo giá là bắt buộc");
+
         var step = await Mediator.Send(new DuAnUpdateStepCommand(dto.DuAnId, dto.BuocId));
         await Mediator.Send(new DuAnUpdatePhaseCommand(dto.DuAnId, step));
 
         var entity = await Mediator.Send(new DuToanDauTuInsertCommand(dto), cancellationToken);
-        // nếu dùng DuToanDauTu cho nhìu màn hình thì lấy  EGroupType.DuToanDauTu theo Loai
-        //tạo contanst LoaiDuToanDauTu
 
-        List<Attachment> files = [.. dto.DanhSachTepDinhKem?.ToEntities(entity.Id, EGroupType.DuToanDauTu) ?? []];
+        List<Attachment> files = [.. dto.DanhSachTepDinhKem.ToEntities(entity.Id, EGroupType.DuToanDauTu)];
         await Mediator.Send(new AttachmentBulkInsertOrUpdateCommand
         {
             GroupId = entity.Id.ToString(),
             GroupTypes = [nameof(EGroupType.DuToanDauTu)],
             Entities = files,
+            AutoDeleteMissing = true
+        }, cancellationToken);
+
+        List<Attachment> fileKhacs = [.. dto.DanhSachTepDinhKemKhac?.ToEntities(entity.Id, EGroupType.DuToanDauTu_Khac) ?? []];
+        await Mediator.Send(new AttachmentBulkInsertOrUpdateCommand
+        {
+            GroupId = entity.Id.ToString(),
+            GroupTypes = [nameof(EGroupType.DuToanDauTu_Khac)],
+            Entities = fileKhacs,
             AutoDeleteMissing = true
         }, cancellationToken);
 
@@ -82,9 +99,13 @@ public class DuToanDauTuController(IServiceProvider serviceProvider) : Aggregate
         [FromServices] IUnitOfWork unitOfWork,
         CancellationToken cancellationToken = default)
     {
+        ManagedException.ThrowIf(
+            dto.DanhSachTepDinhKem == null || dto.DanhSachTepDinhKem.Count == 0,
+            "Công văn đề nghị báo giá là bắt buộc");
+
         var entity = await Mediator.Send(new DuToanDauTuUpdateCommand(dto), cancellationToken);
 
-        List<Attachment> files = [.. dto.DanhSachTepDinhKem?.ToEntities(entity.Id, EGroupType.DuToanDauTu) ?? []];
+        List<Attachment> files = [.. dto.DanhSachTepDinhKem.ToEntities(entity.Id, EGroupType.DuToanDauTu)];
         await Mediator.Send(new AttachmentBulkInsertOrUpdateCommand
         {
             GroupId = entity.Id.ToString(),
@@ -93,13 +114,27 @@ public class DuToanDauTuController(IServiceProvider serviceProvider) : Aggregate
             AutoDeleteMissing = true
         }, cancellationToken);
 
+        List<Attachment> fileKhacs = [.. dto.DanhSachTepDinhKemKhac?.ToEntities(entity.Id, EGroupType.DuToanDauTu_Khac) ?? []];
+        await Mediator.Send(new AttachmentBulkInsertOrUpdateCommand
+        {
+            GroupId = entity.Id.ToString(),
+            GroupTypes = [nameof(EGroupType.DuToanDauTu_Khac)],
+            Entities = fileKhacs,
+            AutoDeleteMissing = true
+        }, cancellationToken);
+
         await unitOfWork.SaveChangesAsync(cancellationToken);
 
         var danhSachTepDinhKem = (await Mediator.Send(new GetAttachmentsQuery(
-            GroupIds: [entity.Id.ToString()]
+            GroupIds: [entity.Id.ToString()],
+            BaseGroupTypes: [nameof(EGroupType.DuToanDauTu)]
+        ), cancellationToken)).ToAttachmentEntities();
+        var danhSachTepDinhKemKhac = (await Mediator.Send(new GetAttachmentsQuery(
+            GroupIds: [entity.Id.ToString()],
+            BaseGroupTypes: [nameof(EGroupType.DuToanDauTu_Khac)]
         ), cancellationToken)).ToAttachmentEntities();
 
-        return ResultApi.Ok(entity.ToDto(danhSachTepDinhKem.ToList()));
+        return ResultApi.Ok(entity.ToDto(danhSachTepDinhKem.ToList(), danhSachTepDinhKemKhac.ToList()));
     }
 
     [ProducesResponseType<ResultApi<PaginatedList<DuToanDauTuDto>>>(StatusCodes.Status200OK)]

--- a/docs/issues/175/index.md
+++ b/docs/issues/175/index.md
@@ -1,0 +1,170 @@
+# Issue #175 — Cập nhật màn hình Trình duyệt dự toán
+
+> **Nguồn:** PMIS / Redmine issue #175  
+> **Nghiệp vụ:** Trình duyệt dự toán — form **Tờ trình phê duyệt dự toán**  
+> **Trạng thái:** ✅ BE code xong — chờ user migration + FE  
+> **Entity BE:** `QLDA.Domain/Entities/DuToanDauTu.cs`  
+> **API chính:** `api/du-toan-dau-tu`
+
+## 1. Mô tả yêu cầu
+
+Chỉ thực hiện 3 thay đổi trên màn **Trình duyệt dự toán**:
+
+| # | Hạng mục | Mô tả |
+|---|----------|--------|
+| 1 | **Tên dự toán** | Bắt buộc; validate null/empty/whitespace; lưu DB + trả lại chi tiết |
+| 2 | **Phương án thiết kế** | Bỏ khỏi form; không bắt nhập/upload; **không** drop column DB |
+| 3 | **Công văn đề nghị báo giá** | Upload file bắt buộc (≥1 file); tách GroupType; load đúng khi chi tiết |
+| — | **Khác** | Upload file **không** bắt buộc; giữ behavior optional |
+
+### Layout form sau chỉnh sửa
+
+- Tên dự toán *
+- Số tờ trình *
+- Ngày trình
+- Trích yếu
+- Tổng dự toán (VNĐ) *
+- Tổng dự toán thẩm định giá (VNĐ) *
+- Các chi phí trong giai đoạn CBĐT
+- Nguồn vốn
+- Thời gian thực hiện (năm)
+- **Công văn đề nghị báo giá *** — upload file, REQUIRED
+- **Khác** — upload file, OPTIONAL
+
+Không còn: **Phương án thiết kế**
+
+### Acceptance / validation cases
+
+| Case | Input | Expect |
+|------|-------|--------|
+| 1 | Không nhập Tên dự toán | Không lưu |
+| 2 | Có Tên, không upload Công văn đề nghị báo giá | Không lưu |
+| 3 | Có Tên + ≥1 file Công văn | Lưu thành công |
+| 4 | Chỉ upload Khác, không có Công văn | Báo thiếu Công văn đề nghị báo giá |
+| 5 | Mở lại bản ghi đã lưu | Tên + file Công văn load đúng |
+
+---
+
+## 2. Kết quả điều tra (pre-implement)
+
+### 2.1. Module BE nào?
+
+| Lớp | Vị trí | Ghi chú |
+|-----|--------|---------|
+| **FE** | Repo Frontend (**không** có trong `E:/SER`) | Form Tờ trình phê duyệt dự toán |
+| **BE API** | `QLDA.WebApi/Controllers/DuToanDauTuController.cs` | Route `api/du-toan-dau-tu` |
+| **Application** | `QLDA.Application/DuToanDauTu/` | Commands / Queries / DTO / Mappings |
+| **Domain** | `QLDA.Domain/Entities/DuToanDauTu.cs` | Entity tiến độ CBĐT |
+| **Persistence** | `QLDA.Persistence/Configurations/DuToanDauTuConfiguration.cs` | EF config |
+
+> **Không nhầm** với `PheDuyetDuToan` (`api/phe-duyet-du-toan`) hay `QuyetDinhDuyetDuToan` (`api/quyet-dinh-duyet-du-toan`).
+
+### 2.2. API endpoints
+
+| Method | Route | Handler |
+|--------|-------|---------|
+| GET | `{id}/chi-tiet` | `DuToanDauTuGetQuery` + hydrate `GetAttachmentsQuery` |
+| POST | `them-moi` | `DuToanDauTuInsertCommand` + `AttachmentBulkInsertOrUpdateCommand` |
+| PUT | `cap-nhat` | `DuToanDauTuUpdateCommand` + attachment sync |
+| DELETE | `{id}/xoa` | `DuToanDauTuDeleteCommand` |
+| GET | `danh-sach-tien-do` | `DuToanDauTuGetPaginatedQuery` |
+
+Body Insert/Update: `DuToanDauTuDto` (Application) — **không** tạo WebApi Model mới.
+
+### 2.3. Field map UI ↔ BE hiện tại
+
+| UI mong muốn | BE property | Có sẵn? |
+|--------------|-------------|---------|
+| Tên dự toán * | — | ❌ cần thêm `Ten` |
+| Số tờ trình * | `SoToTrinh` | ✅ |
+| Ngày trình | `NgayTrinh` | ✅ |
+| Trích yếu | `TrichYeu` | ✅ |
+| Tổng dự toán * | `TongDuToan` | ✅ |
+| Tổng dự toán thẩm định giá * | `TongMucDauTu` | ✅ (tên property ≠ label UI; **không đổi** trong scope này) |
+| Các chi phí trong giai đoạn CBĐT | `NoiDungChiPhis` ↔ DTO `NoiDungChiPhi` | ✅ |
+| Nguồn vốn | `NguonVonId` | ✅ |
+| Thời gian thực hiện (năm) | `Nam` | ✅ |
+| Công văn đề nghị báo giá * | attachment | ⚠️ đang gộp 1 list `DanhSachTepDinhKem` / `EGroupType.DuToanDauTu` |
+| Khác (optional) | attachment | ❌ chưa tách GroupType |
+| Phương án thiết kế (bỏ UI) | `PhuongAnThietKeId` | ✅ còn trên Entity/DTO — **giữ cột, bỏ form** |
+
+### 2.4. `Tên dự toán`
+
+- Entity / DTO / Mapping / snapshot **không** có `Ten` / `TenDuToan`.
+- Đề xuất property: **`Ten`** (`string`) — cùng pattern `KeHoachLuaChonNhaThau.Ten`.
+- Validate Insert/Update: `string.IsNullOrWhiteSpace` → không lưu.
+- **Cần migration** thêm cột trên bảng `DuToanDauTu`.
+
+### 2.5. `Phương án thiết kế`
+
+- DB: `PhuongAnThietKeId` (`int?`) + FK `DmPhuongAnThietKe`.
+- Map đầy đủ Insert / Update / Detail / List (`TenPhuongAnThietKe`).
+- **Không** drop column, **không** migration xóa.
+- Scope: FE bỏ control; BE thôi bắt buộc (có thể giữ property để tương thích payload cũ).
+
+### 2.6. Attachment — hiện trạng & đề xuất
+
+**Hiện tại**
+
+- 1 list: `DanhSachTepDinhKem`
+- `GroupType` = `EGroupType.DuToanDauTu`
+- Get chi tiết: `GetAttachmentsQuery(GroupIds)` **không** truyền `BaseGroupTypes` → lấy mọi file theo `GroupId`
+- List query: subquery attachment cũng không filter GroupType
+- **Chưa** validate số lượng file bắt buộc
+
+**Pattern reuse:** `QuyetDinhDuyetDuToanController` — `DanhSachTepDinhKem` + `DanhSachTepDinhKemKhac` / `QuyetDinhDuyetDuToan` + `QuyetDinhDuyetDuToan_Khac`.
+
+**Đề xuất (Approach A — khuyến nghị)**
+
+| UI | GroupType | DTO list | Bắt buộc? |
+|----|-----------|----------|-----------|
+| Công văn đề nghị báo giá | **Reuse** `DuToanDauTu` | `DanhSachTepDinhKem` | Yes (≥1) |
+| Khác | **Thêm** `DuToanDauTu_Khac` | `DanhSachTepDinhKemKhac` | No |
+
+- Write: 2 lần `AttachmentBulkInsertOrUpdateCommand`, mỗi lần 1 `GroupTypes`, `AutoDeleteMissing = true`
+- Read: 2 lần `GetAttachmentsQuery` với `BaseGroupTypes` tương ứng
+- List: `AttachmentSubquery.ExpandGroupTypes` + filter `Contains` theo từng GroupType (không gọi Mediator trong projection)
+- Validate ≥1 file Công văn ở Controller (hoặc Command nhận DTO) trước khi lưu — **không** áp sang `Khac`
+
+**Không chọn**
+
+- Approach B: tạo `DuToanDauTu_CongVanDeNghiBaoGia` + `_Khac` → file cũ dưới `DuToanDauTu` lệch / cần migrate data
+- Approach C: 1 list + flag FE → dễ lẫn file
+
+### 2.7. Migration
+
+| Thay đổi | Cần migration? |
+|----------|----------------|
+| Thêm `Ten` trên `DuToanDauTu` | ✅ |
+| Thêm `EGroupType.DuToanDauTu_Khac` | ❌ (string trên `TepDinhKem`) |
+| Bỏ UI Phương án thiết kế | ❌ (giữ cột) |
+
+**User tự tạo migration tay** (`ef.bat QLDA add …`) sau Domain + Persistence.Configuration. Agent không chạy migration. **Không** sửa migration cũ / **không** sửa tay `AppDbContextModelSnapshot.cs`.
+
+### 2.8. FE
+
+Repo FE **không** trong workspace. BE mở API/DTO; FE bind label `*`, ẩn Phương án thiết kế, tách 2 upload zone.
+
+---
+
+## 3. Acceptance Criteria
+
+- [ ] `Ten` bắt buộc trên Insert/Update; null/empty/whitespace không lưu
+- [ ] Chi tiết / danh sách trả `Ten` đúng
+- [ ] Form không còn bắt Phương án thiết kế; không drop DB column
+- [ ] Công văn đề nghị báo giá: ≥1 file (`EGroupType.DuToanDauTu` / `DanhSachTepDinhKem`)
+- [ ] Khác optional (`DuToanDauTu_Khac` / `DanhSachTepDinhKemKhac`) — không inherit validate bắt buộc
+- [ ] Chi tiết load đúng 2 list, không lẫn GroupType
+- [ ] Case 1–5 như bảng trên
+- [ ] Build OK; migration chỉ khi thêm `Ten`
+- [ ] Không tạo WebApi Model mới; không refactor ngoài phạm vi
+
+---
+
+## 4. Tài liệu trong issue folder
+
+| File | Mục đích |
+|------|----------|
+| [report.md](./report.md) | Design kỹ thuật + file sửa + checklist code |
+| [journal.md](./journal.md) | Nhật ký công việc |
+| [test-workflow.md](./test-workflow.md) | Cách verify sau implement |

--- a/docs/issues/175/journal.md
+++ b/docs/issues/175/journal.md
@@ -1,0 +1,49 @@
+# Journal — #175 Trình duyệt dự toán (`DuToanDauTu`)
+
+## 2026-08-11 — Survey source + viết docs (chưa code)
+
+**Việc làm:**
+
+- Xác định màn **Trình duyệt dự toán** / form **Tờ trình phê duyệt dự toán** = module BE `DuToanDauTu` (`api/du-toan-dau-tu`), không phải `PheDuyetDuToan` / `QuyetDinhDuyetDuToan`.
+- Trace Controller → Insert/Update/Get/List + attachment `EGroupType.DuToanDauTu`.
+- Xác nhận **chưa có** `Ten` / `TenDuToan` trên Entity/DTO/DB.
+- Xác nhận `PhuongAnThietKeId` còn map đầy đủ; yêu cầu chỉ bỏ UI, không drop cột.
+- Survey `EGroupType`: chỉ có `DuToanDauTu`; chưa có CongVan/BaoGia/`_Khac` cho module này.
+- Pattern multi-file tham chiếu: `QuyetDinhDuyetDuToan` + `QuyetDinhDuyetDuToan_Khac`.
+- FE không có trong workspace `E:/SER`.
+- Viết docs: `index.md`, `report.md`, `test-workflow.md`, journal này.
+- Issue folder: `docs/issues/175/` (user chốt số **#175**).
+
+**Quyết định tạm (chờ duyệt trước khi code):**
+
+1. Thêm `Ten` trên `DuToanDauTu` → **có migration** — **user tự tạo tay** (`ef.bat`); agent không chạy Migrator.
+2. Công văn đề nghị báo giá: **reuse** `EGroupType.DuToanDauTu` + `DanhSachTepDinhKem`; validate ≥1 file.
+3. Khác: thêm `EGroupType.DuToanDauTu_Khac` + `DanhSachTepDinhKemKhac`; optional.
+4. Phương án thiết kế: giữ DB; bỏ form / không bắt buộc.
+5. Không tạo WebApi Model; không drop column; không sửa migration cũ.
+
+**Chưa làm:** FE, commit/PR. Migration do user.
+
+---
+
+## 2026-08-11 — Implement BE (không migration)
+
+**Đã code:**
+
+| Hạng mục | Chi tiết |
+|----------|----------|
+| `Ten` | Entity + Config MaxLength(500) + DTO + Mapping + Insert/Update validate |
+| `DuToanDauTu_Khac` | Enum + `DanhSachTepDinhKemKhac` |
+| Công văn bắt buộc | Controller Create/Update validate ≥1 `DanhSachTepDinhKem` |
+| Hydrate | Get/Update chi tiết 2 `GetAttachmentsQuery` + BaseGroupTypes |
+| List | `ExpandGroupTypes` tách Công văn / Khác; project `Ten` |
+
+**Build:** Domain / Application / Persistence / WebApi — 0 error.
+
+**User tiếp theo:**
+
+```bat
+ef.bat QLDA add AddDuToanDauTuTen
+```
+
+Rồi apply DB + FE bind `ten` / ẩn Phương án thiết kế / 2 upload zone.

--- a/docs/issues/175/report.md
+++ b/docs/issues/175/report.md
@@ -1,0 +1,162 @@
+# Issue #175 — Report: Trình duyệt dự toán (`DuToanDauTu`)
+
+> **Status:** CODE DONE — chờ user migration + FE  
+> **Date:** 2026-08-11  
+> **API:** `api/du-toan-dau-tu`  
+> **Migration:** **User tự tạo tay** (`ef.bat`) — agent **không** chạy migration / không sửa Migrator  
+> **Chi tiết BA + survey:** xem [`index.md`](./index.md)
+
+## Summary
+
+Cập nhật form **Tờ trình phê duyệt dự toán** trên module `DuToanDauTu`:
+
+| Field nghiệp vụ | Cách xử lý | Migration? |
+|-----------------|------------|------------|
+| Tên dự toán * | Thêm `Ten` trên Entity/DTO/Mapping; validate required | ✅ |
+| Phương án thiết kế | Bỏ khỏi form; giữ `PhuongAnThietKeId` trên DB | ❌ |
+| Công văn đề nghị báo giá * | Reuse `EGroupType.DuToanDauTu` + validate ≥1 file | ❌ |
+| Khác (optional) | Thêm `EGroupType.DuToanDauTu_Khac` + `DanhSachTepDinhKemKhac` | ❌ |
+
+## Architecture
+
+Không đổi route Controller. Follow Clean Architecture + CQRS hiện có:
+
+- Write field → Domain + Mapping + Insert/Update handler validate
+- Attachment → BB `AttachmentBulkInsertOrUpdateCommand` / `GetAttachmentsQuery` (pattern `QuyetDinhDuyetDuToan`)
+- **Không** tạo Application Service / WebApi Model mới
+
+```text
+FE form
+  → POST/PUT api/du-toan-dau-tu
+  → DuToanDauTuInsert|UpdateCommand (validate Ten)
+  → Controller sync 2 GroupType attachments (+ validate ≥1 Công văn)
+  → GET chi-tiet hydrate 2 list theo BaseGroupTypes
+```
+
+## Design chi tiết
+
+### 1. `Ten` (Tên dự toán)
+
+| Layer | Thay đổi |
+|-------|----------|
+| Domain | `string? Ten` hoặc `string Ten` trên `DuToanDauTu` — đề xuất `string Ten = ""` + MaxLength config |
+| Persistence | `HasMaxLength` (gợi ý 500, align entity tên tương tự); **không** NOT NULL cứng nếu có data cũ — validate ở Application |
+| DTO | `Ten` trên `DuToanDauTuDto` |
+| Mapping | ToEntity / ToDto / list projection |
+| Insert/Update | `ManagedException.ThrowIf(string.IsNullOrWhiteSpace(dto.Ten), "…")` |
+| Migration | **User tự làm** sau khi Domain + EF Config có `Ten` — xem mục Migration bên dưới |
+
+### 2. Phương án thiết kế
+
+- FE: ẩn control.
+- BE: **không** xóa property/FK; Update có thể thôi gán bắt buộc (payload không gửi → giữ/null tùy policy hiện tại — **không** force clear trừ khi FE gửi null có chủ đích).
+- Scope tối thiểu: không thêm validate bắt buộc; không expose như field nghiệp vụ mới.
+
+### 3. Attachments
+
+| UI | GroupType | DTO |
+|----|-----------|-----|
+| Công văn đề nghị báo giá * | `DuToanDauTu` (reuse) | `DanhSachTepDinhKem` |
+| Khác | `DuToanDauTu_Khac` (**mới**) | `DanhSachTepDinhKemKhac` |
+
+**Controller Create/Update**
+
+```csharp
+// Validate trước sync
+ManagedException.ThrowIf(
+    dto.DanhSachTepDinhKem == null || dto.DanhSachTepDinhKem.Count == 0,
+    "Công văn đề nghị báo giá là bắt buộc");
+
+// Sync Công văn
+await Mediator.Send(new AttachmentBulkInsertOrUpdateCommand {
+    GroupId = entity.Id.ToString(),
+    GroupTypes = [nameof(EGroupType.DuToanDauTu)],
+    Entities = dto.DanhSachTepDinhKem.ToEntities(entity.Id, EGroupType.DuToanDauTu).ToList(),
+    AutoDeleteMissing = true
+});
+
+// Sync Khác (optional — list null/empty OK)
+await Mediator.Send(new AttachmentBulkInsertOrUpdateCommand {
+    GroupId = entity.Id.ToString(),
+    GroupTypes = [nameof(EGroupType.DuToanDauTu_Khac)],
+    Entities = dto.DanhSachTepDinhKemKhac?.ToEntities(entity.Id, EGroupType.DuToanDauTu_Khac).ToList() ?? [],
+    AutoDeleteMissing = true
+});
+```
+
+**Get chi tiết:** 2 lần `GetAttachmentsQuery` với `BaseGroupTypes` riêng → map vào 2 list trên DTO.
+
+**List:** subquery dùng `AttachmentSubquery.ExpandGroupTypes` — không lấy nhầm `_Khac` vào list Công văn.
+
+**Lưu ý data cũ:** file đã lưu dưới `DuToanDauTu` → thuộc khu **Công văn** sau đổi (hợp lý nếu trước đây là upload chính). Không cần SQL migrate GroupType.
+
+## Files dự kiến sửa
+
+### BE (trong repo)
+
+| File | Việc |
+|------|------|
+| `QLDA.Domain/Entities/DuToanDauTu.cs` | + `Ten` |
+| `QLDA.Persistence/Configurations/DuToanDauTuConfiguration.cs` | MaxLength `Ten` |
+| `QLDA.Domain/Enums/EGroupType.cs` | + `DuToanDauTu_Khac` |
+| `QLDA.Application/DuToanDauTu/DTOs/DuToanDauTuDto.cs` | + `Ten`, + `DanhSachTepDinhKemKhac` |
+| `QLDA.Application/DuToanDauTu/DuToanDauTuMappings.cs` | map `Ten`; filter files theo GroupType khi ToDto |
+| `QLDA.Application/DuToanDauTu/Commands/DuToanDauTuInsertCommand.cs` | validate `Ten` |
+| `QLDA.Application/DuToanDauTu/Commands/DuToanDauTuUpdateCommand.cs` | validate `Ten`; gán `Ten` |
+| `QLDA.Application/DuToanDauTu/Queries/DuToanDauTuGetPaginatedQuery.cs` | project `Ten`; split attachment GroupTypes |
+| `QLDA.WebApi/Controllers/DuToanDauTuController.cs` | validate Công văn; sync/load 2 GroupType |
+| `QLDA.Migrator/Migrations/<new>_….cs` | **User tự** `ef.bat` — không nằm trong scope agent code |
+
+### FE (repo ngoài)
+
+| Việc | Ghi chú |
+|------|---------|
+| Input Tên dự toán * | Bind `ten` |
+| Ẩn Phương án thiết kế | Không gửi bắt buộc |
+| Upload Công văn * | Bind `danhSachTepDinhKem` |
+| Upload Khác | Bind `danhSachTepDinhKemKhac` |
+
+### Không sửa
+
+- Migration cũ / sửa tay ModelSnapshot
+- Drop `PhuongAnThietKeId`
+- `PheDuyetDuToan` / `QuyetDinhDuyetDuToan` (module khác)
+- Refactor ngoài phạm vi #175
+
+## Checklist bước code (khi được duyệt)
+
+- [x] 0. Branch (theo convention issue) — dùng branch hiện tại
+- [x] 1. Domain `Ten`
+- [x] 2. EF Configuration `Ten`
+- [ ] 3. Migration — **bỏ qua (user tự làm)**
+- [x] 4. `EGroupType.DuToanDauTu_Khac`
+- [x] 5. DTO + Mapping
+- [x] 6. Insert/Update validate `Ten`
+- [x] 7. Controller: validate Công văn + sync 2 GroupType
+- [x] 8. Get chi tiết hydrate 2 list
+- [x] 9. List projection
+- [x] 10. Build Domain / Application / Persistence / WebApi — 0 error
+- [ ] 11. Commit / PR (khi user yêu cầu; nhớ gộp Migrator khi user đã add)
+
+## Migration — **USER tự tạo tay**
+
+> Agent **không** chạy `ef.bat`, **không** sửa `QLDA.Migrator/Migrations/*`, **không** sửa tay `AppDbContextModelSnapshot.cs`.
+
+Sau khi Domain + `DuToanDauTuConfiguration` đã có `Ten`, user chạy:
+
+```bat
+ef.bat QLDA add AddDuToanDauTuTen
+```
+
+Cột đề xuất trên `DuToanDauTu`:
+
+- `Ten` `nvarchar(…)` NULL hoặc `''` default — Application bắt buộc; data cũ backfill sau nếu cần
+
+Commit group (rule dự án): **Domain + Persistence.Configuration + Migrator** cùng một commit khi đã có file migration.
+
+## Rủi ro / điểm đã chốt tạm
+
+1. **GroupType Công văn = reuse `DuToanDauTu`** — tránh orphan file cũ; tên enum không mirror label UI (OK, FE label riêng).
+2. **Get hiện không filter BaseGroupTypes** — sau khi thêm `_Khac` **bắt buộc** filter, nếu không file Khác lẫn vào `DanhSachTepDinhKem`.
+3. **Validate attachment ở Controller** vì sync file nằm Controller (pattern hiện tại module này); `Ten` validate ở Command.
+4. **`TongMucDauTu` ↔ label “Tổng dự toán thẩm định giá”** — ngoài scope rename; ghi nhận mapping hiện có.

--- a/docs/issues/175/test-workflow.md
+++ b/docs/issues/175/test-workflow.md
@@ -1,0 +1,64 @@
+# Test workflow — #175 Trình duyệt dự toán (`DuToanDauTu`)
+
+## 1. Build
+
+```bash
+dotnet build SER.sln
+```
+
+Expect: 0 error. Không sửa ModelSnapshot thủ công. Migration chỉ do `ef.bat` sinh.
+
+## 2. Migration — **USER tự làm**
+
+Agent không tạo/apply migration. Sau khi Domain + Config có `Ten`:
+
+```bat
+ef.bat QLDA add AddDuToanDauTuTen
+```
+
+Verify migration chỉ thêm cột `Ten` trên `DuToanDauTu` — **không** drop `PhuongAnThietKeId`.
+
+Apply DB trên môi trường local (không drop database).
+
+## 3. API — Insert / Update validate
+
+Base: `POST /api/du-toan-dau-tu/them-moi` và `PUT /api/du-toan-dau-tu/cap-nhat`
+
+| Case | Body | Expect |
+|------|------|--------|
+| 1 | Thiếu / null / `""` / whitespace `ten` | 400 — không lưu |
+| 2 | Có `ten`, `danhSachTepDinhKem` rỗng/null | 400 — thiếu Công văn đề nghị báo giá |
+| 3 | Có `ten` + ≥1 file `danhSachTepDinhKem` | 200 — lưu OK |
+| 4 | Có `ten` + chỉ `danhSachTepDinhKemKhac`, không Công văn | 400 — thiếu Công văn |
+| 5 | Case 3 + optional `danhSachTepDinhKemKhac` | 200 — cả 2 list lưu đúng GroupType |
+
+## 4. API — Chi tiết
+
+`GET /api/du-toan-dau-tu/{id}/chi-tiet`
+
+- [ ] `ten` đúng giá trị đã lưu
+- [ ] `danhSachTepDinhKem` = file Công văn (`GroupType` `DuToanDauTu` / kèm `KySo_` nếu có)
+- [ ] `danhSachTepDinhKemKhac` = file Khác (`DuToanDauTu_Khac`)
+- [ ] Hai list không lẫn file của nhau
+- [ ] Không bắt buộc còn field Phương án thiết kế trên form FE (BE có thể vẫn trả `phuongAnThietKeId` nếu giữ property)
+
+## 5. API — Danh sách
+
+`GET /api/du-toan-dau-tu/danh-sach-tien-do?...`
+
+- [ ] Có `ten` trên từng dòng (nếu projection đã thêm)
+- [ ] Attachment (nếu trả) không lẫn GroupType
+
+## 6. FE (repo ngoài) — checklist
+
+- [ ] Input **Tên dự toán *** bind `ten`
+- [ ] Ẩn **Phương án thiết kế**
+- [ ] Upload **Công văn đề nghị báo giá *** → `danhSachTepDinhKem`
+- [ ] Upload **Khác** (optional) → `danhSachTepDinhKemKhac`
+- [ ] Create / Edit / Detail bind đủ Case 1–5
+
+## 7. Regression
+
+- [ ] Các field cũ (Số tờ trình, Tổng dự toán, Nguồn vốn, …) vẫn lưu/load
+- [ ] Workflow trình/duyệt/trả lại `DuToanDauTu` (nếu dùng) không vỡ
+- [ ] Module `PheDuyetDuToan` / `QuyetDinhDuyetDuToan` không bị ảnh hưởng


### PR DESCRIPTION
## Summary
- Bổ sung field `Ten` (Tên dự toán) bắt buộc trên `DuToanDauTu` + migration `AddDuToanDauTuTen`
- Tách upload: Công văn đề nghị báo giá (`DanhSachTepDinhKem` / `EGroupType.DuToanDauTu`, bắt buộc ≥1 file) và Khác (`DanhSachTepDinhKemKhac` / `DuToanDauTu_Khac`, optional)
- Giữ `PhuongAnThietKe` trên BE/DB; FE ẩn form (không drop cột)

## Test plan
- [ ] Apply migration `AddDuToanDauTuTen`
- [ ] Không nhập `ten` → không lưu
- [ ] Có `ten`, không upload Công văn → không lưu
- [ ] Có `ten` + ≥1 file Công văn → lưu OK
- [ ] Chỉ upload Khác → vẫn báo thiếu Công văn
- [ ] GET chi-tiết: `ten` + 2 list file load đúng, không lẫn GroupType
- [ ] Form FE không còn Phương án thiết kế