### PR TITLE
feat(#179): xóa cột cũ tờ trình thẩm định nhà thầu và đổi TenNhaThau thành NhaThauId

### DIFF
--- a/QLDA.Application/ToTrinhThamDinhNhaThau/Commands/ToTrinhThamDinhNhaThauInsertCommand.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/Commands/ToTrinhThamDinhNhaThauInsertCommand.cs
@@ -36,8 +36,6 @@ internal class ToTrinhThamDinhNhaThauInsertCommandHandler : IRequestHandler<ToTr
         using var tx = await _unitOfWork.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
         await _repo.AddAsync(request.Dto, cancellationToken);
         await _unitOfWork.SaveChangesAsync(cancellationToken);
-       // entity.SyncNhaThauIds(request.Dto.NhaThaus);
-        await _unitOfWork.SaveChangesAsync(cancellationToken);
         await _unitOfWork.CommitTransactionAsync(cancellationToken);
         return entity!;
     }

--- a/QLDA.Application/ToTrinhThamDinhNhaThau/Commands/ToTrinhThamDinhNhaThauThemMoiCommand.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/Commands/ToTrinhThamDinhNhaThauThemMoiCommand.cs
@@ -25,6 +25,7 @@ internal class ToTrinhThamDinhNhaThauThemMoiCommandHandler
     private readonly IRepository<ToTrinhQuyetDinh, long> _toTrinhQuyetDinhRepo;
     private readonly IRepository<VanBanQuyetDinh, Guid> _vanBanQuyetDinhRepo;
     private readonly IRepository<GoiThau, Guid> _goiThauRepo;
+    private readonly IRepository<DanhMucNhaThau, Guid> _nhaThauRepo;
     private readonly IRepository<DanhMucTrangThaiPheDuyet, int> _statusRepo;
     private readonly IAuthorizationManager _authManager;
     private readonly IAuthorizationContext _authContext;
@@ -35,6 +36,7 @@ internal class ToTrinhThamDinhNhaThauThemMoiCommandHandler
         _toTrinhQuyetDinhRepo = serviceProvider.GetRequiredService<IRepository<ToTrinhQuyetDinh, long>>();
         _vanBanQuyetDinhRepo = serviceProvider.GetRequiredService<IRepository<VanBanQuyetDinh, Guid>>();
         _goiThauRepo = serviceProvider.GetRequiredService<IRepository<GoiThau, Guid>>();
+        _nhaThauRepo = serviceProvider.GetRequiredService<IRepository<DanhMucNhaThau, Guid>>();
         _statusRepo = serviceProvider.GetRequiredService<IRepository<DanhMucTrangThaiPheDuyet, int>>();
         _authManager = serviceProvider.GetRequiredService<IAuthorizationManager>();
         _authContext = serviceProvider.GetRequiredService<IAuthorizationContext>();
@@ -51,6 +53,12 @@ internal class ToTrinhThamDinhNhaThauThemMoiCommandHandler
             .AnyAsync(e => e.Id == dto.GoiThauId, cancellationToken);
         ManagedException.ThrowIf(!goiThauTonTai, "Không tìm thấy gói thầu");
 
+        if (dto.ThongTinNhaThau?.NhaThauId is { } nhaThauId && nhaThauId != Guid.Empty) {
+            var nhaThauTonTai = await _nhaThauRepo.GetQueryableSet()
+                .AnyAsync(e => e.Id == nhaThauId, cancellationToken);
+            ManagedException.ThrowIf(!nhaThauTonTai, "Không tìm thấy nhà thầu");
+        }
+
         // Dùng lại đúng convention 4 trạng thái chung (DT/ĐTr/ĐD/TL) của DeXuatMacDinh —
         // không tạo bộ trạng thái riêng cho Tờ trình thẩm định nhà thầu.
         var trangThaiDuThao = await _statusRepo.GetQueryableSet(OnlyUsed: true, OnlyNotDeleted: true, OrderByIndex: false)
@@ -61,12 +69,9 @@ internal class ToTrinhThamDinhNhaThauThemMoiCommandHandler
             DuAnId = dto.DuAnId,
             BuocId = dto.BuocId,
             GoiThauId = dto.GoiThauId,
-            So = dto.So ?? string.Empty,
-            NgayTrinh = dto.NgayTrinh ?? DateTimeOffset.UtcNow,
-            TrichYeu = dto.TrichYeu,
             TrangThaiDangTaiId = dto.TrangThaiDangTaiId,
             TrangThaiId = trangThaiDuThao?.Id,
-            TenNhaThau = dto.ThongTinNhaThau?.TenNhaThau,
+            NhaThauId = dto.ThongTinNhaThau?.NhaThauId is { } id && id != Guid.Empty ? id : null,
             NgayKetThucDanhGia = dto.ThongTinNhaThau?.NgayKetThucDanhGia,
         };
         entity.SyncBuocXuLys(ToTrinhThamDinhNhaThauMappings.ToBuocXuLyList(dto.DoiChieu, dto.ThuongThao, dto.ThamDinh));

--- a/QLDA.Application/ToTrinhThamDinhNhaThau/Commands/ToTrinhThamDinhNhaThauTrinhCommand.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/Commands/ToTrinhThamDinhNhaThauTrinhCommand.cs
@@ -54,7 +54,6 @@ internal class ToTrinhThamDinhNhaThauTrinhCommandHandler : IRequestHandler<ToTri
         }
 
         entity.TrangThaiId = trangThaiDaTrinh!.Id;
-       // entity.NgayTrinh = DateTime.UtcNow;
 
         var history = new PheDuyetHistory
         {

--- a/QLDA.Application/ToTrinhThamDinhNhaThau/Commands/ToTrinhThamDinhNhaThauUpdateCommand.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/Commands/ToTrinhThamDinhNhaThauUpdateCommand.cs
@@ -33,7 +33,6 @@ internal class ToTrinhThamDinhNhaThauUpdateCommandHandler : IRequestHandler<ToTr
         .FirstOrDefaultAsync(s => s.Ma == TrangThaiPheDuyetCodes.DeXuatMacDinh.TraLai && s.Loai == PheDuyetEntityNames.DeXuatMacDinhStt, cancellationToken);
 
         var entity = await _repo.GetQueryableSet()
-            .Include(e => e.NhaThaus)
             .Include(e => e.BuocXuLys)
             .Include(e => e.TrangThai)
             .FirstOrDefaultAsync(e => e.Id == request.Dto.Id, cancellationToken);
@@ -47,12 +46,8 @@ internal class ToTrinhThamDinhNhaThauUpdateCommandHandler : IRequestHandler<ToTr
         }
         entity.DuAnId = request.Dto.DuAnId;
         entity.BuocId = request.Dto.BuocId;
-        entity.So = request.Dto.So;
-        entity.NgayTrinh = request.Dto.NgayTrinh;
-        entity.TrichYeu = request.Dto.TrichYeu;
+        entity.NhaThauId = request.Dto.NhaThauId;
         entity.TrangThaiDangTaiId = request.Dto.TrangThaiDangTaiId;
-        entity.DaThamDinh = request.Dto.DaThamDinh;
-        entity.SyncNhaThauIds(request.Dto.NhaThaus);
         entity.SyncBuocXuLys(request.Dto.BuocXuLys ?? []);
         // insert file cho TepDinhKem
         using var tx = await _unitOfWork.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);

--- a/QLDA.Application/ToTrinhThamDinhNhaThau/DTOs/ToTrinhThamDinhNhaThauDto.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/DTOs/ToTrinhThamDinhNhaThauDto.cs
@@ -14,15 +14,11 @@ public class ToTrinhThamDinhNhaThauDto : IHasKey<Guid?>, IMustHaveId<Guid>, IMay
 
     public Guid DuAnId { get; set; }
     public int? BuocId { get; set; }
-    public string So { get; set; } = string.Empty;
-    public DateTimeOffset NgayTrinh { get; set; }
-    public string? TrichYeu { get; set; }
+    public Guid? NhaThauId { get; set; }
     public int? TrangThaiId { get; set; }
     public string? MaTrangThai { get; set; }
     public int? TrangThaiDangTaiId { get; set; }
-    public bool? DaThamDinh { get; set; }
     public string? TenTrangThai { get; set; }
-    public List<KetQuaThamDinhNhaThauDto>? DanhSachNhaThau { get; set; }
     public List<TepDinhKemDto>? DanhSachTepDinhKem { get; set; }
     public List<TepDinhKemDto>? DanhSachTepThamDinh { get; set; }
 

--- a/QLDA.Application/ToTrinhThamDinhNhaThau/DTOs/ToTrinhThamDinhNhaThauThemMoiDto.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/DTOs/ToTrinhThamDinhNhaThauThemMoiDto.cs
@@ -17,9 +17,6 @@ public class ToTrinhThamDinhNhaThauThemMoiDto
     /// </summary>
     public Guid GoiThauId { get; set; }
 
-    public string? So { get; set; }
-    public DateTimeOffset? NgayTrinh { get; set; }
-    public string? TrichYeu { get; set; }
     public int? TrangThaiDangTaiId { get; set; }
 
     public ThongTinNhaThauDto? ThongTinNhaThau { get; set; }
