### PR TITLE
feat(#178): bổ sung SoLuongGoiThau cho Kế hoạch lựa chọn nhà thầu

### DIFF
--- a/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauDto.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauDto.cs
@@ -25,5 +25,6 @@ public class KeHoachLuaChonNhaThauDto : IHasKey<Guid?>, IMustHaveId<Guid>, ITien
     public long? DuToanThamDinh { get; set; }
     public int? NguonVonId { get; set; }
     public int? ThoiGianThucHien { get; set; }
+    public int? SoLuongGoiThau { get; set; }
     public List<TepDinhKemDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauInsertDto.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauInsertDto.cs
@@ -17,5 +17,6 @@ public class KeHoachLuaChonNhaThauInsertDto : IMayHaveTepDinhKemInsertDto, ITien
     public long? DuToanThamDinh { get; set; }
     public int? NguonVonId { get; set; }
     public int? ThoiGianThucHien { get; set; }
+    public int? SoLuongGoiThau { get; set; }
     public List<TepDinhKemInsertDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauUpdateDto.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauUpdateDto.cs
@@ -16,5 +16,6 @@ public class KeHoachLuaChonNhaThauUpdateDto : IMayHaveTepDinhKemInsertOrUpdateDt
     public long? DuToanThamDinh { get; set; }
     public int? NguonVonId { get; set; }
     public int? ThoiGianThucHien { get; set; }
+    public int? SoLuongGoiThau { get; set; }
     public List<TepDinhKemInsertOrUpdateDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/KeHoachLuaChonNhaThauMappings.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/KeHoachLuaChonNhaThauMappings.cs
@@ -18,7 +18,8 @@ public static class KeHoachLuaChonNhaThauMappings {
             TongDuToan = dto.TongDuToan!.Value,
             DuToanThamDinh = dto.DuToanThamDinh,
             NguonVonId = dto.NguonVonId,
-            ThoiGianThucHien = dto.ThoiGianThucHien
+            ThoiGianThucHien = dto.ThoiGianThucHien,
+            SoLuongGoiThau = dto.SoLuongGoiThau
         };
     }
 
@@ -37,6 +38,7 @@ public static class KeHoachLuaChonNhaThauMappings {
             DuToanThamDinh = entity.DuToanThamDinh,
             NguonVonId = entity.NguonVonId,
             ThoiGianThucHien = entity.ThoiGianThucHien,
+            SoLuongGoiThau = entity.SoLuongGoiThau,
             DanhSachTepDinhKem = [.. files?.ToDtos() ?? []]
         };
     }
@@ -51,5 +53,6 @@ public static class KeHoachLuaChonNhaThauMappings {
         entity.DuToanThamDinh = dto.DuToanThamDinh;
         entity.NguonVonId = dto.NguonVonId;
         entity.ThoiGianThucHien = dto.ThoiGianThucHien;
+        entity.SoLuongGoiThau = dto.SoLuongGoiThau;
     }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs
@@ -55,6 +55,7 @@ internal class
                 DuToanThamDinh = e.DuToanThamDinh,
                 NguonVonId = e.NguonVonId,
                 ThoiGianThucHien = e.ThoiGianThucHien,
+                SoLuongGoiThau = e.SoLuongGoiThau,
                 DanhSachTepDinhKem = TepDinhKem.GetQueryableSet()
                     .Where(i => i.GroupId == e.Id.ToString())
                     .Select(i => i.ToDto()).ToList(),

--- a/QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs
+++ b/QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs
@@ -34,6 +34,11 @@ public class KeHoachLuaChonNhaThau : VanBanQuyetDinh {
     /// </summary>
     public int? ThoiGianThucHien { get; set; }
 
+    /// <summary>
+    /// Số lượng gói thầu
+    /// </summary>
+    public int? SoLuongGoiThau { get; set; }
+
     #region Navigation Properties
 
     public DanhMucNguonVon? NguonVon { get; set; }

--- a/QLDA.Migrator/Migrations/20260812044306_AddKeHoachLuaChonNhaThauSoLuongGoiThau.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260812044306_AddKeHoachLuaChonNhaThauSoLuongGoiThau.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260812044306_AddKeHoachLuaChonNhaThauSoLuongGoiThau")]
+    partial class AddKeHoachLuaChonNhaThauSoLuongGoiThau
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260812044306_AddKeHoachLuaChonNhaThauSoLuongGoiThau.cs
+++ b/QLDA.Migrator/Migrations/20260812044306_AddKeHoachLuaChonNhaThauSoLuongGoiThau.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddKeHoachLuaChonNhaThauSoLuongGoiThau : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "SoLuongGoiThau",
+                table: "KeHoachLuaChonNhaThau",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SoLuongGoiThau",
+                table: "KeHoachLuaChonNhaThau");
+        }
+    }
+}

