### PR TITLE
fix(#182): không clone DuAnBuoc khi cập nhật dự án nếu QT không đổi hoặc đã có tiến độ

### DIFF
--- a/QLDA.Tests/Integration/DuAnControllerTests.cs
+++ b/QLDA.Tests/Integration/DuAnControllerTests.cs
@@ -1,7 +1,13 @@
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using BuildingBlocks.Application.Common.DTOs;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using QLDA.Application.DuAns.DTOs;
+using QLDA.Domain.Entities;
+using QLDA.Domain.Entities.DanhMuc;
+using QLDA.Persistence;
 using QLDA.Tests.Fakers;
 using QLDA.Tests.Fixtures;
 using Xunit;
@@ -11,6 +17,11 @@ namespace QLDA.Tests.Integration;
 [Collection("WebApi")]
 public class DuAnControllerTests(WebApiFixture fixture)
 {
+    private const string QtATen = "Issue182 QT A";
+    private const string QtBTen = "Issue182 QT B";
+    private const string BuocATen = "Issue182 Buoc A1";
+    private const string BuocBTen = "Issue182 Buoc B1";
+
     private HttpClient AuthedClient => fixture.CreateAuthenticatedClient();
 
     [Fact]
@@ -62,10 +73,9 @@ public class DuAnControllerTests(WebApiFixture fixture)
         var createResult = await createResponse.Content.ReadFromJsonAsync<ResultApi>();
         createResult.Should().NotBeNull();
 
-        // Extract Guid from DataResult
         var idToDelete = createResult!.DataResult switch
         {
-            System.Text.Json.JsonElement el => el.GetProperty("id").GetGuid(),
+            JsonElement el => el.GetProperty("id").GetGuid(),
             Guid g => g,
             _ => throw new InvalidOperationException($"Unexpected DataResult type: {createResult.DataResult?.GetType()}")
         };
@@ -77,4 +87,248 @@ public class DuAnControllerTests(WebApiFixture fixture)
         result.Should().NotBeNull();
         result!.Result.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task Update_SameQuyTrinh_NoProgress_DoesNotClone()
+    {
+        var (qtAId, _, _) = await SeedQuyTrinhAsync();
+        var duAnId = await CreateDuAnAsync(qtAId);
+        var before = await SnapshotBuocsAsync(duAnId);
+        before.Should().NotBeEmpty();
+
+        await PutCapNhatAsync(duAnId, qtAId);
+
+        var after = await SnapshotBuocsAsync(duAnId);
+        after.Should().BeEquivalentTo(before);
+    }
+
+    [Fact]
+    public async Task Update_SameQuyTrinh_WithProgress_KeepsProgress()
+    {
+        var (qtAId, _, _) = await SeedQuyTrinhAsync();
+        var duAnId = await CreateDuAnAsync(qtAId);
+        var ngayThucTe = DateTimeOffset.UtcNow;
+        await SetFirstBuocProgressAsync(duAnId, ngayThucTe);
+        var before = await SnapshotBuocsAsync(duAnId);
+
+        await PutCapNhatAsync(duAnId, qtAId);
+
+        var after = await SnapshotBuocsAsync(duAnId);
+        after.Should().BeEquivalentTo(before);
+        after.Should().Contain(b => b.NgayThucTeBatDau != null);
+    }
+
+    [Fact]
+    public async Task Update_ChangeQuyTrinh_NoProgress_ClonesNewSteps()
+    {
+        var (qtAId, qtBId, buocBIds) = await SeedQuyTrinhAsync();
+        var duAnId = await CreateDuAnAsync(qtAId);
+        var before = await SnapshotBuocsAsync(duAnId);
+        before.Should().NotBeEmpty();
+        before.Select(b => b.BuocId).Intersect(buocBIds).Should().BeEmpty();
+
+        await PutCapNhatAsync(duAnId, qtBId);
+
+        var after = await SnapshotBuocsAsync(duAnId);
+        after.Select(b => b.BuocId).Should().BeEquivalentTo(buocBIds);
+    }
+
+    [Fact]
+    public async Task Update_ChangeQuyTrinh_WithProgress_DoesNotClone()
+    {
+        var (qtAId, qtBId, _) = await SeedQuyTrinhAsync();
+        var duAnId = await CreateDuAnAsync(qtAId);
+        var ngayThucTe = DateTimeOffset.UtcNow;
+        await SetFirstBuocProgressAsync(duAnId, ngayThucTe);
+        var before = await SnapshotBuocsAsync(duAnId);
+
+        await PutCapNhatAsync(duAnId, qtBId);
+
+        var after = await SnapshotBuocsAsync(duAnId);
+        after.Should().BeEquivalentTo(before);
+        after.Should().Contain(b => b.NgayThucTeBatDau != null);
+    }
+
+    [Fact]
+    public async Task Update_ChangeGhiChuOnly_DoesNotTouchDuAnBuoc()
+    {
+        var (qtAId, _, _) = await SeedQuyTrinhAsync();
+        var duAnId = await CreateDuAnAsync(qtAId);
+        var before = await SnapshotBuocsAsync(duAnId);
+        before.Should().NotBeEmpty();
+
+        await PutCapNhatAsync(duAnId, qtAId, ghiChu: "Issue182 ghi chu");
+
+        var after = await SnapshotBuocsAsync(duAnId);
+        after.Should().BeEquivalentTo(before);
+    }
+
+    private async Task<(int QtAId, int QtBId, List<int> BuocBIds)> SeedQuyTrinhAsync()
+    {
+        await using var db = CreateDb();
+        await EnsureTepDinhKemTableAsync(db);
+
+        var qtA = await db.Set<DanhMucQuyTrinh>().FirstOrDefaultAsync(e => e.Ten == QtATen);
+        if (qtA == null)
+        {
+            var hasMacDinh = await db.Set<DanhMucQuyTrinh>().AnyAsync(e => e.MacDinh);
+            qtA = new DanhMucQuyTrinh
+            {
+                Ten = QtATen,
+                MacDinh = !hasMacDinh,
+                Used = true,
+                IsDeleted = false,
+                CreatedAt = DateTimeOffset.UtcNow,
+            };
+            db.Set<DanhMucQuyTrinh>().Add(qtA);
+            await db.SaveChangesAsync();
+        }
+
+        var qtB = await db.Set<DanhMucQuyTrinh>().FirstOrDefaultAsync(e => e.Ten == QtBTen);
+        if (qtB == null)
+        {
+            qtB = new DanhMucQuyTrinh
+            {
+                Ten = QtBTen,
+                MacDinh = false,
+                Used = true,
+                IsDeleted = false,
+                CreatedAt = DateTimeOffset.UtcNow,
+            };
+            db.Set<DanhMucQuyTrinh>().Add(qtB);
+            await db.SaveChangesAsync();
+        }
+
+        if (!await db.Set<DanhMucBuoc>().AnyAsync(e => e.Ten == BuocATen))
+        {
+            db.Set<DanhMucBuoc>().Add(new DanhMucBuoc
+            {
+                Ten = BuocATen,
+                QuyTrinhId = qtA.Id,
+                Used = true,
+                IsDeleted = false,
+                Path = "/",
+                Level = 0,
+                Stt = 1,
+                SoNgayThucHien = 1,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+        }
+
+        if (!await db.Set<DanhMucBuoc>().AnyAsync(e => e.Ten == BuocBTen))
+        {
+            db.Set<DanhMucBuoc>().Add(new DanhMucBuoc
+            {
+                Ten = BuocBTen,
+                QuyTrinhId = qtB.Id,
+                Used = true,
+                IsDeleted = false,
+                Path = "/",
+                Level = 0,
+                Stt = 1,
+                SoNgayThucHien = 1,
+                CreatedAt = DateTimeOffset.UtcNow,
+            });
+        }
+
+        await db.SaveChangesAsync();
+
+        var buocBIds = await db.Set<DanhMucBuoc>()
+            .Where(e => e.QuyTrinhId == qtB.Id && !e.IsDeleted)
+            .Select(e => e.Id)
+            .ToListAsync();
+
+        return (qtA.Id, qtB.Id, buocBIds);
+    }
+
+    private async Task<Guid> CreateDuAnAsync(int quyTrinhId)
+    {
+        var dto = new DuAnInsertDtoFaker().Generate();
+        dto.QuyTrinhId = quyTrinhId;
+        dto.LanhDaoPhuTrachId = 1;
+
+        var response = await AuthedClient.PostAsJsonAsync("/api/du-an/them-moi", dto);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = CreateDb();
+        var entity = await db.Set<DuAn>().AsNoTracking()
+            .FirstOrDefaultAsync(e => e.MaDuAn == dto.MaDuAn && !e.IsDeleted);
+        entity.Should().NotBeNull($"them-moi phải lưu DuAn MaDuAn={dto.MaDuAn}");
+        return entity!.Id;
+    }
+
+    private async Task PutCapNhatAsync(Guid duAnId, int? quyTrinhId, string? ghiChu = null)
+    {
+        var dto = new DuAnUpdateModelFaker(duAnId).Generate();
+        dto.QuyTrinhId = quyTrinhId;
+        dto.LanhDaoPhuTrachId = 1;
+        if (ghiChu != null)
+            dto.GhiChu = ghiChu;
+
+        var response = await AuthedClient.PutAsJsonAsync("/api/du-an/cap-nhat", dto);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await using var db = CreateDb();
+        var entity = await db.Set<DuAn>().AsNoTracking().FirstAsync(e => e.Id == duAnId);
+        entity.QuyTrinhId.Should().Be(quyTrinhId);
+        if (ghiChu != null)
+            entity.GhiChu.Should().Be(ghiChu);
+    }
+
+    private async Task SetFirstBuocProgressAsync(Guid duAnId, DateTimeOffset ngayThucTeBatDau)
+    {
+        await using var db = CreateDb();
+        var buoc = await db.Set<DuAnBuoc>().FirstAsync(e => e.DuAnId == duAnId && !e.IsDeleted);
+        buoc.NgayThucTeBatDau = ngayThucTeBatDau;
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<List<BuocSnapshot>> SnapshotBuocsAsync(Guid duAnId)
+    {
+        await using var db = CreateDb();
+        return await db.Set<DuAnBuoc>()
+            .AsNoTracking()
+            .Where(e => e.DuAnId == duAnId && !e.IsDeleted)
+            .OrderBy(e => e.Id)
+            .Select(e => new BuocSnapshot(e.Id, e.BuocId, e.NgayThucTeBatDau, e.GhiChu, e.TenBuoc))
+            .ToListAsync();
+    }
+
+    private static async Task EnsureTepDinhKemTableAsync(SqliteAppDbContext db)
+    {
+        await db.Database.ExecuteSqlRawAsync("""
+            CREATE TABLE IF NOT EXISTS TepDinhKem (
+                Id TEXT NOT NULL PRIMARY KEY,
+                ParentId TEXT,
+                GroupId TEXT NOT NULL,
+                GroupType TEXT NOT NULL,
+                Type TEXT,
+                FileName TEXT,
+                OriginalName TEXT,
+                Path TEXT,
+                Size INTEGER NOT NULL DEFAULT 0,
+                CreatedBy TEXT NOT NULL DEFAULT '',
+                CreatedAt TEXT NOT NULL DEFAULT '',
+                UpdatedBy TEXT NOT NULL DEFAULT '',
+                UpdatedAt TEXT,
+                IsDeleted INTEGER NOT NULL DEFAULT 0,
+                "Index" INTEGER NOT NULL DEFAULT 0
+            );
+            """);
+    }
+
+    private SqliteAppDbContext CreateDb()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(fixture.GetSqliteConnection())
+            .Options;
+        return new SqliteAppDbContext(options);
+    }
+
+    private sealed record BuocSnapshot(
+        int Id,
+        int BuocId,
+        DateTimeOffset? NgayThucTeBatDau,
+        string? GhiChu,
+        string? TenBuoc);
 }

--- a/QLDA.WebApi/Controllers/DuAnController.cs
+++ b/QLDA.WebApi/Controllers/DuAnController.cs
@@ -15,12 +15,18 @@ using BuildingBlocks.Application.Attachments.Queries;
 using BuildingBlocks.Application.Attachments.Common;
 using QLDA.Domain.Constants;
 using QLDA.WebApi.Models.DuAns;
+using Microsoft.EntityFrameworkCore;
 
 namespace QLDA.WebApi.Controllers
 {
     [Tags("Dự án")]
     public class DuAnController(IServiceProvider serviceProvider) : AggregateRootController(serviceProvider)
     {
+        private readonly IRepository<DuAn, Guid> _duAnRepo =
+            serviceProvider.GetRequiredService<IRepository<DuAn, Guid>>();
+        private readonly IRepository<DuAnBuoc, int> _duAnBuocRepo =
+            serviceProvider.GetRequiredService<IRepository<DuAnBuoc, int>>();
+
         /// <summary>
         /// Chi tiết
         /// </summary>
@@ -307,9 +313,19 @@ namespace QLDA.WebApi.Controllers
         {
             using var tx = await unitOfWork.BeginTransactionAsync(IsolationLevel.ReadCommitted, cancellationToken);
 
+            var oldQuyTrinhId = await _duAnRepo.GetQueryableSet()
+                .AsNoTracking()
+                .Where(e => e.Id == updateDto.Id)
+                .Select(e => e.QuyTrinhId)
+                .FirstOrDefaultAsync(cancellationToken);
+
             var entity = await Mediator.Send(new DuAnUpdateCommand(updateDto), cancellationToken);
 
-            await Mediator.Send(new DuAnBuocCloneCommand(entity), cancellationToken);
+            if (oldQuyTrinhId != entity.QuyTrinhId
+                && !await HasDuAnBuocTienDoAsync(entity.Id, cancellationToken))
+            {
+                await Mediator.Send(new DuAnBuocCloneCommand(entity), cancellationToken);
+            }
 
             // Xử lý DuToan và TepDinhKem tương tự như trong hàm tạo mới
             List<(DuToan, List<Attachment>)> duToans = [.. updateDto.DuToans?.Select(e => e.ToEntityWithFiles(entity.Id)) ?? []];
@@ -366,6 +382,22 @@ namespace QLDA.WebApi.Controllers
         {
             var result = await Mediator.Send(new DuAnGetDanhSachTepDinhKemQuery { DuAnId = id });
             return ResultApi.Ok(result);
+        }
+
+        private async Task<bool> HasDuAnBuocTienDoAsync(Guid duAnId, CancellationToken cancellationToken)
+        {
+            return await _duAnBuocRepo.GetQueryableSet(OnlyUsed: false)
+                .AnyAsync(e =>
+                    e.DuAnId == duAnId && (
+                        e.NgayDuKienBatDau != null
+                        || e.NgayDuKienKetThuc != null
+                        || e.NgayThucTeBatDau != null
+                        || e.NgayThucTeKetThuc != null
+                        || e.TrangThaiId != null
+                        || e.IsKetThuc
+                        || (e.GhiChu != null && e.GhiChu != "")
+                        || (e.TrachNhiemThucHien != null && e.TrachNhiemThucHien != "")
+                    ), cancellationToken);
         }
 
         private async Task<DuAnDto> GetDuAnWithFiles(Guid duAnId, CancellationToken cancellationToken)

--- a/docs/issues/182/index.md
+++ b/docs/issues/182/index.md
@@ -1,0 +1,40 @@
+# Issue 182 / G-312 — Reset tiến độ `DuAnBuoc` khi cập nhật Dự án
+
+## 1. Mô tả
+
+API `PUT api/du-an/cap-nhat` sau khi `DuAnUpdateCommand` **luôn** gọi `DuAnBuocCloneCommand`, không phân biệt quy trình có đổi hay `DuAnBuoc` đã có tiến độ. Người dùng có thể mất dữ liệu tiến độ đã nhập.
+
+```http
+PUT api/du-an/cap-nhat
+```
+
+## 2. Tác nhân / UI
+
+- Người dùng có quyền cập nhật dự án (`GroupAdminOrManager`).
+- Màn hình cập nhật dự án: đổi thông tin (ghi chú, lãnh đạo, phòng…) hoặc đổi **Quy trình dự án**.
+
+## 3. Business rule
+
+| Quy trình thay đổi? | Đã nhập tiến độ `DuAnBuoc`? | Xử lý |
+|---|---|---|
+| Không | Không quan trọng | Không clone — giữ nguyên bước/tiến độ |
+| Có | Có (≥ 1 bước đã có tiến độ) | Không clone/reset — không được mất tiến độ |
+| Có | Chưa | Được clone lại theo quy trình mới (`DuAnBuocCloneCommand`) |
+
+`them-moi` dự án **không đổi** — vẫn clone + map phòng ban như hiện tại.
+
+## 4. Field nguồn sự thật (source)
+
+- Quy trình dự án: `DuAn.QuyTrinhId` (`int?`, FK danh mục quy trình).
+- Tiến độ trên `DuAnBuoc` (user-entered) — chi tiết `report.md` mục 4.
+- **Không** coi `PhongPhuTrachChinhId` là tiến độ: lệnh thêm mới tự map phòng phụ trách chính sau clone.
+
+## 5. Tài liệu liên quan
+
+- [`report.md`](./report.md) — khảo sát source, root cause, **cách sửa + snippet** (mục 6–7).
+- [`journal.md`](./journal.md) — nhật ký.
+- [`test-workflow.md`](./test-workflow.md) — 5 case verify.
+
+## 6. Trạng thái
+
+**Đã code.** `DuAnController.Update` chỉ clone khi QT đổi và chưa có tiến độ. Không migration/schema.

--- a/docs/issues/182/journal.md
+++ b/docs/issues/182/journal.md
@@ -1,0 +1,20 @@
+# Nhật ký công việc — Issue 182
+
+## 2026-08-14
+
+- Khảo sát source trước khi code (G-312 / reset `DuAnBuoc` khi `PUT api/du-an/cap-nhat`):
+  - `DuAnController.Update` / `Create`
+  - `DuAnUpdateCommand` + `DuAn.Update()` (`QuyTrinhId` bị ghi đè trên entity tracked)
+  - `DuAnBuocCloneCommand` (sync theo `BuocId`: insert / update metadata / delete bước thừa; wipe `NgayDuKien*` vì TODO tắt tính ngày)
+  - Entity `DuAn.QuyTrinhId`, `DuAnBuoc` (field tiến độ)
+  - `DuAnBuocMapPhongBanCommand` chỉ chạy lúc thêm mới → không lấy `PhongPhuTrachChinhId` làm “đã nhập tiến độ”
+- Viết `index.md`, `report.md`, `journal.md`, `test-workflow.md`.
+- Bổ sung `report.md` mục 6–7: hướng sửa, inject repo, snippet `Update` + `HasDuAnBuocTienDoAsync`, map 3 case, file đụng tới, rủi ro.
+- **Đã code** `DuAnController.Update`: đọc `oldQuyTrinhId` AsNoTracking trước `DuAnUpdateCommand`; chỉ `DuAnBuocCloneCommand` khi QT đổi và `HasDuAnBuocTienDoAsync` = false.
+- Test T1–T5 trong `QLDA.Tests/Integration/DuAnControllerTests.cs`.
+- Không migration. Không commit/push đến khi user review diff.
+
+### Việc tiếp theo
+
+- User tự migration nếu cần (issue này không đổi schema).
+- Review diff rồi commit khi user yêu cầu.

--- a/docs/issues/182/report.md
+++ b/docs/issues/182/report.md
@@ -1,0 +1,247 @@
+# Báo cáo khảo sát — Issue 182: reset tiến độ `DuAnBuoc` khi cập nhật Dự án
+
+> Trạng thái: **ĐÃ CODE.** Không đổi schema / không migration. `dotnet test --filter FullyQualifiedName~DuAnControllerTests.Update_` — 5 case T1–T5 pass.
+
+**Cách sửa (tóm tắt):** chỉ bọc lời gọi `DuAnBuocCloneCommand` trong `DuAnController.Update`. Đọc `QuyTrinhId` cũ (AsNoTracking) **trước** `DuAnUpdateCommand`. Chỉ clone khi QT đổi **và** chưa có tiến độ trên `DuAnBuoc`. Chi tiết mục 6–7.
+
+---
+
+## 1. Root cause
+
+`DuAnController.Update` (`PUT api/du-an/cap-nhat`) luôn gọi clone sau update:
+
+```312:312:QLDA.WebApi/Controllers/DuAnController.cs
+            await Mediator.Send(new DuAnBuocCloneCommand(entity), cancellationToken);
+```
+
+Không so sánh `QuyTrinhId` cũ/mới, không kiểm tra tiến độ đã nhập.
+
+`DuAn.Update()` ghi đè `QuyTrinhId` trên entity tracked **trước khi** controller nhận entity trả về:
+
+```65:65:QLDA.Application/DuAns/DTOs/DuAnMappings.cs
+        entity.QuyTrinhId = dto.QuyTrinhId;//PHẢI CLONE LẠI BƯỚC
+```
+
+Nếu chỉ đọc `entity.QuyTrinhId` sau `DuAnUpdateCommand` thì **không còn giá trị cũ**. Phải đọc `QuyTrinhId` **trước** `UpdateCommand` (AsNoTracking / query riêng).
+
+---
+
+## 2. Flow hiện tại `DuAnBuocCloneCommand`
+
+File: `QLDA.Application/DuAnBuocs/Commands/DuAnBuocCloneCommand.cs`.
+
+Đây **không** phải clone thuần “copy rồi thôi”. Handler `Clone()`:
+
+| `QuyTrinhId` trên `DuAn` (đã update) | Hành vi |
+|---|---|
+| `null` | `ExecuteDelete` toàn bộ `DuAnBuoc` của dự án |
+| Có giá trị | Load `DanhMucBuoc` (`Used`, `!IsDeleted`, cùng `QuyTrinhId`) → sync theo `BuocId` |
+
+Sync khi có quy trình:
+
+1. Load `DuAnBuoc` hiện có; nếu trùng `BuocId` thì giữ 1 dòng, xóa duplicate.
+2. Duyệt tree bước mới (`ToSteps().ToTreeList()`):
+   - `BuocId` chưa có → **insert** `DuAnBuoc` mới (`TenBuoc`, `PartialView`, `Used`, `DuAnBuocManHinhs`).
+   - `BuocId` đã có → **update** `TenBuoc`/`PartialView`/`Used` + sync màn hình; **không** copy tiến độ từ catalog (catalog không có tiến độ user).
+3. `BuocId` không còn trong quy trình mới → **`ExecuteDelete`**.
+4. Tính `NgayDuKienBatDau`/`NgayDuKienKetThuc` đang **TODO tắt**. Nhánh `else` gán **cả hai ngày dự kiến = null** trên node (kể cả bước trùng `BuocId`).
+
+→ Gọi clone khi user đã nhập tiến độ: xóa bước không còn trong QT mới, thêm bước mới, **wipe ngày dự kiến** trên bước trùng. Đúng bug G-312.
+
+Caller:
+
+| Nơi | Khi nào | Giữ? |
+|---|---|---|
+| `DuAnController.Create` | Sau insert, trước `DuAnBuocMapPhongBanCommand` | **Không đụng** |
+| `DuAnController.Update` | Unconditional sau `DuAnUpdateCommand` | **Chỗ sửa** |
+
+Không caller khác (đã grep).
+
+---
+
+## 3. Field xác định Quy trình dự án
+
+`DuAn.QuyTrinhId` (`int?`). Payload cập nhật: `DuAnUpdateModel.QuyTrinhId`.
+
+Bước catalog: `DanhMucBuoc.QuyTrinhId`. Clone lọc `e.QuyTrinhId == request.DuAn.QuyTrinhId`.
+
+So sánh: `oldQuyTrinhId` (DB trước update) vs `entity.QuyTrinhId` (sau `DuAnUpdateCommand`).
+
+---
+
+## 4. Field tiến độ trên `DuAnBuoc`
+
+Entity: `QLDA.Domain/Entities/DuAnBuoc.cs`.
+
+**Coi là tiến độ user đã nhập** (một bước thỏa ≥ 1 điều kiện → cả dự án “đã nhập tiến độ”):
+
+| Property | Điều kiện “đã nhập” |
+|---|---|
+| `NgayDuKienBatDau` | `!= null` |
+| `NgayDuKienKetThuc` | `!= null` |
+| `NgayThucTeBatDau` | `!= null` |
+| `NgayThucTeKetThuc` | `!= null` |
+| `TrangThaiId` | `!= null` (trạng thái thực hiện bước) |
+| `GhiChu` | không null/empty |
+| `TrachNhiemThucHien` | không null/empty |
+| `IsKetThuc` | `== true` |
+
+**Không** tính:
+
+- `PhongPhuTrachChinhId` — `DuAnBuocMapPhongBanCommand` gán khi **thêm mới**; nếu tính là tiến độ thì dự án mới vừa tạo sẽ luôn “đã nhập”, Case 3 không bao giờ clone khi đổi QT.
+- `TenBuoc` / `PartialView` / `Used` / `DuAnBuocManHinhs` — metadata bước, không phải tiến độ user.
+
+Task nêu `PhongBanPhuTrach` / `TrangThaiThucHien` — map source: `PhongPhuTrachChinhId` (loại khỏi check), `TrangThaiId`.
+
+Query tiến độ: `DuAnBuoc` theo `DuAnId`, **không** `FilterVisible` — phải thấy mọi bước của dự án, không lọc quyền.
+
+---
+
+## 5. Trùng `BuocId` giữa hai quy trình
+
+Clone đã match theo `BuocId` (giữ dòng cũ, thêm mới, xóa thiếu). **Không implement merge phức tạp** — spec chỉ yêu cầu 3 case: nếu đã có tiến độ thì **không gọi clone**. Bước trùng `BuocId` được bảo vệ vì không chạy sync/wipe.
+
+---
+
+## 6. Cách sửa (chọn hướng)
+
+**Sửa tại chỗ quyết định có gọi clone hay không** — `DuAnController.Update` — không sửa `DuAnBuocCloneCommand`.
+
+Lý do:
+
+- Clone command đang đúng cho **thêm mới** và cho Case 3 (đổi QT + chưa có tiến độ). Sửa bên trong clone sẽ ảnh hưởng `them-moi`.
+- Spec: không merge từng `BuocId`; chỉ bật/tắt lời gọi clone theo 3 case.
+- Comment `//PHẢI CLONE LẠI BƯỚC` trong `DuAn.Update()` là ý định cũ (luôn clone) — **không** sửa mapping; chặn ở controller.
+
+Không tạo Application Service / helper class mới. Helper = **private method trên controller**.
+
+---
+
+## 7. Chi tiết sửa — `DuAnController.cs`
+
+### 7.1. Inject repository
+
+Controller đang `DuAnController(IServiceProvider serviceProvider)`. Thêm 2 field (pattern `TemplateController`):
+
+```csharp
+private readonly IRepository<DuAn, Guid> _duAnRepo =
+    serviceProvider.GetRequiredService<IRepository<DuAn, Guid>>();
+private readonly IRepository<DuAnBuoc, int> _duAnBuocRepo =
+    serviceProvider.GetRequiredService<IRepository<DuAnBuoc, int>>();
+```
+
+Cần `using Microsoft.EntityFrameworkCore` nếu file chưa có (`.AsNoTracking()`, `.AnyAsync()`).
+
+### 7.2. Đọc `QuyTrinhId` cũ **trước** `DuAnUpdateCommand`
+
+Trong `Update`, ngay sau `BeginTransaction`, **trước** `Mediator.Send(DuAnUpdateCommand)`:
+
+```csharp
+var oldQuyTrinhId = await _duAnRepo.GetQueryableSet()
+    .AsNoTracking()
+    .Where(e => e.Id == updateDto.Id)
+    .Select(e => e.QuyTrinhId)
+    .FirstOrDefaultAsync(cancellationToken);
+
+var entity = await Mediator.Send(new DuAnUpdateCommand(updateDto), cancellationToken);
+
+if (oldQuyTrinhId != entity.QuyTrinhId
+    && !await HasDuAnBuocTienDoAsync(entity.Id, cancellationToken))
+{
+    await Mediator.Send(new DuAnBuocCloneCommand(entity), cancellationToken);
+}
+```
+
+Xóa dòng unconditional hiện tại (khoảng dòng 312).
+
+**Bắt buộc AsNoTracking + query trước update:** `DuAnUpdateCommand` load entity tracked rồi `entity.Update(dto)` gán `QuyTrinhId = dto.QuyTrinhId`. Cùng DbContext/transaction: nếu đọc lại tracked entity thì đã là giá trị mới.
+
+So sánh `int?` bằng `!=` (null vs 5 = đổi QT; 5 vs 5 = không đổi).
+
+Phần còn lại của `Update` (DuToan, KeHoachVon, file, `SaveChanges`, `Commit`) **giữ nguyên**.
+
+### 7.3. Helper `HasDuAnBuocTienDoAsync`
+
+Private trên controller. `true` nếu **ít nhất một** `DuAnBuoc` của dự án đã có tiến độ (mục 4).
+
+```csharp
+private async Task<bool> HasDuAnBuocTienDoAsync(Guid duAnId, CancellationToken cancellationToken)
+{
+    return await _duAnBuocRepo.GetQueryableSet(OnlyUsed: false)
+        .AnyAsync(e =>
+            e.DuAnId == duAnId && (
+                e.NgayDuKienBatDau != null
+                || e.NgayDuKienKetThuc != null
+                || e.NgayThucTeBatDau != null
+                || e.NgayThucTeKetThuc != null
+                || e.TrangThaiId != null
+                || e.IsKetThuc
+                || (e.GhiChu != null && e.GhiChu != "")
+                || (e.TrachNhiemThucHien != null && e.TrachNhiemThucHien != "")
+            ), cancellationToken);
+}
+```
+
+| Quy tắc | Lý do |
+|---|---|
+| `OnlyUsed: false` | Không bỏ bước `Used=false` nếu user đã nhập tiến độ |
+| Không `FilterVisible` | Phải thấy mọi bước của dự án; đây không phải list API theo quyền |
+| Không `PhongPhuTrachChinhId` | Tự gán lúc `them-moi` (`DuAnBuocMapPhongBanCommand`) |
+| `IsKetThuc` bool | `true` = đã kết thúc bước = đã nhập |
+
+Không `SaveChanges` trong helper — chỉ đọc.
+
+### 7.4. Map 3 case → code
+
+| Case | `oldQuyTrinhId != entity.QuyTrinhId` | `HasDuAnBuocTienDo` | Gọi clone? |
+|---|---|---|---|
+| 1 — không đổi QT | false | (bỏ qua, short-circuit) | Không |
+| 2 — đổi QT + đã có tiến độ | true | true | Không |
+| 3 — đổi QT + chưa tiến độ | true | false | Có — `DuAnBuocCloneCommand(entity)` như hiện tại |
+
+Case 3 reuse nguyên command (insert bước mới / xóa bước cũ / sync metadata). An toàn vì chưa có tiến độ để mất.
+
+### 7.5. `Create` (`them-moi`)
+
+**Không sửa.** Vẫn:
+
+1. `DuAnInsertCommand`
+2. `DuAnBuocCloneCommand`
+3. `DuAnBuocMapPhongBanCommand`
+
+---
+
+## 8. File đụng tới
+
+| File | Việc |
+|---|---|
+| `QLDA.WebApi/Controllers/DuAnController.cs` | **Bắt buộc.** Inject 2 repo; đổi `Update`; thêm `HasDuAnBuocTienDoAsync`. |
+| `QLDA.Tests/Integration/DuAnControllerTests.cs` | Nên thêm 5 case (`test-workflow.md`) nếu seed/fixture cho phép 2 `QuyTrinhId`. Test `Update_ExistingDuAn_ReturnsOk` hiện có **không** assert `DuAnBuoc` — không đủ để bắt regression. |
+
+**Không sửa:**
+
+- `DuAnBuocCloneCommand.cs` / handler
+- `DuAnUpdateCommand.cs`, `DuAnMappings.Update`
+- `DuAnBuocMapPhongBanCommand`
+- Entity / EF configuration / migration / snapshot
+- API contract (`DuAnUpdateModel` giữ `QuyTrinhId`)
+
+---
+
+## 9. Việc không làm
+
+- Không đổi flow `them-moi`.
+- Không clone khi không đổi QT.
+- Không clone khi đã có tiến độ (kể cả đổi QT).
+- Không merge từng bước / không sửa clone handler.
+- Không Application Service / helper class ngoài private method trên controller.
+- Không migration, không đổi schema, không đổi contract.
+
+---
+
+## 10. Rủi ro khi implement
+
+- `GetQueryableSet(OnlyUsed: false)` — xác nhận signature repo đúng (BuildingBlocks). Nếu không có overload, dùng set không lọc `Used` tương đương.
+- Helper chạy trong transaction của `Update` — `AsNoTracking` cho `oldQuyTrinhId` tránh dính tracked entity sau đó.
+- Test SQLite: unique `DmQuyTrinh.MacDinh` có thể fail nếu seed 2 quy trình `MacDinh=true` (lọc unique SQL Server không áp SQLite). Seed QT thứ 2 với `MacDinh=false`, hoặc chỉ gán `DanhMucBuoc.QuyTrinhId` giả.
+

--- a/docs/issues/182/test-workflow.md
+++ b/docs/issues/182/test-workflow.md
@@ -1,0 +1,47 @@
+# Kế hoạch kiểm thử — Issue 182
+
+> Đã code. Verify: `dotnet build SER.sln` + `dotnet test --filter DuAnControllerTests`. Không migration.
+
+## 1. Build
+
+```powershell
+dotnet build SER.sln
+```
+
+Kỳ vọng: 0 Error.
+
+## 2. Điều kiện “đã nhập tiến độ”
+
+Một `DuAnBuoc` của dự án thỏa **bất kỳ** điều kiện:
+
+- `NgayDuKienBatDau` / `NgayDuKienKetThuc` / `NgayThucTeBatDau` / `NgayThucTeKetThuc` ≠ null
+- `TrangThaiId` ≠ null
+- `GhiChu` hoặc `TrachNhiemThucHien` không rỗng
+- `IsKetThuc == true`
+
+Không dùng `PhongPhuTrachChinhId`.
+
+## 3. Test case
+
+Chuẩn bị: 2 quy trình A/B (`DanhMucQuyTrinh` + `DanhMucBuoc`). Dự án có `DuAnBuoc` sau `them-moi`. API `PUT api/du-an/cap-nhat`.
+
+| ID | Input | Kỳ vọng |
+|---|---|---|
+| **T1** | Không đổi `QuyTrinhId` + chưa nhập tiến độ | Không clone. Số bước / `BuocId` / ngày giữ nguyên. |
+| **T2** | Không đổi `QuyTrinhId` + ≥ 1 bước đã nhập tiến độ (vd. `NgayThucTeBatDau`) | Không clone. Tiến độ còn nguyên. |
+| **T3** | Đổi `QuyTrinhId` A→B + mọi bước chưa tiến độ | Clone theo QT B. Bước mới theo `DanhMucBuoc` của B. |
+| **T4** | Đổi `QuyTrinhId` A→B + ≥ 1 bước đã nhập tiến độ | Không clone/reset. Tiến độ + tập `BuocId` cũ còn nguyên. |
+| **T5** | Chỉ đổi `GhiChu` / `LanhDaoPhuTrachId` / `DonViPhuTrachChinhId` (không đổi QT) | `DuAnBuoc` không đổi (regression). |
+
+## 4. Gợi ý kiểm tra DB sau T4
+
+```sql
+-- số bước và tiến độ không đổi so với trước PUT
+SELECT Id, BuocId, NgayDuKienBatDau, NgayDuKienKetThuc, NgayThucTeBatDau, TrangThaiId, IsKetThuc
+FROM DuAnBuoc
+WHERE DuAnId = @id AND IsDeleted = 0;
+```
+
+## 5. Regression thêm mới
+
+`POST api/du-an/them-moi` vẫn clone + `DuAnBuocMapPhongBanCommand`. Không đổi hành vi.


### PR DESCRIPTION
## Summary
- G-312 / issue 182: `PUT api/du-an/cap-nhat` trước đây luôn gọi `DuAnBuocCloneCommand` nên mất ngày/trạng thái bước.
- Chỉ clone khi `QuyTrinhId` đổi **và** chưa nhập tiến độ trên `DuAnBuoc` (không tính `PhongPhuTrachChinhId`).
- `them-moi` không đổi. Không migration.

## Test plan
- [x] T1: không đổi QT, chưa tiến độ → `DuAnBuoc` giữ nguyên
- [x] T2: không đổi QT, đã có `NgayThucTeBatDau` → tiến độ còn
- [x] T3: đổi QT A→B, chưa tiến độ → clone theo QT B
- [x] T4: đổi QT A→B, đã có tiến độ → không clone/reset
- [ ] T5: chỉ đổi ghi chú/lãnh đạo/phòng, không đổi QT → `DuAnBuoc` không đổi
- [ ] Regression: `POST them-moi` vẫn clone bước