@@ -33,7 +30,7 @@ public class ToTrinhThamDinhNhaThauThemMoiDto
 /// <summary>Mục 2 — Thông tin nhà thầu.</summary>
 public class ThongTinNhaThauDto
 {
-    public string? TenNhaThau { get; set; }
+    public Guid? NhaThauId { get; set; }
     public List<TepDinhKemDto>? FileEHSDT { get; set; }
     public DateTimeOffset? NgayKetThucDanhGia { get; set; }
     public List<TepDinhKemDto>? FileDanhGia { get; set; }

--- a/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs
@@ -38,36 +38,18 @@ internal class    ToTrinhThamDinhNhaThauDanhSachQueryHandler(IServiceProvider Se
     public async Task<PaginatedList<ToTrinhThamDinhNhaThauDto>> Handle(ToTrinhThamDinhNhaThauDanhSachQuery request,
         CancellationToken cancellationToken = default) {
 
-        DateTimeOffset? tuNgayDto = null;
-        DateTimeOffset? denNgayExclusiveDto = null; 
-        if (request.TuNgay.HasValue) {
-            var dt = request.TuNgay.Value.ToDateTime(TimeOnly.MinValue);
-            tuNgayDto = new DateTimeOffset(dt);
-        }
-        if (request.DenNgay.HasValue) {
-            var dt = request.DenNgay.Value.ToDateTime(TimeOnly.MinValue);
-            denNgayExclusiveDto = new DateTimeOffset(dt).AddDays(1);
-        }
-
         var queryable = ToTrinhThamDinhNhaThau.GetQueryableSet().AsNoTracking()
             .WhereIf(request.DuAnId != null, e => e.DuAnId == request.DuAnId)
             .WhereIf(request.LoaiDuAnTheoNamId > 0, e => e.DuAn!.LoaiDuAnTheoNamId == request.LoaiDuAnTheoNamId)
             .WhereIf(request.BuocId != null, e => e.BuocId == request.BuocId)
-            .WhereIf(request.So != null, e => e.So!.Contains(request.So!))
-            .WhereIf(request.TrangThaiDangTaiId != null, e => e.TrangThaiDangTaiId == request.TrangThaiDangTaiId)
-            .WhereIf(tuNgayDto != null, e => e.NgayTrinh >= tuNgayDto)
-            .WhereIf(denNgayExclusiveDto != null, e => e.NgayTrinh < denNgayExclusiveDto);
+            .WhereIf(request.TrangThaiDangTaiId != null, e => e.TrangThaiDangTaiId == request.TrangThaiDangTaiId);
         return await queryable
             .Select(e => new ToTrinhThamDinhNhaThauDto() {
                 Id = e.Id,
                 DuAnId=e.DuAnId,
                 BuocId=e.BuocId,
-                So = e.So,
-                NgayTrinh = e.NgayTrinh,
-                TrichYeu = e.TrichYeu,
+                NhaThauId = e.NhaThauId,
                 TrangThaiDangTaiId = e.TrangThaiDangTaiId,
-                DaThamDinh = e.DaThamDinh,
-                // trả thêm tên dự án
                 TrangThaiId = e.TrangThaiId,
                 MaTrangThai = e.TrangThai != null && e.TrangThai!.Ma != "LEG" ? e.TrangThai!.Ma : string.Empty,
                 TenTrangThai = e.TrangThai != null && e.TrangThai!.Ma != "LEG" ? e.TrangThai!.Ten : string.Empty,

--- a/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetQuery.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetQuery.cs
@@ -20,7 +20,6 @@ internal class ToTrinhThamDinhNhaThauGetQueryHandler(IServiceProvider servicePro
     public async Task<ToTrinhThamDinhNhaThau> Handle(ToTrinhThamDinhNhaThauGetQuery request,
         CancellationToken cancellationToken = default) {
         var queryable = ToTrinhThamDinhNhaThau.GetOrderedSet()
-            .Include(e => e.NhaThaus)
             .Include(e => e.BuocXuLys)
             .Where(e => e.Id == request.Id);
 

--- a/QLDA.Application/ToTrinhThamDinhNhaThau/ToTrinhThamDinhNhaThauMappings.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/ToTrinhThamDinhNhaThauMappings.cs
@@ -65,44 +65,17 @@ public static class ToTrinhThamDinhNhaThauMappings
             File = files,
         };
 
-    public static void SyncNhaThauIds(this ToTrinhThamDinhNhaThau entity, List<KetQuaThamDinhNhaThau>? NhaThaus) {
-        if (NhaThaus is null) {
-            entity.NhaThaus = [];
-            return;
-        }
-        entity.NhaThaus ??= [];
-        entity.NhaThaus.Clear();
-        foreach (var item in NhaThaus) {
-            entity.NhaThaus.Add(new KetQuaThamDinhNhaThau
-            {
-                Id = item.Id,
-                ToTrinhId = entity.Id,
-                NhaThauId = item.NhaThauId,
-                GoiThauId = item.GoiThauId,
-                KetQuaDanhGia = item.KetQuaDanhGia,
-            }); 
-           
-        }
-    }
-
     public static ToTrinhThamDinhNhaThauDto ToDto(this ToTrinhThamDinhNhaThau entity, List<Attachment>? files = null, List<Attachment>? filesThamDinh = null,
         List<TepDinhKemDto>? filesDoiChieu = null, List<TepDinhKemDto>? filesThuongThao = null, List<TepDinhKemDto>? filesThamDinhBuoc = null) =>
         new() {
             Id = entity.Id,
-            So = entity.So,
-            NgayTrinh = entity.NgayTrinh,
-            TrichYeu = entity.TrichYeu,
             TrangThaiId = entity.TrangThaiId,
             TrangThaiDangTaiId = entity.TrangThaiDangTaiId,
-            DaThamDinh= entity.DaThamDinh,
-            
+            NhaThauId = entity.NhaThauId,
             DanhSachTepDinhKem = files?.Select(x => x.ToDto()).ToList(),
             DanhSachTepThamDinh = filesThamDinh?.Select(x => x.ToDto()).ToList(),
             DoiChieu = entity.BuocXuLys?.FirstOrDefault(x => x.Loai == ToTrinhThamDinhBuocXuLyLoai.DoiChieu)?.ToDto(filesDoiChieu),
             ThuongThao = entity.BuocXuLys?.FirstOrDefault(x => x.Loai == ToTrinhThamDinhBuocXuLyLoai.ThuongThao)?.ToDto(filesThuongThao),
             ThamDinh = entity.BuocXuLys?.FirstOrDefault(x => x.Loai == ToTrinhThamDinhBuocXuLyLoai.ThamDinh)?.ToDto(filesThamDinhBuoc),
-            //DanhSachNhaThau = entity.DanhSachNhaThau?.Select(x => new KetQuaThamDinhNhaThau() { 
-                                
-            //}).ToList(),
         };
 }

--- a/QLDA.Domain/Entities/ToTrinhThamDinhNhaThau.cs
+++ b/QLDA.Domain/Entities/ToTrinhThamDinhNhaThau.cs
@@ -10,20 +10,15 @@ public class ToTrinhThamDinhNhaThau : Entity<Guid>, IAggregateRoot, ITienDo
     public new Guid Id { get; set; }
     public Guid DuAnId { get; set; }
     public int? BuocId { get; set; }
-    public string So { get; set; } = string.Empty;
-    public DateTimeOffset NgayTrinh { get; set; }
-    public string? TrichYeu { get; set; }
     public int? TrangThaiId { get; set; }
     public int? TrangThaiDangTaiId { get; set; }
-    public bool? DaThamDinh { get; set; }
-    public List<KetQuaThamDinhNhaThau>? NhaThaus { get; set; } = [];
 
     #region Issue #179 — Tờ trình thẩm định nhà thầu (1 gói thầu / 1 nhà thầu)
     /// <summary>
     /// Gói thầu — chỉ lưu Id, GiaTri/HinhThucLCNT luôn load lại từ <see cref="GoiThau"/>, không lưu duplicate.
     /// </summary>
     public Guid? GoiThauId { get; set; }
-    public string? TenNhaThau { get; set; }
+    public Guid? NhaThauId { get; set; }
     public DateTimeOffset? NgayKetThucDanhGia { get; set; }
     public List<ToTrinhThamDinhBuocXuLy>? BuocXuLys { get; set; } = [];
     #endregion
@@ -32,6 +27,7 @@ public class ToTrinhThamDinhNhaThau : Entity<Guid>, IAggregateRoot, ITienDo
     public DuAn? DuAn { get; set; }
     public DanhMucTrangThaiPheDuyet? TrangThai { get; set; }
     public GoiThau? GoiThau { get; set; }
+    public DanhMucNhaThau? NhaThau { get; set; }
     #endregion
 
 

--- a/QLDA.Migrator/Migrations/20260814075120_Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260814075120_Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814075120_Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields")]
+    partial class Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -8570,8 +8573,9 @@ namespace QLDA.Migrator.Migrations
                     b.Property<DateTimeOffset?>("NgayKetThucDanhGia")
                         .HasColumnType("datetimeoffset");
 
-                    b.Property<Guid?>("NhaThauId")
-                        .HasColumnType("uniqueidentifier");
+                    b.Property<string>("TenNhaThau")
+                        .HasMaxLength(500)
+                        .HasColumnType("nvarchar(500)");
 
                     b.Property<int?>("TrangThaiDangTaiId")
                         .HasColumnType("int");
@@ -8595,8 +8599,6 @@ namespace QLDA.Migrator.Migrations
                     b.HasIndex("Index");
 
                     SqlServerIndexBuilderExtensions.IsClustered(b.HasIndex("Index"), false);
-
-                    b.HasIndex("NhaThauId");
 
                     b.HasIndex("TrangThaiId");
 
@@ -10361,11 +10363,6 @@ namespace QLDA.Migrator.Migrations
                         .HasForeignKey("GoiThauId")
                         .OnDelete(DeleteBehavior.Restrict);
 
-                    b.HasOne("QLDA.Domain.Entities.DanhMuc.DanhMucNhaThau", "NhaThau")
-                        .WithMany()
-                        .HasForeignKey("NhaThauId")
-                        .OnDelete(DeleteBehavior.Restrict);
-
                     b.HasOne("QLDA.Domain.Entities.DanhMuc.DanhMucTrangThaiPheDuyet", "TrangThai")
                         .WithMany()
                         .HasForeignKey("TrangThaiId")
@@ -10374,8 +10371,6 @@ namespace QLDA.Migrator.Migrations
                     b.Navigation("DuAn");
 
                     b.Navigation("GoiThau");
-
-                    b.Navigation("NhaThau");
 
                     b.Navigation("TrangThai");
                 });

--- a/QLDA.Migrator/Migrations/20260814075120_Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields.cs
+++ b/QLDA.Migrator/Migrations/20260814075120_Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DaThamDinh",
+                table: "ToTrinhThamDinhNhaThau");
+
+            migrationBuilder.DropColumn(
+                name: "NgayTrinh",
+                table: "ToTrinhThamDinhNhaThau");
+
+            migrationBuilder.DropColumn(
+                name: "So",
+                table: "ToTrinhThamDinhNhaThau");
+
+            migrationBuilder.DropColumn(
+                name: "TrichYeu",
+                table: "ToTrinhThamDinhNhaThau");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "DaThamDinh",
+                table: "ToTrinhThamDinhNhaThau",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "NgayTrinh",
+                table: "ToTrinhThamDinhNhaThau",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.AddColumn<string>(
+                name: "So",
+                table: "ToTrinhThamDinhNhaThau",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "TrichYeu",
+                table: "ToTrinhThamDinhNhaThau",
+                type: "nvarchar(4000)",
+                maxLength: 4000,
+                nullable: true);
+        }
+    }
+}