--- a/docs/issues/178/index.md
+++ b/docs/issues/178/index.md
@@ -1,0 +1,195 @@
+# Issue #178 — Bổ sung field form Quyết định duyệt Kế hoạch lựa chọn nhà thầu
+
+**Issue:** #178 (PMIS/Redmine liên quan branch `178-9665---feature/add-ke-hoach-lcnt-fields`)  
+**Liên quan:** [#170](../170/index.md) — đã bổ sung phần lớn field trên cùng module  
+**Branch:** `178-9665---feature/add-ke-hoach-lcnt-fields`  
+**Trạng thái:** Code `SoLuongGoiThau` (Approach B) done — migration để user tự tạo  
+**Phạm vi code:** Chỉ `KeHoachLuaChonNhaThau` (+ reuse CBB nguồn vốn sẵn có). Không đụng `QuyetDinhDuyetKHLCNT` entity riêng, không đụng RutGon.
+
+---
+
+## 0. Kết luận nhanh (5 điểm bắt buộc trước khi code)
+
+### 1. Module / entity / API hiện tại
+
+| Hạng mục | Giá trị |
+|----------|---------|
+| Màn hình nghiệp vụ | Form **Quyết định / Kế hoạch lựa chọn nhà thầu** (Controller XML: *"Quyết định kế hoạch lựa chọn nhà thầu"*) |
+| Module xử lý form | **`KeHoachLuaChonNhaThau`** — **không** phải entity `QuyetDinhDuyetKHLCNT` |
+| API | `api/ke-hoach-lua-chon-nha-thau` |
+| Controller | `QLDA.WebApi/Controllers/KeHoachLuaChonNhaThauController.cs` |
+| Entity | `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs` (TPT từ `VanBanQuyetDinh`) |
+| CQRS | `QLDA.Application/KeHoachLuaChonNhaThaus/` |
+
+Endpoints form:
+
+| Flow | Method | Path |
+|------|--------|------|
+| Thêm mới | POST | `/them-moi` |
+| Cập nhật | PUT | `/cap-nhat` |
+| Chi tiết | GET | `/{id}/chi-tiet` |
+| Danh sách | GET | `/danh-sach-tien-do` |
+
+**Lưu ý phân biệt module:**
+
+- `QuyetDinhDuyetKHLCNT` (`api/quyet-dinh-duyet-khlcnt`) chỉ là bản ghi liên kết `KeHoachLuaChonNhaThauId` + `VanBanQuyetDinh` — **không** chứa Tổng dự toán / Nguồn vốn / Thời gian thực hiện.
+- Các field form nằm trên **`KeHoachLuaChonNhaThau`** (DTO dùng `IQuyetDinh`: `SoQuyetDinh`, `NgayQuyetDinh`, …).
+
+### 2. Field đã tồn tại (code + migration đã có trên branch)
+
+| Nghiệp vụ | Property | Kiểu | Layer đã có |
+|-----------|----------|------|-------------|
+| Tổng dự toán | `TongDuToan` | `long` (DTO Insert/Update: `long?` + validate) | Entity, EF FK/config, DTO×3, Mapping, Insert/Update validate, List projection, Migration |
+| Dự toán thẩm định | `DuToanThamDinh` | `long?` | Như trên (đổi tên từ `TongDuToanThamDinhGia` qua migration rename) |
+| Nguồn vốn | `NguonVonId` | `int?` + nav `NguonVon` | Như trên + validate thuộc `DuAnNguonVon` |
+| Thời gian thực hiện (năm) | `ThoiGianThucHien` | `int?` | Như trên |
+| Số tờ trình (label FE) | `So` / DTO `SoQuyetDinh` | `string?` | Reuse base `VanBanQuyetDinh` — không đổi schema |
+
+Migrations liên quan (#170):
+
+1. `20260810095922_AddKeHoachLuaChonNhaThauBoSungThongTin`
+2. `20260811022108_RenameTongDuToanThamDinhGiaToDuToanThamDinh`
+3. `20260811023400_FixRenameTongDuToanThamDinhGiaToDuToanThamDinh`
+
+Datatype tiền: `bigint` / `long` — cùng pattern `DuToanDauTu.TongDuToan`.
+
+### 3. Field phải thêm mới (gap còn lại so với yêu cầu task này)
+
+| Nghiệp vụ | Hiện trạng | Hành động đề xuất |
+|-----------|------------|-------------------|
+| **Số lượng gói thầu** | Persist `int? SoLuongGoiThau` (Approach B) trên Entity/DTO/Mapping/List | Code done; **user tự migration** cột `SoLuongGoiThau int NULL` |
+
+Không thiếu (đã làm #170): Tổng dự toán, Dự toán thẩm định, Nguồn vốn, Thời gian thực hiện.
+
+### 4. Nguồn vốn của Dự án đang lưu / lấy ở đâu
+
+| Thành phần | Chi tiết |
+|------------|----------|
+| Junction | `DuAnNguonVon` (`LeftId` = `DuAnId`, `RightId` = `NguonVonId`) |
+| Danh mục | `DanhMucNguonVon` → bảng `DmNguonVon` |
+| DuAn DTO | `DanhSachNguonVon: List<int>?` |
+| **CBB API đã có — reuse** | `GET api/danh-muc-nguon-von/danh-sach?duAnId={guid}` |
+| Query | `DanhMucNguonVonGetDanhSachQuery` — khi có `duAnId` filter `DuAnNguonVons.Any(i => i.LeftId == …)` |
+| Validate khi lưu KHLCNT | Insert/Update: nếu `NguonVonId > 0` thì phải thuộc `DuAn.DuAnNguonVons` |
+
+**Không** tạo bảng/danh mục/API nguồn vốn mới. Flow CBB:
+
+`Chọn Dự án` → `DuAnId` → `GET …/danh-muc-nguon-von/danh-sach?duAnId=` → chọn → lưu `NguonVonId` trên KHLCNT.
+
+### 5. File dự kiến cần sửa (chỉ nếu làm `SoLuongGoiThau`)
+
+Tùy approach (xem §3). **Không sửa** Controller signature nếu chỉ mở rộng DTO. **Không sửa** migration cũ / snapshot thủ công.
+
+---
+
+## 1. Survey source chi tiết
+
+### 1.1. Entity hiện tại (`KeHoachLuaChonNhaThau`)
+
+```csharp
+public long TongDuToan { get; set; }
+public long? DuToanThamDinh { get; set; }
+public int? NguonVonId { get; set; }
+public int? ThoiGianThucHien { get; set; }
+public DanhMucNguonVon? NguonVon { get; set; }
+public ICollection<GoiThau>? GoiThaus { get; set; }
+```
+
+### 1.2. DTO Insert / Update / Detail / List
+
+Đã có đủ 4 field trên `KeHoachLuaChonNhaThauDto`, `InsertDto`, `UpdateDto`; list projection trong `KeHoachLuaChonNhaThauGetDanhSachQuery` đã map.
+
+### 1.3. Validate hiện có
+
+- `TongDuToan` bắt buộc (*"Tổng dự toán là bắt buộc"*)
+- `NguonVonId` thuộc dự án (*"Nguồn vốn không thuộc dự án"*)
+- Trùng số tờ trình (*"Số tờ trình đã tồn tại"*)
+
+### 1.4. `QuyetDinhDuyetKHLCNT` — ngoài scope field
+
+Entity chỉ có `KeHoachLuaChonNhaThauId` + navigation `VanBanQuyetDinh`. Form field mới **không** đưa vào module này.
+
+---
+
+## 2. Mapping yêu cầu task ↔ hiện trạng
+
+| # | Yêu cầu | Hiện trạng | Cần làm thêm? |
+|---|---------|------------|---------------|
+| 1 | Tổng dự toán (tiền) | Đã có `TongDuToan` `long`/`bigint` | Không (verify API sau apply migration) |
+| 2 | Dự toán thẩm định | Đã có `DuToanThamDinh` full flow | Không (verify) |
+| 3 | Nguồn vốn CBB theo dự án | Đã có `NguonVonId` + CBB sẵn có | Không (reuse API) |
+| 4 | Thời gian thực hiện (năm) | Đã có `ThoiGianThucHien` `int?` | Không (verify) |
+| 5 | Số lượng gói thầu | Approach B `SoLuongGoiThau` | Code done; chờ migration tay |
+
+---
+
+## 3. Approaches cho **Số lượng gói thầu** (cần chốt)
+
+### Approach A — Computed (khuyến nghị nếu UI chỉ hiển thị)
+
+- Không thêm cột DB.
+- Detail/List: `SoLuongGoiThau = e.GoiThaus!.Count(g => !g.IsDeleted)` (hoặc Count theo convention soft-delete của `GoiThau`).
+- Insert/Update: **không** nhận field (hoặc ignore nếu FE gửi).
+- Pros: không trùng dữ liệu với danh sách gói thầu; đúng rule *"có thể tính thì không tạo field trùng"*.
+- Cons: lúc mới tạo KHLCNT chưa có gói thầu → luôn = 0; không cho BA nhập tay số dự kiến.
+
+### Approach B — Persist field nhập tay
+
+- Thêm `int? SoLuongGoiThau` trên Entity + DTO Insert/Update/Detail/List + Mapping + Migration mới.
+- Pros: form lập kế hoạch nhập trước khi có danh sách gói thầu.
+- Cons: có thể lệch với `GoiThaus.Count` nếu không sync.
+
+### Approach C — Persist + sync khi CRUD gói thầu
+
+- Như B + cập nhật count khi thêm/xóa gói thầu.
+- Pros: đủ cả nhập tay lẫn đồng bộ.
+- Cons: scope lớn, đụng module `GoiThau` — **không khuyến nghị** cho task này.
+
+**Đã chốt:** **Approach B** (persist nhập tay). Migration **không** tạo bởi agent — user tự `ef.bat QLDA add …`.
+
+### Files dự kiến nếu chọn A
+
+1. `…/DTOs/KeHoachLuaChonNhaThauDto.cs` — thêm `SoLuongGoiThau` (read-only trên response)
+2. `…/KeHoachLuaChonNhaThauMappings.cs` — map count khi có collection
+3. `…/Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs` — projection count
+4. `…/Queries/KeHoachLuaChonNhaThauQuery.cs` hoặc Controller Get — đảm bảo Include/count khi ToDto
+5. Docs `report.md` / `journal.md`
+
+Không migration.
+
+### Files dự kiến nếu chọn B
+
+1. `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs`
+2. `QLDA.Persistence/Configurations/KeHoachLuaChonNhaThauConfiguration.cs` (chỉ nếu cần config; thường không)
+3. Migration mới qua `ef.bat QLDA add …` (Domain + Config + Migrator cùng commit group)
+4. `DTOs/KeHoachLuaChonNhaThauDto.cs`, `InsertDto.cs`, `UpdateDto.cs`
+5. `KeHoachLuaChonNhaThauMappings.cs`
+6. `Commands/KeHoachLuaChonNhaThauInsertCommand.cs` / `UpdateCommand.cs` — validate optional nếu BA yêu cầu
+7. `Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs`
+8. Docs `report.md` / `journal.md`
+
+---
+
+## 4. Việc không làm
+
+- Không sửa `QuyetDinhDuyetKHLCNT` / RutGon / module khác
+- Không tạo Model WebApi mới cho field này
+- Không tạo danh mục nguồn vốn mới / hard-code list
+- Không sửa migration cũ / `AppDbContextModelSnapshot` thủ công
+- Không drop DB / xóa data
+- Không refactor `IQuyetDinh` / rename `SoQuyetDinh`
+
+---
+
+## 5. Acceptance (sau khi chốt + implement phần còn lại)
+
+1. Field 1–4 tiếp tục hoạt động đầy đủ trên thêm mới / cập nhật / chi tiết / danh sách.
+2. CBB nguồn vốn chỉ theo `duAnId` (API sẵn có).
+3. `SoLuongGoiThau` theo approach đã chốt, không trùng nghĩa với dữ liệu đã có nếu chọn A.
+4. Nếu B: migration mới chỉ thêm cột trên `KeHoachLuaChonNhaThau`.
+
+---
+
+## 6. Liên kết docs #170
+
+Chi tiết thiết kế 4 field đầu + bước code đã làm: [`../170/index.md`](../170/index.md), [`../170/report.md`](../170/report.md), [`../170/test-workflow.md`](../170/test-workflow.md).

--- a/docs/issues/178/journal.md
+++ b/docs/issues/178/journal.md
@@ -1,0 +1,16 @@
+# Journal — Issue #178 Form KHLCNT bổ sung field
+
+## 2026-08-12
+
+- Survey source theo yêu cầu "Quyết định duyệt Kế hoạch lựa chọn nhà thầu".
+- Kết luận module form = `KeHoachLuaChonNhaThau` (`api/ke-hoach-lua-chon-nha-thau`), không phải `QuyetDinhDuyetKHLCNT`.
+- 4 field (Tổng dự toán, Dự toán thẩm định, Nguồn vốn, Thời gian thực hiện) **đã có** từ #170 (entity/DTO/command/list + 3 migration).
+- Nguồn vốn dự án: `DuAnNguonVon` + CBB `GET api/danh-muc-nguon-von/danh-sach?duAnId=` — reuse, không tạo mới.
+- Gap còn lại: **Số lượng gói thầu** — chưa có field; có thể count từ `GoiThaus` (A) hoặc persist `SoLuongGoiThau` (B).
+- Viết docs `docs/issues/178/index.md`, `report.md`, `journal.md`. Chưa implement — chờ user chốt approach.
+
+- User: code theo `index.md`, migration để tự làm.
+- Chốt **Approach B** — thêm `int? SoLuongGoiThau` trên Entity + DTO Insert/Update/Dto + Mapping + List projection.
+- **Không** chạy `ef.bat add` — user tự migration.
+- Không thêm validate bắt buộc (optional như `ThoiGianThucHien`).
+- Build `QLDA.Application` succeeded, 0 error.

--- a/docs/issues/178/report.md
+++ b/docs/issues/178/report.md
@@ -1,0 +1,63 @@
+# Implementation Report — Issue #178 Form KHLCNT bổ sung field
+
+## Issue #178 | Branch: `178-9665---feature/add-ke-hoach-lcnt-fields`
+## Status: CODE DONE — migration `SoLuongGoiThau` để user tự tạo
+
+Chi tiết survey: [`index.md`](./index.md). Nền tảng 4 field: [#170](../170/report.md).
+
+## Summary
+
+| Field nghiệp vụ | Status |
+|-----------------|--------|
+| Tổng dự toán | Đã có (#170) |
+| Dự toán thẩm định | Đã có (#170) |
+| Nguồn vốn (CBB theo dự án) | Đã có (#170) + reuse CBB |
+| Thời gian thực hiện (năm) | Đã có (#170) |
+| Số lượng gói thầu | **Approach B** — `int? SoLuongGoiThau` (code done, chờ migration tay) |
+
+## Module
+
+- Form: `KeHoachLuaChonNhaThau` — `api/ke-hoach-lua-chon-nha-thau`
+- Không đụng `QuyetDinhDuyetKHLCNT`
+
+## Checklist
+
+- [x] Survey + docs
+- [x] Chốt Approach B (persist; user sẽ migration tay)
+- [x] Domain `SoLuongGoiThau`
+- [x] DTO Insert/Update/Dto
+- [x] Mapping
+- [x] List projection
+- [ ] Migration — **user tự** `ef.bat QLDA add …`
+- [ ] Build / test API sau khi apply migration
+- [ ] Commit / PR (khi user yêu cầu)
+
+## Files Changed (#178)
+
+| Layer | File | Thay đổi |
+|-------|------|----------|
+| Domain | `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs` | +`SoLuongGoiThau` |
+| Application | `DTOs/KeHoachLuaChonNhaThauDto.cs` | +field |
+| Application | `DTOs/KeHoachLuaChonNhaThauInsertDto.cs` | +field |
+| Application | `DTOs/KeHoachLuaChonNhaThauUpdateDto.cs` | +field |
+| Application | `KeHoachLuaChonNhaThauMappings.cs` | map field |
+| Application | `Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs` | projection |
+| Docs | `docs/issues/178/*` | cập nhật |
+
+EF Configuration: không cần đổi (int? default).
+
+## Migration (user tự làm)
+
+```bat
+ef.bat QLDA add AddKeHoachLuaChonNhaThauSoLuongGoiThau
+```
+
+Cần cột trên `KeHoachLuaChonNhaThau`:
+
+- `SoLuongGoiThau` `int` NULL
+
+Không sửa migration cũ / không sửa tay snapshot.
+
+## PR
+
+- PR: *(chưa có)*


### PR DESCRIPTION
## Summary
- Thêm field `SoLuongGoiThau` (`int?`) trên form Kế hoạch lựa chọn nhà thầu (`api/ke-hoach-lua-chon-nha-thau`): Entity, DTO Insert/Update/Detail, Mapping, List projection.
- Migration `AddKeHoachLuaChonNhaThauSoLuongGoiThau` (cột `int` NULL trên `KeHoachLuaChonNhaThau`).
- Docs: `docs/issues/178/`.

Ghi chú: Tổng dự toán / Dự toán thẩm định / Nguồn vốn / Thời gian thực hiện đã có từ #170.

## Test plan
- [x] `ef.bat QLDA update` đã apply migration
- [x] CBB nguồn vốn: `GET /api/danh-muc-nguon-von/danh-sach?duAnId=`
- [x] POST `them-moi` kèm `soLuongGoiThau` → chi tiết trả đúng
- [x] PUT `cap-nhat` đổi `soLuongGoiThau` → chi tiết / danh sách đồng bộ
- [ ] `soLuongGoiThau: null` vẫn OK (optional)