### PR TITLE
fix(#182): cấm đổi QuyTrinhId khi dự án đã có tiến độ DuAnBuoc

### DIFF
--- a/QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs
+++ b/QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs
@@ -15,6 +15,7 @@ internal class DuAnUpdateCommandHandler : IRequestHandler<DuAnUpdateCommand, DuA
     private readonly IRepository<DuToan, Guid> DuToan;
     private readonly IRepository<KeHoachVon, Guid> KeHoachVon;
     private readonly IRepository<DanhMucNguonVon, int> DanhMucNguonVon;
+    private readonly IRepository<DuAnBuoc, int> DuAnBuoc;
     private readonly IAuthorizationManager _auth;
     private readonly IUnitOfWork _unitOfWork;
     private readonly Serilog.ILogger _logger = Serilog.Log.ForContext<DuAnUpdateCommandHandler>();
@@ -24,6 +25,7 @@ internal class DuAnUpdateCommandHandler : IRequestHandler<DuAnUpdateCommand, DuA
         DuToan = serviceProvider.GetRequiredService<IRepository<DuToan, Guid>>();
         KeHoachVon = serviceProvider.GetRequiredService<IRepository<KeHoachVon, Guid>>();
         DanhMucNguonVon = serviceProvider.GetRequiredService<IRepository<DanhMucNguonVon, int>>();
+        DuAnBuoc = serviceProvider.GetRequiredService<IRepository<DuAnBuoc, int>>();
         _auth = serviceProvider.GetRequiredService<IAuthorizationManager>();
         _unitOfWork = DuAn.UnitOfWork;
     }
@@ -43,6 +45,13 @@ internal class DuAnUpdateCommandHandler : IRequestHandler<DuAnUpdateCommand, DuA
         // Phòng ban phối hợp (thuộc DuAnChiuTrachNhiemXuLys, Loai=DonViPhoiHop) mới được chỉnh sửa.
         if (!await _auth.CanExecuteAsync(AuthorizationResourceKeys.DuAn, entity, cancellationToken))
             throw new ForbiddenException("User không có quyền chỉnh sửa dự án này");
+
+        // Cấm đổi QuyTrinhId khi đã nhập tiến độ: validate trước khi map request vào entity,
+        // tránh DuAn.QuyTrinhId=B nhưng DuAnBuoc vẫn thuộc QT A.
+        var doiQuyTrinh = entity.QuyTrinhId != request.Model.QuyTrinhId;
+        ManagedException.ThrowIf(
+            doiQuyTrinh && await HasDuAnBuocTienDoAsync(entity.Id, cancellationToken),
+            "Quy trình không thể đổi");
 
         // Store the original ParentId to check if it changed
         var originalParentId = entity.ParentId;
@@ -100,6 +109,21 @@ internal class DuAnUpdateCommandHandler : IRequestHandler<DuAnUpdateCommand, DuA
 
     private async Task UpdateAsync(DuAn entity, CancellationToken cancellationToken) {
         await DuAn.UpdateAsync(entity, cancellationToken);
+    }
+
+    private async Task<bool> HasDuAnBuocTienDoAsync(Guid duAnId, CancellationToken cancellationToken) {
+        return await DuAnBuoc.GetQueryableSet(OnlyUsed: false)
+            .AnyAsync(e =>
+                e.DuAnId == duAnId && (
+                    e.NgayDuKienBatDau != null
+                    || e.NgayDuKienKetThuc != null
+                    || e.NgayThucTeBatDau != null
+                    || e.NgayThucTeKetThuc != null
+                    || e.TrangThaiId != null
+                    || e.IsKetThuc
+                    || (e.GhiChu != null && e.GhiChu != "")
+                    || (e.TrachNhiemThucHien != null && e.TrachNhiemThucHien != "")
+                ), cancellationToken);
     }
     #endregion
 }

--- a/QLDA.Tests/Integration/DuAnControllerTests.cs
+++ b/QLDA.Tests/Integration/DuAnControllerTests.cs
@@ -134,7 +134,7 @@ public class DuAnControllerTests(WebApiFixture fixture)
     }
 
     [Fact]
