### PR TITLE
feat(#179): API to-trinh-tham-dinh-nha-thau tra them goiThauId va tenGoiThau

### DIFF
--- a/QLDA.Application/ToTrinhThamDinhNhaThau/DTOs/ToTrinhThamDinhNhaThauDto.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/DTOs/ToTrinhThamDinhNhaThauDto.cs
@@ -15,6 +15,7 @@ public class ToTrinhThamDinhNhaThauDto : IHasKey<Guid?>, IMustHaveId<Guid>, IMay
     public Guid DuAnId { get; set; }
     public int? BuocId { get; set; }
     public Guid? GoiThauId { get; set; }
+    public string TenGoiThau { get; set; } = string.Empty;
     public Guid? NhaThauId { get; set; }
     public int? TrangThaiId { get; set; }
     public string? MaTrangThai { get; set; }

--- a/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs
@@ -39,6 +39,7 @@ internal class    ToTrinhThamDinhNhaThauDanhSachQueryHandler(IServiceProvider Se
         CancellationToken cancellationToken = default) {
 
         var queryable = ToTrinhThamDinhNhaThau.GetQueryableSet().AsNoTracking()
+            .Include(e => e.GoiThau)
             .WhereIf(request.DuAnId != null, e => e.DuAnId == request.DuAnId)
             .WhereIf(request.LoaiDuAnTheoNamId > 0, e => e.DuAn!.LoaiDuAnTheoNamId == request.LoaiDuAnTheoNamId)
             .WhereIf(request.BuocId != null, e => e.BuocId == request.BuocId)
@@ -49,6 +50,7 @@ internal class    ToTrinhThamDinhNhaThauDanhSachQueryHandler(IServiceProvider Se
                 DuAnId=e.DuAnId,
                 BuocId=e.BuocId,
                 GoiThauId = e.GoiThauId,
+                TenGoiThau = e.GoiThau != null ? e.GoiThau.Ten ?? string.Empty : string.Empty,
                 NhaThauId = e.NhaThauId,
                 TrangThaiDangTaiId = e.TrangThaiDangTaiId,
                 TrangThaiId = e.TrangThaiId,


### PR DESCRIPTION
## Tóm tắt
- **Mục tiêu**: Trả thêm `goiThauId` + `tenGoiThau` trong response của endpoint `GET api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do`.
- **Issue**: #179
- **Phạm vi ảnh hưởng**: Chỉ response DTO + query handler — không đổi request/contract hiện có.

## Thay đổi chính
- `ToTrinhThamDinhNhaThauDto`: thêm `GoiThauId` (Guid?) + `TenGoiThau` (string, default `string.Empty` — không bao giờ null để UI không lỗi).
- `ToTrinhThamDinhNhaThauGetDanhSachQuery`: projection `GoiThauId = e.GoiThauId`, `TenGoiThau = e.GoiThau != null ? e.GoiThau.Ten ?? string.Empty : string.Empty`; thêm `Include(e => e.GoiThau)`; refactor load `TepDinhKem` riêng sau phân trang (bỏ correlated subquery gây lỗi SQL APPLY trên SQLite).

## Test plan
- [x] `dotnet build SER.sln` — 0 lỗi, 0 warning
- [x] Verify DB dev-data.db: 4 bản ghi đều có `goiThauId`