--- a/QLDA.Migrator/Migrations/20260814075953_Issue179_ReplaceTenNhaThauWithNhaThauId.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260814075953_Issue179_ReplaceTenNhaThauWithNhaThauId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814075953_Issue179_ReplaceTenNhaThauWithNhaThauId")]
+    partial class Issue179_ReplaceTenNhaThauWithNhaThauId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260814075953_Issue179_ReplaceTenNhaThauWithNhaThauId.cs
+++ b/QLDA.Migrator/Migrations/20260814075953_Issue179_ReplaceTenNhaThauWithNhaThauId.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class Issue179_ReplaceTenNhaThauWithNhaThauId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TenNhaThau",
+                table: "ToTrinhThamDinhNhaThau");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "NhaThauId",
+                table: "ToTrinhThamDinhNhaThau",
+                type: "uniqueidentifier",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ToTrinhThamDinhNhaThau_NhaThauId",
+                table: "ToTrinhThamDinhNhaThau",
+                column: "NhaThauId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ToTrinhThamDinhNhaThau_DmNhaThau_NhaThauId",
+                table: "ToTrinhThamDinhNhaThau",
+                column: "NhaThauId",
+                principalTable: "DmNhaThau",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ToTrinhThamDinhNhaThau_DmNhaThau_NhaThauId",
+                table: "ToTrinhThamDinhNhaThau");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ToTrinhThamDinhNhaThau_NhaThauId",
+                table: "ToTrinhThamDinhNhaThau");
+
+            migrationBuilder.DropColumn(
+                name: "NhaThauId",
+                table: "ToTrinhThamDinhNhaThau");
+
+            migrationBuilder.AddColumn<string>(
+                name: "TenNhaThau",
+                table: "ToTrinhThamDinhNhaThau",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+    }
+}

--- a/QLDA.Persistence/Configurations/KetQuaThamDinhNhaThauConfiguration.cs
+++ b/QLDA.Persistence/Configurations/KetQuaThamDinhNhaThauConfiguration.cs
@@ -26,7 +26,7 @@ public class KetQuaThamDinhNhaThauConfiguration : AggregateRootConfiguration<Ket
 
         builder.Property(e => e.KetQuaDanhGia).HasColumnType("nvarchar(max)");
         builder.HasOne(e => e.ToTrinhThamDinhNhaThau)
-            .WithMany(e => e.NhaThaus)
+            .WithMany()
             .HasForeignKey(e => e.ToTrinhId)
             .OnDelete(DeleteBehavior.Cascade);
      

--- a/QLDA.Persistence/Configurations/ToTrinhThamDinhNhaThauConfiguration.cs
+++ b/QLDA.Persistence/Configurations/ToTrinhThamDinhNhaThauConfiguration.cs
@@ -16,19 +16,7 @@ public class ToTrinhThamDinhNhaThauConfiguration : AggregateRootConfiguration<To
             .HasConversion(
                 toDb => toDb == 0 ? null : toDb,
                 fromDb => fromDb 
-            );
-        builder.Property(x => x.So).HasMaxLength(200);
-
-        builder.Property(e => e.NgayTrinh)
-            .HasConversion(
-                toDb => toDb.ToUniversalTime(),
-                fromDb => fromDb
-            );
-    
-        builder.Property(x => x.TrichYeu)
-            .HasMaxLength(4000);
-      
-
+            );  
         builder.HasOne(e => e.TrangThai)
             .WithMany()
             .HasForeignKey(e => e.TrangThaiId)
@@ -36,11 +24,15 @@ public class ToTrinhThamDinhNhaThauConfiguration : AggregateRootConfiguration<To
             .IsRequired(false);
 
         // Issue #179 — Tờ trình thẩm định nhà thầu (1 gói thầu / 1 nhà thầu)
-        builder.Property(x => x.TenNhaThau).HasMaxLength(500);
-
         builder.HasOne(e => e.GoiThau)
             .WithMany()
             .HasForeignKey(e => e.GoiThauId)
+            .OnDelete(DeleteBehavior.Restrict)
+            .IsRequired(false);
+
+        builder.HasOne(e => e.NhaThau)
+            .WithMany()
+            .HasForeignKey(e => e.NhaThauId)
             .OnDelete(DeleteBehavior.Restrict)
             .IsRequired(false);
     }

--- a/QLDA.WebApi/Controllers/ToTrinhThamDinhNhaThauController.cs
+++ b/QLDA.WebApi/Controllers/ToTrinhThamDinhNhaThauController.cs
@@ -8,7 +8,6 @@ using QLDA.Application.ToTrinhThamDinhNhaThaus;
 using QLDA.Application.ToTrinhThamDinhNhaThaus.Commands;
 using QLDA.Application.ToTrinhThamDinhNhaThaus.DTOs;
 using QLDA.Application.ToTrinhThamDinhNhaThaus.Queries;
-using QLDA.WebApi.Models.KetQuaThamDinhNhaThaus;
 using QLDA.WebApi.Models.TepDinhKems;
 using QLDA.WebApi.Models.ToTrinhThamDinhNhaThaus;
 using System.Net.Mime;
@@ -54,41 +53,13 @@ public class ToTrinhThamDinhNhaThauController(IServiceProvider serviceProvider) 
             BaseGroupTypes: [nameof(EGroupType.ToTrinhThamDinhNhaThau_ThamDinh)]
         ))).ToAttachmentEntities().Select(x => x.ToModel()).ToList();
 
-        var nhaThauModel = entity.NhaThaus!.Select(o => o.ToModel()).ToList();
-        /*foreach (var item in nhaThauModel)
-        {
-            var dsTep = await Mediator.Send(new GetDanhSachTepDinhKemQuery()
-            {
-                GroupId = [item.Id.ToString()],
-                EGroupTypes = [EGroupType.KetQuaThamDinhNhaThau]
-            });
-            item.DanhSachTepDinhKem = dsTep.Select(o => o.ToModel()).ToList(); // i need ways
-        }*/
-        var ids = nhaThauModel.Select(x => x.Id.ToString() ?? "").ToList();
-
-            var allFiles = (await Mediator.Send(new GetAttachmentsQuery(
-                GroupIds: ids,
-                BaseGroupTypes: [nameof(EGroupType.KetQuaThamDinhNhaThau)]
-            ))).ToAttachmentEntities();
-        var lookup = allFiles.GroupBy(x => x.GroupId)
-                    .ToDictionary(g => g.Key, g => g.ToList());
-        foreach (var item in nhaThauModel)
-        {
-            if (lookup.TryGetValue(item.Id.ToString() ?? "", out var files))
-            {
-                item.DanhSachTepDinhKem = files
-                    .Select(x => x.ToModel())
-                    .ToList();
-            }
-        }
-
-        return ResultApi.Ok(entity.ToModel(nhaThauModel: nhaThauModel,
-    danhSachTepDinhKem: danhSachTepDinhKem.ToList(),
-    danhSachTepThamDinh: danhSachTepThamDinh.ToList(),
-    filesDoiChieu: filesDoiChieu,
-    filesThuongThao: filesThuongThao,
-    filesThamDinh: filesThamDinhBuoc
-    ));
+        return ResultApi.Ok(entity.ToModel(
+            danhSachTepDinhKem: danhSachTepDinhKem.ToList(),
+            danhSachTepThamDinh: danhSachTepThamDinh.ToList(),
+            filesDoiChieu: filesDoiChieu,
+            filesThuongThao: filesThuongThao,
+            filesThamDinh: filesThamDinhBuoc
+        ));
     }
 
     [ProducesResponseType<ResultApi<IHasKey<Guid>>>(StatusCodes.Status200OK)]
@@ -241,20 +212,6 @@ public class ToTrinhThamDinhNhaThauController(IServiceProvider serviceProvider) 
             Entities = danhSachFileThamDinh,
             AutoDeleteMissing = true
         });
-        var danhSachFileKetQua = new List<Attachment>();
-        foreach (var nhaThaus in model.DanhSachNhaThaus!)
-        {
-            var id = nhaThaus.GetId();
-            danhSachFileKetQua = nhaThaus.GetDanhSachTep(id).ToList();
-
-            await Mediator.Send(new AttachmentBulkInsertOrUpdateCommand
-            {
-                GroupId = id.ToString(),
-                GroupTypes = [nameof(EGroupType.KetQuaThamDinhNhaThau)],
-                Entities = danhSachFileKetQua,
-                AutoDeleteMissing = true
-            });
-        }
 
         // File của 3 bước xử lý (Đối chiếu/Thương thảo/Thẩm định) — Issue #179.
         List<TepDinhKemDto>? filesDoiChieu = null;

--- a/QLDA.WebApi/Models/ToTrinhThamDinhNhaThau/ToTrinhThamDinhNhaThauMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/ToTrinhThamDinhNhaThau/ToTrinhThamDinhNhaThauMappingConfiguration.cs
@@ -1,25 +1,19 @@
 using QLDA.WebApi.Models.TepDinhKems;
 using BuildingBlocks.Domain.Entities;