-    public async Task Update_ChangeQuyTrinh_WithProgress_DoesNotClone()
+    public async Task Update_ChangeQuyTrinh_WithProgress_RejectsAndKeepsOldQuyTrinh()
     {
         var (qtAId, qtBId, _) = await SeedQuyTrinhAsync();
         var duAnId = await CreateDuAnAsync(qtAId);
@@ -142,7 +142,29 @@ public class DuAnControllerTests(WebApiFixture fixture)
         await SetFirstBuocProgressAsync(duAnId, ngayThucTe);
         var before = await SnapshotBuocsAsync(duAnId);
 
-        await PutCapNhatAsync(duAnId, qtBId);
+        await using var dbBefore = CreateDb();
+        var ghiChuTruoc = await dbBefore.Set<DuAn>().AsNoTracking()
+            .Where(e => e.Id == duAnId)
+            .Select(e => e.GhiChu)
+            .FirstAsync();
+
+        var dto = new DuAnUpdateModelFaker(duAnId).Generate();
+        dto.QuyTrinhId = qtBId;
+        dto.LanhDaoPhuTrachId = 1;
+        dto.GhiChu = "Issue182 ghi chu se khong luu";
+
+        var response = await AuthedClient.PutAsJsonAsync("/api/du-an/cap-nhat", dto);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ResultApi>();
+        result.Should().NotBeNull();
+        result!.Result.Should().BeFalse();
+        result.ErrorMessage.Should().Be("Quy trình không thể đổi");
+
+        await using var db = CreateDb();
+        var entity = await db.Set<DuAn>().AsNoTracking().FirstAsync(e => e.Id == duAnId);
+        entity.QuyTrinhId.Should().Be(qtAId);
+        entity.GhiChu.Should().Be(ghiChuTruoc, "T4 không được save dở các field khác của PUT");
 
         var after = await SnapshotBuocsAsync(duAnId);
         after.Should().BeEquivalentTo(before);

--- a/QLDA.WebApi/Controllers/DuAnController.cs
+++ b/QLDA.WebApi/Controllers/DuAnController.cs
@@ -24,8 +24,6 @@ namespace QLDA.WebApi.Controllers
     {
         private readonly IRepository<DuAn, Guid> _duAnRepo =
             serviceProvider.GetRequiredService<IRepository<DuAn, Guid>>();
-        private readonly IRepository<DuAnBuoc, int> _duAnBuocRepo =
-            serviceProvider.GetRequiredService<IRepository<DuAnBuoc, int>>();
 
         /// <summary>
         /// Chi tiết
@@ -321,8 +319,7 @@ namespace QLDA.WebApi.Controllers
 
             var entity = await Mediator.Send(new DuAnUpdateCommand(updateDto), cancellationToken);
 
-            if (oldQuyTrinhId != entity.QuyTrinhId
-                && !await HasDuAnBuocTienDoAsync(entity.Id, cancellationToken))
+            if (oldQuyTrinhId != entity.QuyTrinhId)
             {
                 await Mediator.Send(new DuAnBuocCloneCommand(entity), cancellationToken);
             }
@@ -382,22 +379,6 @@ namespace QLDA.WebApi.Controllers
         {
             var result = await Mediator.Send(new DuAnGetDanhSachTepDinhKemQuery { DuAnId = id });
             return ResultApi.Ok(result);
-        }
-
-        private async Task<bool> HasDuAnBuocTienDoAsync(Guid duAnId, CancellationToken cancellationToken)
-        {
-            return await _duAnBuocRepo.GetQueryableSet(OnlyUsed: false)
-                .AnyAsync(e =>
-                    e.DuAnId == duAnId && (
-                        e.NgayDuKienBatDau != null
-                        || e.NgayDuKienKetThuc != null
-                        || e.NgayThucTeBatDau != null
-                        || e.NgayThucTeKetThuc != null
-                        || e.TrangThaiId != null
-                        || e.IsKetThuc
-                        || (e.GhiChu != null && e.GhiChu != "")
-                        || (e.TrachNhiemThucHien != null && e.TrachNhiemThucHien != "")
-                    ), cancellationToken);
         }
 
         private async Task<DuAnDto> GetDuAnWithFiles(Guid duAnId, CancellationToken cancellationToken)

--- a/docs/issues/182/index.md
+++ b/docs/issues/182/index.md
@@ -17,11 +17,13 @@ PUT api/du-an/cap-nhat
 
 | Quy trình thay đổi? | Đã nhập tiến độ `DuAnBuoc`? | Xử lý |
 |---|---|---|
-| Không | Không quan trọng | Không clone — giữ nguyên bước/tiến độ |
-| Có | Có (≥ 1 bước đã có tiến độ) | Không clone/reset — không được mất tiến độ |
-| Có | Chưa | Được clone lại theo quy trình mới (`DuAnBuocCloneCommand`) |
+| Không | Không quan trọng | Update bình thường. Không clone. |
+| Có | Có (≥ 1 bước đã có tiến độ) | **Reject.** Message `"Quy trình không thể đổi"`. Không đổi `DuAn.QuyTrinhId`, không clone/reset bước, không save field khác của request. |
+| Có | Chưa | Cho đổi QT + clone bước theo quy trình mới (`DuAnBuocCloneCommand`) |
 
 `them-moi` dự án **không đổi** — vẫn clone + map phòng ban như hiện tại.
+
+> **Không** hiểu “đã phát sinh `DuAnBuoc`” = chỉ cần có dòng bước. `them-moi` luôn clone bước. Predicate tiến độ = user đã nhập (mục 4 `report.md`), giống phase 1.
 
 ## 4. Field nguồn sự thật (source)
 
@@ -31,10 +33,11 @@ PUT api/du-an/cap-nhat
 
 ## 5. Tài liệu liên quan
 
-- [`report.md`](./report.md) — khảo sát source, root cause, **cách sửa + snippet** (mục 6–7).
+- [`report.md`](./report.md) — khảo sát + cách sửa. **Phase 2 (chặn đổi QT): mục 11.**
 - [`journal.md`](./journal.md) — nhật ký.
-- [`test-workflow.md`](./test-workflow.md) — 5 case verify.
+- [`test-workflow.md`](./test-workflow.md) — case verify (T4 đổi: reject).
 
 ## 6. Trạng thái
 
-**Đã code.** `DuAnController.Update` chỉ clone khi QT đổi và chưa có tiến độ. Không migration/schema.
+**Phase 1 (G-312 skip clone): đã merge PR #184.**  
+**Phase 2 (không cho đổi `QuyTrinhId` khi đã có tiến độ): ĐÃ CODE.** Validate trong `DuAnUpdateCommandHandler` trước `entity.Update()`. Không migration/schema.

--- a/docs/issues/182/journal.md
+++ b/docs/issues/182/journal.md
@@ -14,7 +14,18 @@
 - Test T1–T5 trong `QLDA.Tests/Integration/DuAnControllerTests.cs`.
 - Không migration. Không commit/push đến khi user review diff.
 
+### Việc tiếp theo (cũ — phase 1 xong)
+
+- Phase 1 đã commit/PR #184.
+
+## 2026-08-17
+
+- Spec mới: Case 2 không chỉ “không clone” — **cấm đổi `QuyTrinhId`**. Reject `"Quy trình không thể đổi"`, rollback cả request.
+- Root cause còn lại: `DuAnUpdateCommand` gọi `entity.Update(dto)` **trước** cửa clone ở controller → `DuAn.QuyTrinhId` vẫn thành B dù bước còn A.
+- Viết docs phase 2 (`index.md` rule, `report.md` mục 11, `test-workflow.md` T4).
+- **Đã code.** Validate trong `DuAnUpdateCommandHandler` sau load entity, **trước** `entity.Update()`. Message `"Quy trình không thể đổi"`. T4 test reject + giữ `QuyTrinhId` cũ.
+
 ### Việc tiếp theo
 
-- User tự migration nếu cần (issue này không đổi schema).
 - Review diff rồi commit khi user yêu cầu.
+- Không migration.

--- a/docs/issues/182/report.md
+++ b/docs/issues/182/report.md
@@ -1,8 +1,10 @@
 # Báo cáo khảo sát — Issue 182: reset tiến độ `DuAnBuoc` khi cập nhật Dự án
 
-> Trạng thái: **ĐÃ CODE.** Không đổi schema / không migration. `dotnet test --filter FullyQualifiedName~DuAnControllerTests.Update_` — 5 case T1–T5 pass.
+> Trạng thái: **Phase 1 đã merge.** **Phase 2 ĐÃ CODE** — cấm đổi QT khi đã có tiến độ. Không đổi schema. Chi tiết phase 2: mục 11.
 
-**Cách sửa (tóm tắt):** chỉ bọc lời gọi `DuAnBuocCloneCommand` trong `DuAnController.Update`. Đọc `QuyTrinhId` cũ (AsNoTracking) **trước** `DuAnUpdateCommand`. Chỉ clone khi QT đổi **và** chưa có tiến độ trên `DuAnBuoc`. Chi tiết mục 6–7.
+**Phase 1 (G-312):** chỉ clone khi QT đổi và chưa có tiến độ. Mục 6–7.
+
+**Phase 2:** Case 2 không chỉ skip clone — **reject cả PUT**, `DuAn.QuyTrinhId` giữ A. Mục 11.
 
 ---
 
@@ -99,7 +101,7 @@ Query tiến độ: `DuAnBuoc` theo `DuAnId`, **không** `FilterVisible` — ph�
 
 ## 5. Trùng `BuocId` giữa hai quy trình
 
-Clone đã match theo `BuocId` (giữ dòng cũ, thêm mới, xóa thiếu). **Không implement merge phức tạp** — spec chỉ yêu cầu 3 case: nếu đã có tiến độ thì **không gọi clone**. Bước trùng `BuocId` được bảo vệ vì không chạy sync/wipe.
+Clone đã match theo `BuocId`. Phase 1: đã có tiến độ thì không gọi clone. **Phase 2:** đã có tiến độ thì **không cho đổi QT** (reject) — không còn lệch `QuyTrinhId=B` / bước A.
 
 ---
 
@@ -244,4 +246,142 @@ Case 3 reuse nguyên command (insert bước mới / xóa bước cũ / sync met
 - `GetQueryableSet(OnlyUsed: false)` — xác nhận signature repo đúng (BuildingBlocks). Nếu không có overload, dùng set không lọc `Used` tương đương.
 - Helper chạy trong transaction của `Update` — `AsNoTracking` cho `oldQuyTrinhId` tránh dính tracked entity sau đó.
 - Test SQLite: unique `DmQuyTrinh.MacDinh` có thể fail nếu seed 2 quy trình `MacDinh=true` (lọc unique SQL Server không áp SQLite). Seed QT thứ 2 với `MacDinh=false`, hoặc chỉ gán `DanhMucBuoc.QuyTrinhId` giả.
+
+---
+
+## 11. Phase 2 — Không cho đổi `QuyTrinhId` khi đã có tiến độ
+
+> **ĐÃ CODE.** Không migration. Không đổi clone Case 3 (`them-moi` / đổi QT chưa tiến độ).
+
+### 11.1. Root cause (còn lại sau phase 1)
+
+Phase 1 chỉ chặn **clone** ở `DuAnController.Update`. `DuAnUpdateCommand` vẫn chạy **trước** cửa đó:
+
+```
+Controller.Update
+  tx.Begin
+  oldQuyTrinhId = AsNoTracking          // A
+  DuAnUpdateCommand
+    load entity                         // QuyTrinhId = A
+    entity.Update(dto)                  // gán QuyTrinhId = B  ← quá sớm
+    UpdateAsync (tracked, chưa SaveChanges nếu đang có tx)
+  if (old != new && !HasTienDo) clone   // Case 2: skip clone
+  attachments
+  SaveChanges + Commit                  // DuAn.QuyTrinhId = B vẫn được lưu
+```
+
+`DuAn.Update()`:
+
+```65:65:QLDA.Application/DuAns/DTOs/DuAnMappings.cs
+        entity.QuyTrinhId = dto.QuyTrinhId;//PHẢI CLONE LẠI BƯỚC
+```
+
+Case 2 hiện tại: bước còn A, `DuAn.QuyTrinhId` thành B. Đúng bug phase 2.
+
+Chặn clone ở controller **không đủ**. Phải reject **trước** `entity.Update()`.
+
+### 11.2. Chỗ đặt validate (CQRS)
+
+**Đặt trong `DuAnUpdateCommandHandler`**, sau load + auth, **trước** `entity.Update(request.Model)`.
+
+| Chỗ | Được? | Lý do |
+|---|---|---|
+| FluentValidation trên DTO | Không | Không có `QuyTrinhId` cũ / tiến độ DB |
+| `DuAnController` sau `DuAnUpdateCommand` | Không | `entity.Update` đã gán B; field khác đã map; dễ save dở nếu quên rollback |
+| `DuAnMappings.Update` | Không | Mapping không query `DuAnBuoc` |
+| `DuAnBuocCloneCommand` | Không | Case 2 không gọi clone; sửa clone ảnh hưởng `them-moi` |
+| **`DuAnUpdateCommandHandler` trước `entity.Update`** | **Có** | Đúng lớp Application; chưa gán QT; chưa `SaveChanges` |
+
+Pattern lỗi: `ManagedException` — cùng `ValidateAsync` nguồn vốn. **Không** tạo exception type mới.
+
+```csharp
+throw new ManagedException("Quy trình không thể đổi");
+// hoặc
+ManagedException.ThrowIf(doiQt && daCoTienDo, "Quy trình không thể đổi");
+```
+
+`ExceptionMiddleware`: `ManagedException` → HTTP **200**, body `result: false`, `errorMessage` = message trên (không phải HTTP 400).
+
+### 11.3. Điều kiện
+
+```text
+entity.QuyTrinhId != request.Model.QuyTrinhId
+AND HasDuAnBuocTienDo(entity.Id)
+    → throw "Quy trình không thể đổi"
+```
+
+`HasDuAnBuocTienDo`: **cùng predicate phase 1** (mục 4). Không `Any()` theo sự tồn tại dòng `DuAnBuoc` — `them-moi` luôn clone bước; nếu dùng `Any()` thì Case 3 không bao giờ đổi QT.
+
+Không `PhongPhuTrachChinhId`. Không `FilterVisible`. `GetQueryableSet(OnlyUsed: false)`.
+
+### 11.4. Snippet handler
+
+File: `QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs`.
+
+Inject thêm `IRepository<DuAnBuoc, int>` (cùng pattern handler hiện tại).
+
+Sau `CanExecuteAsync`, trước `entity.Update`:
+
+```csharp
+var doiQuyTrinh = entity.QuyTrinhId != request.Model.QuyTrinhId;
+ManagedException.ThrowIf(
+    doiQuyTrinh && await HasDuAnBuocTienDoAsync(entity.Id, cancellationToken),
+    "Quy trình không thể đổi");
+
+entity.Update(request.Model);
+```
+
+Helper `HasDuAnBuocTienDoAsync`: copy LINQ từ controller (mục 7.3). Không tạo `Application/Services`.
+
+Không gọi `SaveChanges` trong nhánh throw. Controller đang bọc tx: `HasTransaction == true` → handler không commit riêng. Exception → không tới `SaveChanges`/`Commit` ở controller → `using tx` dispose rollback. Field khác của request không vào DB.
+
+### 11.5. Controller (phạm vi nhỏ)
+
+Sau khi handler reject Case 2, `DuAnUpdateCommand` không return → không clone, không attachment, không `SaveChanges`.
+
+Giữ đọc `oldQuyTrinhId` + clone Case 3:
+
+```csharp
+if (oldQuyTrinhId != entity.QuyTrinhId)
+    await Mediator.Send(new DuAnBuocCloneCommand(entity), cancellationToken);
+```
+
+`!HasDuAnBuocTienDo` trên controller **thừa** (Case 2 đã throw trong handler). Được xóa helper controller nếu đã chuyển LINQ sang handler — tránh 2 chỗ lệch predicate. Không đụng `Create`.
+
+### 11.6. Map case
+
+| Case | Kết quả |
+|---|---|
+| Không đổi QT | Update OK, không clone |
+| A→B, chưa tiến độ | Update OK, `QuyTrinhId=B`, clone QT B |
+| A→B, đã tiến độ | `"Quy trình không thể đổi"`. DB: `QuyTrinhId` vẫn A. Không clone/reset/xóa bước. Không lưu field khác của PUT |
+
+### 11.7. File đụng tới (phase 2)
+
+| File | Việc |
+|---|---|
+| `QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs` | **Bắt buộc.** Validate trước `entity.Update`. Inject `DuAnBuoc` repo + helper tiến độ. |
+| `QLDA.WebApi/Controllers/DuAnController.cs` | Đơn giản hóa cửa clone (`old != new` thôi). Xóa helper nếu đã chuyển sang handler. |
+| `QLDA.Tests/Integration/DuAnControllerTests.cs` | Đổi T4: reject + `QuyTrinhId` còn A + bước/ghi chú không đổi. |
+
+**Không sửa:** `DuAnBuocCloneCommand`, `DuAnMappings.Update` (vẫn gán QT — handler không gọi khi reject), `Create`, entity/EF/migration, contract DTO.
+
+### 11.8. Việc không làm
+
+- Không migration / schema.
+- Không đổi Case 3 (chưa tiến độ vẫn clone).
+- Không đổi `them-moi`.
+- Không Application Service mới.
+- Không merge từng `BuocId`.
+- Không HTTP status mới — giữ `ManagedException`.
+
+### 11.9. Xác nhận Case A→B đã có tiến độ
+
+Sau implement, một PUT với `QuyTrinhId=B` + bước đã có `NgayThucTeBatDau`/`TrangThaiId`:
+
+1. Response `errorMessage == "Quy trình không thể đổi"`.
+2. SQL `DuAn.QuyTrinhId` vẫn A.
+3. `DuAnBuoc` snapshot = trước PUT.
+4. `DuAn.GhiChu` (nếu payload đổi) không đổi — chứng minh không save dở.
+
 

--- a/docs/issues/182/test-workflow.md
+++ b/docs/issues/182/test-workflow.md
@@ -1,14 +1,15 @@
 # Kế hoạch kiểm thử — Issue 182
 
-> Đã code. Verify: `dotnet build SER.sln` + `dotnet test --filter DuAnControllerTests`. Không migration.
+> Phase 2 **đã code.** Verify: build + filter test dưới. Không migration.
 
 ## 1. Build
 
 ```powershell
 dotnet build SER.sln
+dotnet test QLDA.Tests/QLDA.Tests.csproj --filter "FullyQualifiedName~QLDA.Tests.Integration.DuAnControllerTests.Update_SameQuyTrinh|FullyQualifiedName~QLDA.Tests.Integration.DuAnControllerTests.Update_Change"
 ```
 
-Kỳ vọng: 0 Error.
+Kỳ vọng: 0 Error; T1–T5 (T4 đổi nghĩa — xem bảng).
 
 ## 2. Điều kiện “đã nhập tiến độ”
 
@@ -19,29 +20,36 @@ Một `DuAnBuoc` của dự án thỏa **bất kỳ** điều kiện:
 - `GhiChu` hoặc `TrachNhiemThucHien` không rỗng
 - `IsKetThuc == true`
 
-Không dùng `PhongPhuTrachChinhId`.
+Không dùng `PhongPhuTrachChinhId`. Không dùng “chỉ cần có dòng `DuAnBuoc`”.
 
 ## 3. Test case
 
-Chuẩn bị: 2 quy trình A/B (`DanhMucQuyTrinh` + `DanhMucBuoc`). Dự án có `DuAnBuoc` sau `them-moi`. API `PUT api/du-an/cap-nhat`.
+Chuẩn bị: 2 quy trình A/B. API `PUT api/du-an/cap-nhat`.
+
+`ManagedException` → HTTP **200**, body `result: false`, `errorMessage` như dưới (pattern hiện tại, không phải HTTP 400).
 
 | ID | Input | Kỳ vọng |
 |---|---|---|
-| **T1** | Không đổi `QuyTrinhId` + chưa nhập tiến độ | Không clone. Số bước / `BuocId` / ngày giữ nguyên. |
-| **T2** | Không đổi `QuyTrinhId` + ≥ 1 bước đã nhập tiến độ (vd. `NgayThucTeBatDau`) | Không clone. Tiến độ còn nguyên. |
-| **T3** | Đổi `QuyTrinhId` A→B + mọi bước chưa tiến độ | Clone theo QT B. Bước mới theo `DanhMucBuoc` của B. |
-| **T4** | Đổi `QuyTrinhId` A→B + ≥ 1 bước đã nhập tiến độ | Không clone/reset. Tiến độ + tập `BuocId` cũ còn nguyên. |
-| **T5** | Chỉ đổi `GhiChu` / `LanhDaoPhuTrachId` / `DonViPhuTrachChinhId` (không đổi QT) | `DuAnBuoc` không đổi (regression). |
+| **T1** | Không đổi `QuyTrinhId` + chưa nhập tiến độ | Update OK. `DuAnBuoc` giữ nguyên. |
+| **T2** | Không đổi `QuyTrinhId` + ≥ 1 bước đã nhập tiến độ | Update OK. Tiến độ còn. `QuyTrinhId` vẫn A. |
+| **T3** | Đổi A→B + mọi bước chưa tiến độ | Update OK. `DuAn.QuyTrinhId = B`. Clone bước theo QT B. |
+| **T4** | Đổi A→B + ≥ 1 bước đã nhập tiến độ | **Reject.** `errorMessage = "Quy trình không thể đổi"`. `DuAn.QuyTrinhId` vẫn **A**. `DuAnBuoc` không clone/reset. Field khác của payload (vd. `GhiChu`) **không** lưu. |
+| **T5** | Chỉ đổi `GhiChu` / lãnh đạo / phòng, không đổi QT | Update OK. `DuAnBuoc` không đổi. |
 
-## 4. Gợi ý kiểm tra DB sau T4
+## 4. SQL sau T4 (reject)
 
 ```sql
--- số bước và tiến độ không đổi so với trước PUT
-SELECT Id, BuocId, NgayDuKienBatDau, NgayDuKienKetThuc, NgayThucTeBatDau, TrangThaiId, IsKetThuc
+SELECT QuyTrinhId, GhiChu FROM DuAn
+WHERE Id = CAST('...' AS uniqueidentifier);
+
+SELECT Id, BuocId, NgayThucTeBatDau, TrangThaiId, IsKetThuc
 FROM DuAnBuoc
-WHERE DuAnId = @id AND IsDeleted = 0;
+WHERE DuAnId = CAST('...' AS uniqueidentifier) AND IsDeleted = 0
+ORDER BY Id;
 ```
+
+`QuyTrinhId` phải còn A. Snapshot bước = trước PUT. `GhiChu` dự án không đổi nếu payload có ghi chú mới.
 
 ## 5. Regression thêm mới
 
-`POST api/du-an/them-moi` vẫn clone + `DuAnBuocMapPhongBanCommand`. Không đổi hành vi.
+`POST api/du-an/them-moi` vẫn clone + `DuAnBuocMapPhongBanCommand`.


### PR DESCRIPTION
## Summary
- `PUT api/du-an/cap-nhat` trước đây vẫn lưu `QuyTrinhId` mới dù đã có tiến độ bước — phase 1 (PR #184) chỉ skip clone, QT vẫn bị đổi.
- Validate trong `DuAnUpdateCommandHandler` **trước** `entity.Update()`: đổi QT khi đã nhập tiến độ → reject `"Quy trình không thể đổi"`, giữ QT cũ, không clone/reset bước.
- Clone bước chỉ khi QT đổi **và** chưa có tiến độ. `them-moi` không đổi.

## Test plan
- [x] Đổi thông tin dự án, **không** đổi QT → update OK, không clone
- [x] Đổi QT khi bước **chưa** có tiến độ → cho đổi + clone bước mới
- [x] Đổi QT khi bước **đã** có tiến độ (ngày DK/TT, trạng thái, ghi chú, trách nhiệm, `IsKetThuc`) → `result: false`, message `"Quy trình không thể đổi"`, `QuyTrinhId` giữ nguyên
- [ ] `PhongPhuTrachChinhId` / chỉ có dòng bước sau them-moi **không** tính là tiến độ