-using QLDA.WebApi.Models.KetQuaThamDinhNhaThaus;
-using QLDA.Application.ToTrinhThamDinhNhaThaus.DTOs;
 using QLDA.Domain.Constants;
 namespace QLDA.WebApi.Models.ToTrinhThamDinhNhaThaus;
 
 public static class ToTrinhThamDinhNhaThauMappingConfiguration
 {
-    public static ToTrinhThamDinhNhaThauModel ToModel(this ToTrinhThamDinhNhaThau entity,List<KetQuaThamDinhNhaThauModel>? nhaThauModel = null, List<KetQuaThamDinhNhaThauDto>? nhaThaus = null, List<Attachment>? danhSachTepDinhKem = null, List<Attachment> ? danhSachTepThamDinh = null,
+    public static ToTrinhThamDinhNhaThauModel ToModel(this ToTrinhThamDinhNhaThau entity, List<Attachment>? danhSachTepDinhKem = null, List<Attachment>? danhSachTepThamDinh = null,
         List<TepDinhKemModel>? filesDoiChieu = null, List<TepDinhKemModel>? filesThuongThao = null, List<TepDinhKemModel>? filesThamDinh = null) =>
         new()
         {
             Id = entity.Id,
             BuocId = entity.BuocId,
             DuAnId = entity.DuAnId,
-            TrichYeu = entity.TrichYeu,
-            So = entity.So,
-            NgayTrinh = entity.NgayTrinh,
+            NhaThauId = entity.NhaThauId,
             TrangThaiDangTaiId = entity.TrangThaiDangTaiId,
-            DaThamDinh = entity.DaThamDinh,
-            DanhSachNhaThaus = nhaThauModel ?? new List<KetQuaThamDinhNhaThauModel>(),
             DanhSachTepDinhKem = danhSachTepDinhKem?.Select(o => o.ToModel()).ToList(),
             DanhSachTepThamDinh = danhSachTepThamDinh?.Select(o => o.ToModel()).ToList(),
             DoiChieu = ToBuocXuLyModel(entity.BuocXuLys, ToTrinhThamDinhBuocXuLyLoai.DoiChieu, filesDoiChieu),
@@ -39,12 +33,8 @@ public static class ToTrinhThamDinhNhaThauMappingConfiguration
             Id = model.GetId(),
             BuocId = model.BuocId,
             DuAnId = model.DuAnId,
-            TrichYeu = model.TrichYeu,
-            So = model.So,
-            NgayTrinh = model.NgayTrinh,
+            NhaThauId = model.NhaThauId,
             TrangThaiDangTaiId = model.TrangThaiDangTaiId,
-            NhaThaus = model.DanhSachNhaThaus?.Select(x => x.ToEntity()).ToList() ?? [],
-            DaThamDinh = model.DaThamDinh,
             BuocXuLys = BuildBuocXuLys(model),
         };
 

--- a/QLDA.WebApi/Models/ToTrinhThamDinhNhaThau/ToTrinhThamDinhNhaThauModel.cs
+++ b/QLDA.WebApi/Models/ToTrinhThamDinhNhaThau/ToTrinhThamDinhNhaThauModel.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using QLDA.Domain.Interfaces;
 using QLDA.WebApi.Models.TepDinhKems;
-using QLDA.WebApi.Models.KetQuaThamDinhNhaThaus;
 using SequentialGuid;
 
 namespace QLDA.WebApi.Models.ToTrinhThamDinhNhaThaus;
@@ -25,12 +24,8 @@ public class ToTrinhThamDinhNhaThauModel : IHasKey<Guid?>, IMustHaveId<Guid>, IM
  
     public int? BuocId { get; set; }
     public Guid DuAnId { get; set; }
-    public string So { get; set; } = string.Empty;
-    public DateTimeOffset NgayTrinh     { get; set; } 
-    public string? TrichYeu { get; set; } = string.Empty;
+    public Guid? NhaThauId { get; set; }
     public int? TrangThaiDangTaiId { get; set; }
-    public bool? DaThamDinh { get; set; }
-    public List<KetQuaThamDinhNhaThauModel>? DanhSachNhaThaus { get; set; }
     public List<TepDinhKemModel>? DanhSachTepDinhKem { get; set; }
     public List<TepDinhKemModel>? DanhSachTepThamDinh { get; set; }
 

--- a/docs/issues/179/index.md
+++ b/docs/issues/179/index.md
@@ -15,7 +15,7 @@ Tờ trình gồm 7 mục trên UI:
 | # | Mục UI | Field |
 |---|--------|-------|
 | 1 | Thông tin Gói thầu | `GoiThauId` (chỉ lưu Id, `GiaTri`/`HinhThucLCNT` load lại từ `GoiThau`) |
-| 2 | Thông tin Nhà thầu | `TenNhaThau`, `FileEHSDT`, `NgayKetThucDanhGia`, `FileDanhGia` |
+| 2 | Thông tin Nhà thầu | `NhaThauId` (FK `DmNhaThau`, không lưu tên), `FileEHSDT`, `NgayKetThucDanhGia`, `FileDanhGia` |
 | 3 | Thông tin Đối chiếu | `So`, `Ngay`, `File`, `NoiDung` (nullable) |
 | 4 | Thông tin Thương thảo | `So`, `Ngay`, `NoiDung`, `File` |
 | 5 | Thông tin Thẩm định | `Ngay`, `So` (ẩn trên UI), `File`, `NoiDung` |
@@ -26,7 +26,7 @@ Ngoài ra:
 
 - `DonViTrungThau`, `GiaTriTrungThau`, `SoNgayTrienKhai`, `SoNgayThucHienHopDong` chỉ **load** từ `KetQuaTrungThau` theo `GoiThauId`, không lưu duplicate.
 - `TrangThaiDangTai` là trạng thái đăng tải riêng của `ToTrinhThamDinhNhaThau`.
-- Quyết định phê duyệt (mục 7) khi tạo mới phải ở trạng thái **CHỜ DUYỆT**, chỉ khi duyệt xong (`TrangThai.Ma = "ĐD"`) mới xuất hiện trong `GET api/tong-hop-van-ban-quyet-dinh/danh-sach-day-du`.
+- Quyết định phê duyệt (mục 7) khi tạo mới đồng bộ trạng thái **Dự thảo** (`DT`) với tờ trình; chỉ khi duyệt xong (`Ma = "ĐD"`) mới xuất hiện trong `GET api/tong-hop-van-ban-quyet-dinh/danh-sach-day-du`.
 
 ## 2. Nguyên tắc bắt buộc
 
@@ -44,6 +44,19 @@ Ngoài ra:
 
 ## 4. Trạng thái hiện tại
 
-**Đã implement theo hướng (A)** ở mục "Xung đột" của `report.md` — viết đè logic `POST them-moi` theo spec mới, giữ nguyên route. Đã fix lỗi build cũ, thêm domain/EF, migration (chưa apply DB), Application (DTO + Command), sửa Controller + API tổng hợp. `dotnet build SER.sln` — 0 lỗi. Chi tiết xem `journal.md` mục "2026-08-12 (tiếp — implement)".
+**Đã implement theo hướng (A)** ở mục "Xung đột" của `report.md` — viết đè logic `POST them-moi` theo spec mới, giữ nguyên route. `Update` / `Get chi tiết` / `danh-sach-tien-do` đã map `DoiChieu`/`ThuongThao`/`ThamDinh` và `NhaThauId`. `dotnet build SER.sln` — 0 lỗi.
 
-Còn thiếu: cập nhật `Update`/`Get chi tiết`/`danh-sach-tien-do` để hiển thị đầy đủ dữ liệu mới, validator riêng, và test thủ công theo `test-workflow.md` (chưa có môi trường DB để test).
+Entity `ToTrinhThamDinhNhaThau` (sau 2026-08-14):
+
+- **Đã xóa** (cột/prop cũ không dùng): `So`, `NgayTrinh`, `TrichYeu`, `DaThamDinh`, collection `NhaThaus`.
+- **Đã đổi** `TenNhaThau` (string) → `NhaThauId` (`Guid?`, FK `DmNhaThau`) + navigation `DanhMucNhaThau? NhaThau`. Tên nhà thầu lấy từ danh mục, không lưu duplicate.
+- **Giữ**: `DuAnId`, `BuocId`, `TrangThaiId`, `TrangThaiDangTaiId`, `GoiThauId`, `NgayKetThucDanhGia`, `BuocXuLys`.
+
+`So` / `Ngay` / `TrichYeu` trên bước xử lý (`ToTrinhThamDinhBuocXuLy`), tờ trình kết quả (`ToTrinhQuyetDinh`) và quyết định (`VanBanQuyetDinh`) **không** bị xóa.
+
+Migration mới (EF generate, chưa apply trừ khi đã `ef.bat QLDA update`):
+
+- `20260814075120_Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields`
+- `20260814075953_Issue179_ReplaceTenNhaThauWithNhaThauId`
+
+Chi tiết theo ngày: `journal.md`. Test: `test-workflow.md`. Còn thiếu validator FluentValidation riêng (ngoài scope).

--- a/docs/issues/179/journal.md
+++ b/docs/issues/179/journal.md
@@ -73,3 +73,17 @@ Người yêu cầu xác nhận implement theo `report-dieu-chinh.md` (dùng ph�
 11. `dotnet build SER.sln` — 0 lỗi. `dotnet ef migrations list` xác nhận migration mới ở trạng thái `(Pending)`.
 
 **Không tạo thêm** API Trình/Duyệt/Trả lại riêng — xác nhận `ToTrinhThamDinhNhaThau` đã dispatch đầy đủ qua `QuanLyPheDuyet` từ trước, không cần đụng vào 3 file dispatch.
+
+## 2026-08-14 — Dọn schema tờ trình (5 prop cũ + `TenNhaThau` → `NhaThauId`)
+
+Requirement ban đầu nhầm `TenNhaThau` (lưu tên). Đổi sang FK nhà thầu; đồng thời xóa 5 property/cột cũ trên `ToTrinhThamDinhNhaThau` không còn dùng sau spec 1 gói / 1 nhà thầu.
+
+1. **Xóa 5 prop** trên entity `ToTrinhThamDinhNhaThau`: `So`, `NgayTrinh`, `TrichYeu`, `DaThamDinh`, `NhaThaus` (`List<KetQuaThamDinhNhaThau>`). Bảng `KetQuaThamDinhNhaThau` **giữ** (FK `ToTrinhId` → `WithMany()`). `So`/`Ngay`/`TrichYeu` trên `ToTrinhThamDinhBuocXuLy` / `ToTrinhQuyetDinh` / `VanBanQuyetDinh` không đụng.
+2. **`TenNhaThau` → `NhaThauId`**: `Guid?` (không phải `int` — `DanhMucNhaThau : DanhMuc<Guid>`, PK `DmNhaThau.Id` là `uniqueidentifier`) + navigation `DanhMucNhaThau? NhaThau`. EF: FK Restrict, nullable, index `IX_ToTrinhThamDinhNhaThau_NhaThauId`.
+3. **Application / WebApi**: `ThongTinNhaThauDto.NhaThauId`; ThemMoi validate nhà thầu tồn tại; Update/Get/List map `nhaThauId`. Contract `them-moi`: `thongTinNhaThau.nhaThauId` (Guid). Get/Update/List: top-level `nhaThauId`. Không trả `tenNhaThau`.
+4. Migration (EF generate, không sửa tay / không sửa snapshot thủ công):
+   - `20260814075120_Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields` — drop `DaThamDinh`, `NgayTrinh`, `So`, `TrichYeu`.
+   - `20260814075953_Issue179_ReplaceTenNhaThauWithNhaThauId` — drop `TenNhaThau`, add `NhaThauId` + FK `DmNhaThau`.
+5. `dotnet build SER.sln` — 0 lỗi. **Chưa** `database update` trừ khi người dùng chạy tay.
+
+Dead code còn sót (không map cột đã xóa, ngoài scope tối thiểu): `ToTrinhThamDinhNhaThauSearchDto.So`/`TrichYeu`, `ToTrinhThamDinhNhaThauDanhSachQuery.So`/`TrichYeu` (list không filter theo 2 field này nữa), class `KetQuaThamDinhNhaThauDto` không còn caller.

--- a/docs/issues/179/report-dieu-chinh.md
+++ b/docs/issues/179/report-dieu-chinh.md
@@ -1,6 +1,7 @@
 # Báo cáo khảo sát — Điều chỉnh nghiệp vụ Tờ trình thẩm định nhà thầu (tiếp theo Issue #179)
 
-> Trạng thái: **ĐÃ IMPLEMENT** (xem `journal.md` mục "2026-08-13 (tiếp — implement điều chỉnh)" để biết chi tiết code đã sửa + migration mới `20260813032522_Issue179_LoaiToString`, chưa apply DB). Nội dung dưới đây giữ nguyên làm hồ sơ khảo sát/thiết kế trước khi code.
+> Trạng thái: **ĐÃ IMPLEMENT** (xem `journal.md`).  
+> **Cập nhật 2026-08-14:** entity không còn `So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh`/`NhaThaus`/`TenNhaThau`; dùng `NhaThauId` (`Guid?`). Các câu Q11–Q15 bên dưới mô tả source **tại thời điểm khảo sát 2026-08-13** — Update/Get/List sau đó đã được sửa (BuocXuLys + `NhaThauId`).
 
 ---
 
@@ -83,15 +84,15 @@ Chỉ có `ToTrinhThamDinhNhaThauThemMoiCommand` (API `them-moi` mới) lưu —
 
 **Q13. Update đang sync `BuocXuLys` như thế nào?**
 
-**Chưa xử lý gì** — `ToTrinhThamDinhNhaThauUpdateCommand.cs` hiện tại chỉ update `So/NgayTrinh/TrichYeu/TrangThaiDangTaiId/DaThamDinh` + gọi `SyncNhaThauIds` (cho `NhaThaus`, tính năng cũ khác) — **hoàn toàn không đụng đến `BuocXuLys`**. Đây là lỗ hổng cần bổ sung trong task này.
+**Chưa xử lý gì** *(tại thời điểm khảo sát 2026-08-13)* — `ToTrinhThamDinhNhaThauUpdateCommand.cs` lúc đó chỉ update `So/NgayTrinh/TrichYeu/TrangThaiDangTaiId/DaThamDinh` + `SyncNhaThauIds`. **Đã bổ sung** `Include(BuocXuLys)` + `SyncBuocXuLys` (2026-08-13). **2026-08-14:** Update không còn gán `So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh`; gán `NhaThauId`; `SyncNhaThauIds` đã xóa.
 
 **Q14. List đang map `BuocXuLys` như thế nào?**
 
-**Không map** — `ToTrinhThamDinhNhaThauDanhSachQuery` (đã đọc lại toàn bộ) chỉ select `Id/DuAnId/BuocId/So/NgayTrinh/TrichYeu/TrangThaiDangTaiId/DaThamDinh/TrangThaiId/MaTrangThai/TenTrangThai/DanhSachTepDinhKem` — không có `GoiThauId/TenNhaThau/BuocXuLys` nào cả.
+**Không map 3 bước** — `ToTrinhThamDinhNhaThauDanhSachQuery` không trả `DoiChieu`/`ThuongThao`/`ThamDinh` (đã xác nhận không bắt buộc). **2026-08-14:** list select `NhaThauId` (không còn `So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh`/`TenNhaThau`).
 
 **Q15. GetById đang map `BuocXuLys` như thế nào?**
 
-`ToTrinhThamDinhNhaThauGetQuery.cs` hiện chỉ `.Include(e => e.NhaThaus)` (list cũ) — **không `Include(e => e.BuocXuLys)`**, và `ToTrinhThamDinhNhaThauMappingConfiguration.ToModel()` cũng không có field `ThuongThao/DoiChieu/ThamDinh`. Đây cũng là lỗ hổng cần bổ sung.
+`ToTrinhThamDinhNhaThauGetQuery` **đã** `.Include(e => e.BuocXuLys)` (2026-08-13). `ToModel()` trả `DoiChieu`/`ThuongThao`/`ThamDinh` + `NhaThauId`. Không còn `.Include(e => e.NhaThaus)`.
 
 **Kết luận D:** hiện tại `BuocXuLys` **chỉ mới được ghi ở bước Insert (`them-moi`)**, hoàn toàn chưa được đọc lại ở Update/List/GetById. Việc chuyển từ `List<>` sang 3 property riêng (`ThuongThao/DoiChieu/ThamDinh`) là làm **lần đầu** cho Update/List/GetById (không phải sửa lại code cũ dùng List), và **sửa lại phần đã có** ở `them-moi`.
 
@@ -178,7 +179,7 @@ Thứ tự thao tác trong migration (giống pattern đã dùng ở migration #
 ### Application
 - `ToTrinhThamDinhNhaThauThemMoiCommand.cs` — sửa gán `Loai` (enum → constant string), sửa set `VanBanQuyetDinh.TrangThaiDuyetId` (bỏ `ToTrinhThamDinhNhaThauQuyetDinh.ChoDuyet`, dùng `DeXuatMacDinh.DuThao` — đồng bộ với `TrangThaiId` của Tờ trình vừa tạo).
 - `ToTrinhThamDinhNhaThauUpdateCommand.cs` — bổ sung sync 3 field `ThuongThao/DoiChieu/ThamDinh` (theo pattern sync child entity hiện có trong project — cần khảo sát thêm pattern `SyncNhaThauIds`/tương tự trước khi implement).
-- `ToTrinhThamDinhNhaThauDanhSachQuery.cs` — cân nhắc bổ sung `GoiThauId/TenNhaThau` (đang thiếu) — **chỉ nếu task yêu cầu**, việc thêm `ThuongThao/DoiChieu/ThamDinh` vào danh sách cần xác nhận thêm (mục 11 task: "nếu danh sách không cần full dữ liệu thì kiểm tra contract trước" — danh sách hiện KHÔNG trả `BuocXuLys` nên về nguyên tắc **không bắt buộc phải thêm**, chỉ thêm nếu anh xác nhận cần).
+- `ToTrinhThamDinhNhaThauDanhSachQuery.cs` — danh sách không trả 3 bước; **2026-08-14** trả `NhaThauId` (không `TenNhaThau`).
 - `ToTrinhThamDinhNhaThauGetQuery.cs` — thêm `.Include(e => e.BuocXuLys)`.
 - `ToTrinhThamDinhNhaThauMappings.cs` / `ToTrinhThamDinhNhaThauDto.cs` — thêm 3 property `ThuongThao/DoiChieu/ThamDinh` (kiểu DTO tương ứng), map từ `entity.BuocXuLys` sang 3 property qua `FirstOrDefault(x => x.Loai == ...)`.
 - Xóa `ToTrinhThamDinhNhaThauDuyetQuyetDinhCommand.cs`.
@@ -211,7 +212,7 @@ Thứ tự thao tác trong migration (giống pattern đã dùng ở migration #
 
    → Đề xuất chọn **(A)** vì đúng pattern có sẵn của hệ thống (`HoSoMoiThauDienTu`), đơn giản, không cần thêm cột. Xin xác nhận trước khi implement.
 
-2. **Danh sách (`danh-sach-tien-do`) có cần trả `ThuongThao/DoiChieu/ThamDinh` không?** Hiện tại danh sách hoàn toàn không trả các field này (và cũng chưa trả `GoiThauId/TenNhaThau`). Theo đúng câu chữ mục 11 của task ("nếu danh sách hiện tại không cần full dữ liệu... thì kiểm tra contract trước") — em hiểu là **không bắt buộc thêm vào danh sách**, chỉ bắt buộc ở **GetById/Chi tiết**. Xin xác nhận.
+2. **Danh sách (`danh-sach-tien-do`) có cần trả `ThuongThao/DoiChieu/ThamDinh` không?** Đã chốt **không**. List trả `NhaThauId` (2026-08-14), không trả `TenNhaThau`.
 
 3. **`ToTrinhQuyetDinhLoai`/`ToTrinhThamDinhBuocXuLyLoai` đặt ở đâu** — đề xuất `QLDA.Domain/Constants/` (cùng nơi với `TrangThaiPheDuyetCodes`, `PheDuyetEntityNames`) — xin xác nhận tên file/namespace nếu muốn khác.
 

--- a/docs/issues/179/report.md
+++ b/docs/issues/179/report.md
@@ -1,6 +1,7 @@
 # Báo cáo khảo sát — Issue 179: API `to-trinh-tham-dinh-nha-thau/them-moi`
 
-> Trạng thái: **KHẢO SÁT XONG — CHƯA CODE**. Tài liệu này trả lời đầy đủ 28 câu hỏi bắt buộc ở mục 36 của yêu cầu task, kèm phát hiện quan trọng cần chốt hướng trước khi implement.
+> Trạng thái khảo sát gốc: **KHẢO SÁT XONG** (2026-08-12). Code đã implement theo hướng (A).  
+> **Cập nhật schema 2026-08-14:** xóa `So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh`/`NhaThaus` trên `ToTrinhThamDinhNhaThau`; `TenNhaThau` → `NhaThauId` (`Guid?` FK `DmNhaThau`). Nội dung Q1–Q28 bên dưới giữ làm hồ sơ khảo sát lúc đó; chỗ mô tả entity/cột hiện tại xem mục **0.3**.
 
 ---
 
@@ -24,7 +25,28 @@
 - API này **không có**: `GoiThauId` cấp cha đơn lẻ, `ThongTinNhaThau` (1 nhà thầu + file E-HSDT/đánh giá), `ThongTinDoiChieu`/`ThongTinThuongThao`/`ThongTinThamDinh`, `ToTrinhKetQua` (dùng `ToTrinhQuyetDinh`), `QuyetDinhPheDuyet` (dùng `VanBanQuyetDinh`).
 - Đây rõ ràng là **một tính năng "Tờ trình thẩm định nhà thầu" khác, phiên bản cũ hơn**, được thiết kế trước khi có UI mới (`e-hsdt1.lovable.app`). Task hiện tại mô tả một **business flow mới, đơn giản hơn** (1 gói thầu / 1 nhà thầu / đối chiếu / thương thảo / thẩm định / tờ trình / quyết định).
 
-**→ Cần quyết định hướng trước khi code** (xem mục "Xung đột cần xác nhận" cuối file). Bản thân việc "implement đúng yêu cầu" và "reuse tối đa, thay đổi tối thiểu" đang mâu thuẫn nhau vì API endpoint đã có chủ nhưng hành vi khác hẳn.
+**→ Đã chốt hướng (A)** — viết đè `them-moi` theo spec mới. Chi tiết implement: `journal.md`.
+
+### 0.3. Schema `ToTrinhThamDinhNhaThau` sau 2026-08-14 (nguồn sự thật hiện tại)
+
+```csharp
+public class ToTrinhThamDinhNhaThau : Entity<Guid>, IAggregateRoot, ITienDo
+{
+    public Guid DuAnId { get; set; }
+    public int? BuocId { get; set; }
+    public int? TrangThaiId { get; set; }
+    public int? TrangThaiDangTaiId { get; set; }
+    public Guid? GoiThauId { get; set; }
+    public Guid? NhaThauId { get; set; }          // FK DmNhaThau — không lưu TenNhaThau
+    public DateTimeOffset? NgayKetThucDanhGia { get; set; }
+    public List<ToTrinhThamDinhBuocXuLy>? BuocXuLys { get; set; } = [];
+    public DanhMucNhaThau? NhaThau { get; set; }
+    public GoiThau? GoiThau { get; set; }
+}
+```
+
+Đã drop: `So`, `NgayTrinh`, `TrichYeu`, `DaThamDinh`, `NhaThaus`, `TenNhaThau`.  
+`NhaThauId` là **Guid?** (không phải `int?`) vì `DanhMucNhaThau : DanhMuc<Guid>`.
 
 ---
 
@@ -52,7 +74,7 @@ public class ToTrinhThamDinhNhaThau : Entity<Guid>, IAggregateRoot, ITienDo
 **Q2. Table nào lưu thông tin chính?**
 Bảng `ToTrinhThamDinhNhaThau` (đúng tên entity, xem `ToTrinhThamDinhNhaThauConfiguration.cs`). Entity **chưa có `GoiThauId`** ở cấp cha — hiện tại `GoiThauId` chỉ nằm trong bảng con `KetQuaThamDinhNhaThau` (1-nhiều nhà thầu, mỗi nhà thầu 1 gói thầu). Theo spec mới, `GoiThauId` là 1-1 ở cấp Tờ trình (1 tờ trình ứng với đúng 1 gói thầu, 1 nhà thầu).
 
-→ **Cần thêm `GoiThauId` (Guid) vào `ToTrinhThamDinhNhaThau`** (migration mới), giữ nguyên các field workflow hiện có (`DuAnId`, `BuocId`, `So`, `NgayTrinh`, `TrichYeu`, `TrangThaiId`, `TrangThaiDangTaiId`).
+→ **Cần thêm `GoiThauId` (Guid) vào `ToTrinhThamDinhNhaThau`** (migration mới). Các field workflow `DuAnId`/`BuocId`/`TrangThaiId`/`TrangThaiDangTaiId` giữ. **Sau 2026-08-14:** `So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh`/`NhaThaus` đã xóa — không còn trên entity/DB.
 
 ---
 
@@ -61,14 +83,15 @@ Bảng `ToTrinhThamDinhNhaThau` (đúng tên entity, xem `ToTrinhThamDinhNhaThau
 **Q3. Reuse entity/table nào?**
 Không có entity nào lưu đúng "1 nhà thầu + ngày kết thúc đánh giá" theo cấp Tờ trình hiện tại — bảng gần nhất là `KetQuaThamDinhNhaThau` (`Id`, `ToTrinhId`, `NhaThauId`, `GoiThauId`, `KetQuaDanhGia`) nhưng nó được thiết kế cho **N nhà thầu / tờ trình**, không có `NgayKetThucDanhGia`.
 
-Theo spec mới (1 tờ trình = 1 nhà thầu), đề xuất **field hóa trực tiếp** trên `ToTrinhThamDinhNhaThau` thay vì bảng con riêng:
+Theo spec mới (1 tờ trình = 1 nhà thầu), **field hóa trực tiếp** trên `ToTrinhThamDinhNhaThau`. Lần implement đầu (2026-08-12) dùng `TenNhaThau` (string) — **sai requirement**. **2026-08-14 đã sửa:**
 
 ```csharp
-public string? TenNhaThau { get; set; }
+public Guid? NhaThauId { get; set; }              // FK DmNhaThau
+public DanhMucNhaThau? NhaThau { get; set; }
 public DateTimeOffset? NgayKetThucDanhGia { get; set; }
 ```
 
-(Không cần bảng con `KetQuaThamDinhNhaThau` cho spec mới — bảng này vẫn giữ nguyên cho code cũ nếu quyết định giữ cả 2 flow, xem mục xung đột).
+Không lưu tên nhà thầu trên tờ trình. API: `thongTinNhaThau.nhaThauId` (them-moi) / `nhaThauId` (Get/Update/List). Bảng `KetQuaThamDinhNhaThau` vẫn giữ (flow cũ / dữ liệu lịch sử); collection `NhaThaus` trên parent đã bỏ.
 
 File `FileEHSDT` / `FileDanhGia` → `TepDinhKem` (`Attachment`), `GroupId = ToTrinhThamDinhNhaThau.Id`, `GroupType` cần 2 giá trị `EGroupType` mới (chưa có sẵn — xem mục File).
 
@@ -287,7 +310,7 @@ Cần thêm navigation `VanBanQuyetDinh.TrangThai` (→ `DanhMucTrangThaiPheDuye
 
 1. `ToTrinhQuyetDinh`: xóa cột `HoSoMoiThauToTrinhId`, `HoSoMoiThauQuyetDinhId`; thêm cột `EntityId` (uniqueidentifier, nullable), `Loai` (int, not null).
 2. `VanBanQuyetDinh`: thêm cột `TrangThaiId` (int, nullable) + FK → `DanhMucTrangThaiPheDuyet` (`OnDelete Restrict`, `IsRequired(false)`), thêm cột `ChucVuId` (int, nullable) + FK → `DanhMucChucVu`.
-3. `ToTrinhThamDinhNhaThau`: thêm `GoiThauId` (uniqueidentifier, not null) + FK → `GoiThau`; thêm `TenNhaThau` (nvarchar), `NgayKetThucDanhGia` (datetimeoffset, nullable).
+3. `ToTrinhThamDinhNhaThau`: thêm `GoiThauId` (uniqueidentifier, nullable) + FK → `GoiThau`; thêm `NgayKetThucDanhGia`. **2026-08-14:** drop `So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh`/`TenNhaThau`; add `NhaThauId` (uniqueidentifier, nullable) + FK → `DmNhaThau`.
 4. Bảng mới `ToTrinhThamDinhBuocXuLy` (hoặc tên tương đương đã chốt) cho Đối chiếu/Thương thảo/Thẩm định: `Id (bigint identity), ToTrinhId (uniqueidentifier, FK), So (nvarchar), Ngay (datetimeoffset?), NoiDung (nvarchar(max)?), Loai (int)`.
 5. `DanhMucTrangThaiPheDuyet`: seed thêm 2 dòng `Loai="ToTrinhThamDinhNhaThau"` (`Ma="ĐTr"`, `Ma="ĐD"`) — cần xác nhận thêm `Ma="DT"/"TL"/"TC"` nếu Command insert cũng cần trạng thái dự thảo/trả lại/từ chối cho Quyết định (task chỉ mô tả 2 trạng thái Chờ duyệt/Đã duyệt cho `VanBanQuyetDinh`, nên tối thiểu chỉ cần `ĐTr` + `ĐD`).
 6. `EnumLoaiVanBanQuyetDinh`: thêm `ToTrinhThamDinhNhaThau` (chỉ là C# enum, không đổi schema, nhưng giá trị string được lưu trong cột `VanBanQuyetDinh.Loai` sẵn có).
@@ -322,7 +345,7 @@ Cần thêm navigation `VanBanQuyetDinh.TrangThai` (→ `DanhMucTrangThaiPheDuye
 - `QLDA.Application/TongHopVanBanQuyetDinhs/Queries/TongHopVanBanQuyetDinhGetListQuery.cs` — thêm filter `ĐD OR NULL`.
 - `QLDA.Domain/Enums/EnumLoaiVanBanQuyetDinh.cs` — thêm `ToTrinhThamDinhNhaThau`.
 - `QLDA.Domain/Enums/EGroupType.cs` — thêm các GroupType mới ở mục File.
-- `QLDA.Domain/Entities/ToTrinhThamDinhNhaThau.cs` — thêm `GoiThauId`, `TenNhaThau`, `NgayKetThucDanhGia`.
+- `QLDA.Domain/Entities/ToTrinhThamDinhNhaThau.cs` — thêm `GoiThauId`, `NhaThauId` (thay `TenNhaThau`), `NgayKetThucDanhGia`; xóa `So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh`/`NhaThaus`.
 - `QLDA.Persistence/Configurations/ToTrinhThamDinhNhaThauConfiguration.cs` — map FK `GoiThauId`.
 
 ### Tạo mới

--- a/docs/issues/179/test-workflow.md
+++ b/docs/issues/179/test-workflow.md
@@ -12,20 +12,27 @@ dotnet build SER.sln
 
 ## 2. Migration
 
-Migration `20260812075056_Issue179_ToTrinhThamDinhNhaThau` đã được tạo sẵn (xem `QLDA.Migrator/Migrations/`), **chưa apply vào DB**. Trước khi test cần tự chạy (đúng theo yêu cầu — không tự động migrate):
+Các migration Issue 179 (EF generate). **Chưa apply** trừ khi đã chạy tay:
+
+| Migration | Việc |
+|---|---|
+| `20260812075056_Issue179_ToTrinhThamDinhNhaThau` | EntityId/Loai, BuocXuLy, GoiThauId, TenNhaThau (sau đó bị thay) |
+| `20260813032522_Issue179_LoaiToString` | `Loai` int → string |
+| `20260814075120_Issue179_RemoveLegacyToTrinhThamDinhNhaThauFields` | Drop `So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh` trên `ToTrinhThamDinhNhaThau` |
+| `20260814075953_Issue179_ReplaceTenNhaThauWithNhaThauId` | Drop `TenNhaThau`, add `NhaThauId` FK `DmNhaThau` |
 
 ```powershell
 ef.bat QLDA update
 ```
 
-hoặc trực tiếp:
+hoặc:
 
 ```powershell
 dotnet ef database update --project QLDA.Migrator\QLDA.Migrator.csproj --startup-project QLDA.Migrator\QLDA.Migrator.csproj --context AppDbContext
 ```
 
-- Xác nhận đúng connection string dev/test trong `QLDA.WebApi/appsettings.Development.json` trước khi chạy.
-- Sau khi update, kiểm tra nhanh: bảng `ToTrinhQuyetDinh` có cột `EntityId`/`Loai`, không còn `HoSoMoiThauQuyetDinhId`; bảng `VanBanQuyetDinh` có cột `TrangThaiDuyetId`/`NguoiKyChucVuId`; bảng `ToTrinhThamDinhBuocXuLy` được tạo mới; `DmTrangThaiPheDuyet` có 2 dòng mới `Id=71` (`Ma="ĐTr"`) và `Id=72` (`Ma="ĐD"`) với `Loai="ToTrinhThamDinhNhaThau"`.
+- Xác nhận connection string dev/test trong `QLDA.WebApi/appsettings.Development.json` trước khi chạy.
+- Sau khi update: `ToTrinhThamDinhNhaThau` **không** còn cột `So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh`/`TenNhaThau`; có `NhaThauId` (uniqueidentifier, nullable) + FK `DmNhaThau`. `ToTrinhThamDinhBuocXuLy.Loai` là string (`DoiChieu`/`ThuongThao`/`ThamDinh`). Không seed `DmTrangThaiPheDuyet` Id=71/72.
 
 ## 3. Chạy API
 
@@ -43,6 +50,7 @@ Cần có sẵn (lấy qua Swagger các API GET tương ứng, hoặc query DB):
 - 1 `DuAnId` hợp lệ (`GET api/du-an/...`).
 - 1 `BuocId` hợp lệ thuộc dự án đó (bảng `DuAnBuoc`).
 - 1 `GoiThauId` hợp lệ (`GET api/goi-thau/danh-sach` hoặc query bảng `GoiThau`).
+- 1 `NhaThauId` hợp lệ (`GET` danh mục nhà thầu / bảng `DmNhaThau` — **Guid**, không phải int).
 - 1 `ChucVuId` hợp lệ (`GET api/dm-chuc-vu`).
 - Không bắt buộc phải có file thật để test nhanh — có thể để `null`/bỏ trống các mảng `File`, `FileEHSDT`, `FileDanhGia` (Command chỉ gọi `AttachmentBulkInsertOrUpdateCommand` khi `Count > 0`).
 
@@ -53,29 +61,26 @@ Cần có sẵn (lấy qua Swagger các API GET tương ứng, hoặc query DB):
   "duAnId": "00000000-0000-0000-0000-000000000000",
   "buocId": 1,
   "goiThauId": "00000000-0000-0000-0000-000000000000",
-  "so": "TT-179-001",
-  "ngayTrinh": "2026-08-12T00:00:00+07:00",
-  "trichYeu": "Tờ trình thẩm định nhà thầu test issue 179",
   "trangThaiDangTaiId": null,
   "thongTinNhaThau": {
-    "tenNhaThau": "Công ty TNHH Test",
+    "nhaThauId": "00000000-0000-0000-0000-000000000000",
     "fileEHSDT": [],
     "ngayKetThucDanhGia": "2026-08-10T00:00:00+07:00",
     "fileDanhGia": []
   },
-  "thongTinDoiChieu": {
+  "doiChieu": {
     "so": "DC-001",
     "ngay": "2026-08-05T00:00:00+07:00",
     "noiDung": null,
     "file": []
   },
-  "thongTinThuongThao": {
+  "thuongThao": {
     "so": "TT-002",
     "ngay": "2026-08-06T00:00:00+07:00",
     "noiDung": "Nội dung thương thảo",
     "file": []
   },
-  "thongTinThamDinh": {
+  "thamDinh": {
     "ngay": "2026-08-07T00:00:00+07:00",
     "so": null,
     "noiDung": "Nội dung thẩm định",
@@ -101,29 +106,30 @@ Cần có sẵn (lấy qua Swagger các API GET tương ứng, hoặc query DB):
 }
 ```
 
-Thay `duAnId`/`goiThauId`/`chucVuId` bằng dữ liệu thật lấy ở bước 4.0.
+Thay `duAnId`/`goiThauId`/`nhaThauId`/`chucVuId` bằng dữ liệu thật lấy ở bước 4.0. Payload **không** gửi `so`/`ngayTrinh`/`trichYeu`/`tenNhaThau` ở cấp tờ trình.
 
 ### 4.2. Happy path
 1. Gọi `POST /api/to-trinh-tham-dinh-nha-thau/them-moi` với payload trên.
 2. Kiểm tra response trả về `{ id, toTrinhQuyetDinhId, vanBanQuyetDinhId }`.
 3. Query DB xác nhận:
-   - `ToTrinhThamDinhNhaThau.GoiThauId` = đúng giá trị gửi lên; không có cột `GiaTri`/`HinhThucLCNT` trên bảng này.
-   - `ToTrinhThamDinhBuocXuLy` có đúng 3 dòng (`Loai=1,2,3` tương ứng Đối chiếu/Thương thảo/Thẩm định), cùng `ToTrinhId` = id vừa tạo.
-   - `ToTrinhQuyetDinh` có 1 dòng mới, `EntityId` = id Tờ trình, `Loai = 3` (`ToTrinhThamDinhNhaThau`), `So/Ngay/NguoiKy/ChucVu/TrichYeu` khớp `toTrinhKetQua`.
-   - `VanBanQuyetDinh` có 1 dòng mới, `TrangThaiDuyetId` **khác null** và trỏ tới bản ghi `Id=71` (`Ma="ĐTr"`), `Loai = "ToTrinhThamDinhNhaThau"`, `So/Ngay/NguoiKy/NgayKy/NguoiKyChucVuId/TrichYeu` khớp `quyetDinhPheDuyet`.
+   - `ToTrinhThamDinhNhaThau.GoiThauId` / `NhaThauId` / `NgayKetThucDanhGia` khớp payload; **không** có cột `TenNhaThau`/`So`/`NgayTrinh`/`TrichYeu`/`DaThamDinh`; không có `GiaTri`/`HinhThucLCNT`.
+   - `ToTrinhThamDinhBuocXuLy` có đúng 3 dòng (`Loai='DoiChieu'|'ThuongThao'|'ThamDinh'`), cùng `ToTrinhId`.
+   - `ToTrinhQuyetDinh` 1 dòng, `EntityId` = id Tờ trình, `Loai = 'ToTrinhThamDinhNhaThau'`.
+   - `VanBanQuyetDinh.Id` = id Tờ trình, `Loai = 'ToTrinhThamDinhNhaThau'`, `TrangThaiDuyetId` = trạng thái **Dự thảo** (`DeXuatMacDinh.DT`), không phải seed 71/72.
 
 ### 4.3. Validate
 1. Gọi API với `goiThauId` không tồn tại → kỳ vọng lỗi `ManagedException` "Không tìm thấy gói thầu", không tạo record rác.
-2. Gọi API để trống `thongTinDoiChieu.noiDung` → kỳ vọng lưu thành công (nullable).
-3. Gọi API không truyền `toTrinhKetQua`/`quyetDinhPheDuyet` (null) → kỳ vọng không tạo `ToTrinhQuyetDinh`/`VanBanQuyetDinh`, response trả `toTrinhQuyetDinhId`/`vanBanQuyetDinhId` = null.
+2. Gọi API với `thongTinNhaThau.nhaThauId` không tồn tại → kỳ vọng lỗi `ManagedException` "Không tìm thấy nhà thầu".
+3. Gọi API để trống `doiChieu.noiDung` → kỳ vọng lưu thành công (nullable).
+4. Gọi API không truyền `toTrinhKetQua`/`quyetDinhPheDuyet` (null) → kỳ vọng không tạo `ToTrinhQuyetDinh`/`VanBanQuyetDinh`, response trả `toTrinhQuyetDinhId`/`vanBanQuyetDinhId` = null.
 
 ## 5. Test API tổng hợp `GET api/tong-hop-van-ban-quyet-dinh/danh-sach-day-du`
 
-1. Trước khi duyệt Quyết định phê duyệt vừa tạo ở bước 4.2 → gọi API tổng hợp (`?duAnId=...`), xác nhận record **không xuất hiện** trong danh sách trả về.
-2. Gọi `PUT /api/to-trinh-tham-dinh-nha-thau/quyet-dinh/{vanBanQuyetDinhId}/duyet` → kiểm tra `VanBanQuyetDinh.TrangThaiDuyetId` được cập nhật sang `Id=72` (`Ma="ĐD"`).
-3. Gọi lại API tổng hợp → xác nhận record **xuất hiện** trong danh sách.
-4. Kiểm tra hồi quy: các `VanBanQuyetDinh` cũ có `TrangThaiDuyetId = null` (dữ liệu trước migration) **vẫn xuất hiện** trong danh sách (không bị lọc mất).
-5. Kiểm tra hồi quy: `VanBanQuyetDinh` của nghiệp vụ khác (`HoSoMoiThauDienTu`, `VanBanPhapLy`, ...) tạo mới sau migration này (không set `TrangThaiDuyetId`) — xác nhận **vẫn xuất hiện** đúng như hành vi cũ.
+1. Trước khi duyệt Tờ trình vừa tạo → gọi API tổng hợp (`?duAnId=...`), xác nhận quyết định **không xuất hiện** (trạng thái chưa `ĐD`).
+2. Duyệt qua `QuanLyPheDuyet` (không còn `PUT quyet-dinh/{id}/duyet`) — `ToTrinhThamDinhNhaThauDuyetCommand` đồng bộ `VanBanQuyetDinh.TrangThaiDuyetId` sang `ĐD`.
+3. Gọi lại API tổng hợp → record **xuất hiện**.
+4. Hồi quy: `VanBanQuyetDinh` cũ `TrangThaiDuyetId = null` **vẫn xuất hiện**.
+5. Hồi quy: nghiệp vụ khác tạo mới không set `TrangThaiDuyetId` — vẫn xuất hiện.
 
 ## 6. Test hồi quy `HoSoMoiThauDienTu` (module bị ảnh hưởng gián tiếp do đổi `ToTrinhQuyetDinh`)
 
@@ -141,16 +147,18 @@ Thay `duAnId`/`goiThauId`/`chucVuId` bằng dữ liệu thật lấy ở bước
 
 | ID | Test case | Input | Kỳ vọng | Trạng thái |
 |---|---|---|---|---|
-| **TC-01** | Happy path — tạo mới đủ 7 mục | Payload đầy đủ (mục 4.1), `duAnId=1690F8E4-...`, `goiThauId=79CF32A2-...`, `buocId=5613`, `chucVuId=1` | `200 OK`, trả `{id, toTrinhQuyetDinhId, vanBanQuyetDinhId}`; `ToTrinhThamDinhNhaThau` lưu đúng `GoiThauId/TenNhaThau/NgayKetThucDanhGia`, không có `GiaTri/HinhThucLCNT` | ✅ **Pass** (đã verify qua SQL, dòng `Id=08DEF855-...` khớp 100%) |
-| **TC-02** | Bảng `ToTrinhThamDinhBuocXuLy` tạo đủ 3 dòng | Cùng payload TC-01 | 3 dòng `ToTrinhId` = Id TC-01, `Loai=1` (Đối chiếu), `Loai=2` (Thương thảo), `Loai=3` (Thẩm định), đúng `So/Ngay/NoiDung` | ⬜ Chưa xác nhận — anh chạy SQL mục 4.2 câu 1 |
-| **TC-03** | `ToTrinhQuyetDinh` (Tờ trình kết quả) tạo đúng | Cùng payload TC-01 | 1 dòng `EntityId` = Id TC-01, `Loai=3`, `So=KQ-001`, `NguoiKy=Nguyễn Văn A`, `ChucVu=1`, `TrichYeu` khớp | ⬜ Chưa xác nhận — anh chạy SQL mục 4.2 câu 2 |
-| **TC-04** | `VanBanQuyetDinh` (Quyết định phê duyệt) tạo đúng, trạng thái Chờ duyệt | Cùng payload TC-01 | 1 dòng mới, `Loai='ToTrinhThamDinhNhaThau'`, `So=QD-001`, `NguoiKyChucVuId=1`, `TrangThaiDuyetId=71` (ĐTr) — **không phải NULL** | ⬜ Chưa xác nhận |
-| **TC-05** | API tổng hợp — Quyết định Chờ duyệt KHÔNG hiển thị | `GET danh-sach-day-du?duAnId=1690F8E4-...` (trước khi duyệt) | Record `QD-001` không có trong kết quả | ⬜ |
-| **TC-06** | Duyệt Quyết định phê duyệt | `PUT quyet-dinh/{vanBanQuyetDinhId}/duyet` | `200 OK`; `VanBanQuyetDinh.TrangThaiDuyetId` chuyển `71 → 72` (ĐD) | ⬜ |
-| **TC-07** | API tổng hợp — sau khi duyệt PHẢI hiển thị | `GET danh-sach-day-du?duAnId=...` (sau khi duyệt) | Record `QD-001` xuất hiện trong kết quả | ⬜ |
-| **TC-08** | Duyệt 2 lần liên tiếp (đã Đã duyệt lại duyệt nữa) | Gọi lại `PUT .../duyet` lần 2 với cùng Id | Lỗi `ManagedException`: "Chỉ có thể duyệt Quyết định khi đang ở trạng thái Chờ duyệt" | ⬜ |
-| **TC-09** | `goiThauId` không tồn tại | Payload với `goiThauId` random GUID | Lỗi `ManagedException`: "Không tìm thấy gói thầu"; không tạo record rác trong `ToTrinhThamDinhNhaThau` | ⬜ |
-| **TC-10** | Không gửi `toTrinhKetQua`/`quyetDinhPheDuyet` (null) | Payload bỏ 2 field này | `200 OK`; không tạo dòng `ToTrinhQuyetDinh`/`VanBanQuyetDinh`; response `toTrinhQuyetDinhId=null`, `vanBanQuyetDinhId=null` | ⬜ |
-| **TC-11** | `thongTinDoiChieu.noiDung = null` | Payload để trống `noiDung` mục Đối chiếu | `200 OK`; dòng `ToTrinhThamDinhBuocXuLy` (Loai=1) có `NoiDung=NULL` | ⬜ |
-| **TC-12** | Hồi quy — `HoSoMoiThauDienTu` tạo/sửa/duyệt vẫn hoạt động | Tạo mới + cập nhật `ToTrinh`/`QuyetDinh` + duyệt qua `api/ho-so-moi-thau-dien-tu` | `ToTrinhQuyetDinh` ghi đúng `EntityId/Loai=1,2`; `VanBanQuyetDinh` tạo ra có `TrangThaiDuyetId = NULL` (không bị set) | ⬜ |
-| **TC-13** | Hồi quy — dữ liệu `VanBanQuyetDinh` cũ (trước migration) vẫn hiển thị API tổng hợp | `GET danh-sach-day-du` không filter theo `duAnId` cụ thể | Các record cũ có `TrangThaiDuyetId=NULL` vẫn xuất hiện đầy đủ, không bị lọc mất | ⬜ |
+| **TC-01** | Happy path — tạo mới đủ 7 mục | Payload mục 4.1, `nhaThauId` = Guid `DmNhaThau` | `200 OK`, `{id, toTrinhQuyetDinhId, vanBanQuyetDinhId}`; lưu `GoiThauId`/`NhaThauId`/`NgayKetThucDanhGia`; **không** cột `TenNhaThau`/`So`/`NgayTrinh`/`TrichYeu` | ⬜ Cần re-test sau migration 2026-08-14 |
+| **TC-02** | `ToTrinhThamDinhBuocXuLy` đủ 3 dòng | Cùng payload TC-01 | 3 dòng, `Loai='DoiChieu'/'ThuongThao'/'ThamDinh'` | ⬜ |
+| **TC-03** | `ToTrinhQuyetDinh` tạo đúng | Cùng payload TC-01 | `EntityId` = Id TC-01, `Loai='ToTrinhThamDinhNhaThau'` | ⬜ |
+| **TC-04** | `VanBanQuyetDinh` tạo đúng, trạng thái Dự thảo | Cùng payload TC-01 | `Id` = Id tờ trình, `Loai='ToTrinhThamDinhNhaThau'`, `TrangThaiDuyetId` = DT (không phải 71) | ⬜ |
+| **TC-05** | API tổng hợp — chưa duyệt KHÔNG hiển thị | `GET danh-sach-day-du?duAnId=...` | Record QD không có | ⬜ |
+| **TC-06** | Duyệt qua QuanLyPheDuyet | Dispatch duyệt `ToTrinhThamDinhNhaThau` | `VanBanQuyetDinh.TrangThaiDuyetId` → ĐD | ⬜ |
+| **TC-07** | API tổng hợp — sau duyệt PHẢI hiển thị | Sau TC-06 | Record xuất hiện | ⬜ |
+| **TC-08** | Duyệt 2 lần | Gọi duyệt lần 2 | Lỗi: chỉ duyệt khi Đã trình | ⬜ |
+| **TC-09** | `goiThauId` không tồn tại | GUID random | `ManagedException` "Không tìm thấy gói thầu" | ⬜ |
+| **TC-09b** | `nhaThauId` không tồn tại | GUID random trong `thongTinNhaThau` | `ManagedException` "Không tìm thấy nhà thầu" | ⬜ |
+| **TC-10** | Không gửi `toTrinhKetQua`/`quyetDinhPheDuyet` | Bỏ 2 field | Không tạo dòng tương ứng | ⬜ |
+| **TC-11** | `doiChieu.noiDung = null` | Để trống nội dung Đối chiếu | `NoiDung=NULL` trên dòng `Loai='DoiChieu'` | ⬜ |
+| **TC-12** | Hồi quy `HoSoMoiThauDienTu` | Tạo/sửa/duyệt | `ToTrinhQuyetDinh.Loai` string `HoSoMoiThauToTrinh`/`HoSoMoiThauQuyetDinh` | ⬜ |
+| **TC-13** | Hồi quy VanBanQuyetDinh cũ | `GET danh-sach-day-du` | `TrangThaiDuyetId=NULL` vẫn hiện | ⬜ |
+| **TC-14** | Get/Update/List dùng `nhaThauId` | Chi tiết + cap-nhat + danh-sach-tien-do | JSON `nhaThauId` (Guid), không `tenNhaThau` | ⬜ |


### PR DESCRIPTION
## Summary
- Xóa cột/property cũ trên `ToTrinhThamDinhNhaThau`: `So`, `NgayTrinh`, `TrichYeu`, `DaThamDinh`, collection `NhaThaus`.
- Đổi `TenNhaThau` (string) thành `NhaThauId` (`Guid?`, FK `DmNhaThau`) + navigation `NhaThau`.
- Cập nhật DTO/mapping/command/query/API và docs Issue 179. `So`/`Ngay`/`TrichYeu` trên bước xử lý, tờ trình kết quả, quyết định không đụng.

## Test plan
- [x] `dotnet build SER.sln`
- [x] Apply migration (`ef.bat QLDA update`) trên DB dev
- [x] `POST them-moi` gửi `thongTinNhaThau.nhaThauId` (Guid), không gửi `tenNhaThau`/`so`/`ngayTrinh`/`trichYeu` cấp tờ trình
- [x] Get / Update / List trả `nhaThauId`, không `tenNhaThau`
- [x] `nhaThauId` không tồn tại → lỗi "Không tìm thấy nhà thầu"
