### PR TITLE
fix: GET chi-tiet QĐ duyệt KHLCNT trả thêm 5 field; docs lỗi đổi QuyTrinhId

### DIFF
--- a/.opencode/commands/pr.md
+++ b/.opencode/commands/pr.md
@@ -1,0 +1,52 @@
+---
+description: Generate Pull Request title and description from current changes
+agent: plan
+---
+
+Hãy tạo nội dung Pull Request cho branch hiện tại.
+
+Trước tiên phải kiểm tra:
+
+- `git status`
+- `git diff`
+- `git diff --staged`
+- các commit của branch hiện tại so với `main`
+
+Đọc code thực tế để hiểu thay đổi, không suy diễn từ tên branch.
+
+## Yêu cầu Title
+
+- Theo Conventional Commit.
+- Tóm tắt đúng các thay đổi chính.
+- Không dùng title chung chung như `Fix bug du an`.
+- Nếu có nhiều thay đổi liên quan, có thể nối bằng `;`.
+
+Ví dụ:
+
+`fix: GET chi-tiet QĐ duyệt KHLCNT trả thêm 5 field; docs lỗi đổi QuyTrinhId`
+
+Chỉ dùng ví dụ trên nếu changes thực tế đúng như vậy.
+
+## Yêu cầu Description
+
+Xuất Markdown theo đúng format:
+
+## Summary
+- Liệt kê ngắn gọn các thay đổi thực tế.
+- Nêu endpoint/module liên quan.
+- Không bịa requirement.
+
+## Test plan
+- [ ] Các API/case cần test dựa trên changes.
+- [ ] Các edge case liên quan.
+- [ ] Build/test nếu phù hợp.
+
+Không sửa code.
+
+Chỉ trả ra:
+
+Title:
+<PR title>
+
+Description:
+<markdown để copy vào GitHub>

--- a/QLDA.Application/QuyetDinhDuyetKHLCNTs/Queries/QuyetDinhDuyetKHLCNTGetQuery.cs
+++ b/QLDA.Application/QuyetDinhDuyetKHLCNTs/Queries/QuyetDinhDuyetKHLCNTGetQuery.cs
@@ -19,7 +19,9 @@ internal class QuyetDinhDuyetKHLCNTGetQueryHandler(IServiceProvider serviceProvi
 
     public async Task<QuyetDinhDuyetKHLCNT> Handle(QuyetDinhDuyetKHLCNTGetQuery request,
         CancellationToken cancellationToken = default) {
-        var queryable = QuyetDinhDuyetKHLCNT.GetOrderedSet().Include(e=> e.VanBanQuyetDinh)
+        var queryable = QuyetDinhDuyetKHLCNT.GetOrderedSet()
+            .Include(e => e.VanBanQuyetDinh)
+            .Include(e => e.KeHoachLuaChonNhaThau)
             .Where(e => e.Id == request.Id);
 
         if (request.IsNoTracking)

--- a/QLDA.WebApi/Models/QuyetDinhDuyetKHLCNTs/QuyetDinhDuyetKHLCNTMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/QuyetDinhDuyetKHLCNTs/QuyetDinhDuyetKHLCNTMappingConfiguration.cs
@@ -11,6 +11,11 @@ public static class QuyetDinhDuyetKHLCNTMappingConfiguration
         {
             Id = entity.Id,
             KeHoachLuaChonNhaThauId = entity.KeHoachLuaChonNhaThauId,
+            TongDuToan = entity.KeHoachLuaChonNhaThau?.TongDuToan ?? 0,
+            DuToanThamDinh = entity.KeHoachLuaChonNhaThau?.DuToanThamDinh,
+            NguonVonId = entity.KeHoachLuaChonNhaThau?.NguonVonId,
+            ThoiGianThucHien = entity.KeHoachLuaChonNhaThau?.ThoiGianThucHien,
+            SoLuongGoiThau = entity.KeHoachLuaChonNhaThau?.SoLuongGoiThau,
             VanBanQuyetDinh = new TongHopVanBanQuyetDinhs.VanBanQuyetDinhModel()
             {
                 DuAnId = entity.VanBanQuyetDinh!.DuAnId,

--- a/QLDA.WebApi/Models/QuyetDinhDuyetKHLCNTs/QuyetDinhDuyetKHLCNTModel.cs
+++ b/QLDA.WebApi/Models/QuyetDinhDuyetKHLCNTs/QuyetDinhDuyetKHLCNTModel.cs
@@ -17,5 +17,11 @@ public class QuyetDinhDuyetKHLCNTModel : IHasKey<Guid?>, IMustHaveId<Guid>, IMay
    
     public Guid? KeHoachLuaChonNhaThauId { get; set; }
 
+    public long TongDuToan { get; set; }
+    public long? DuToanThamDinh { get; set; }
+    public int? NguonVonId { get; set; }
+    public int? ThoiGianThucHien { get; set; }
+    public int? SoLuongGoiThau { get; set; }
+
     public List<TepDinhKemModel>? DanhSachTepDinhKem { get; set; }
 }

--- a/docs/issues/du-an-cap-nhat-quy-trinh-khong-the-doi/index.md
+++ b/docs/issues/du-an-cap-nhat-quy-trinh-khong-the-doi/index.md
@@ -1,0 +1,60 @@
+# Lỗi cập nhật Dự án — `PUT /api/du-an/cap-nhat` → "Quy trình không thể đổi"
+
+## Tóm tắt
+
+Khi **cập nhật Dự án** (`PUT du-an/cap-nhat`), nếu payload đổi `quyTrinhId` của một dự án **đã có tiến độ ghi nhận ở các bước (DuAnBuoc)** thì backend trả lỗi **"Quy trình không thể đổi"**, và phía FE lại nhìn thấy `500` / `"Response status code does not indicate success: 400 (Bad Request)."`.
+
+Đây là **lỗi nghiệp vụ (business validation)** có chủ đích trong code, không phải lỗi hệ thống ngẫu nhiên.
+
+---
+
+## Actor / người dùng bị ảnh hưởng
+
+- Người dùng có quyền **chỉnh sửa dự án** (Lãnh đạo phụ trách / Người tạo / Phòng ban phụ trách chính / Phòng ban phối hợp) thao tác sửa Dự án ở màn hình chi tiết dự án.
+
+---
+
+## Triệu chứng báo cáo
+
+| # | Triệu chứng | Mức độ |
+|---|-------------|--------|
+| 1 | UI hiện `Request failed with status code 500` | Blocker |
+| 2 | Network Response (body) lại là: `{ result: false, errorMessage: "Response status code does not indicate success: 400 (Bad Request).", dataResult: null, statusCode: 200 }` | — |
+| 3 | Lỗi chỉ xảy ra khi thay đổi **Quy trình** của dự án đã có tiến độ | High |
+
+---
+
+## Payload ví dụ
+
+```json
+{
+  "id": "08defc3c-2db8-a6d1-687a-7b252c02763d",
+  "tenDuAn": "kiểm tra tiến độ",
+  "quyTrinhId": 48,
+  "diaDiem": "..."
+}
+```
+
+> Lưu ý: Giá trị `quyTrinhId` (48 trong ví dụ / 46 trong log thật) **khác** với quy trình hiện tại của dự án ⇒ kích hoạt guard.
+
+---
+
+## Endpoint liên quan
+
+| Endpoint | Method | Controller |
+|----------|--------|------------|
+| `PUT /api/du-an/cap-nhat` | `Update` | `QLDA.WebApi/Controllers/DuAnController.cs:302` |
+
+---
+
+## File/điểm lỗi chính (root cause)
+
+- `QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs` — `DuAnUpdateCommandHandler.Handle`, dòng **51–54**
+- Helper `HasDuAnBuocTienDoAsync`, dòng **114–127**
+
+---
+
+## Liên quan
+
+- Middleware xử lý exception: `BuildingBlocks/src/BuildingBlocks.Application/Middlewares/ExceptionMiddleware.cs` (dòng 20–21)
+- Log chứng cứ: `QLDA.WebApi/logs/service-20260817.log` (dòng 1574, 1615)

--- a/docs/issues/du-an-cap-nhat-quy-trinh-khong-the-doi/journal.md
+++ b/docs/issues/du-an-cap-nhat-quy-trinh-khong-the-doi/journal.md
@@ -1,0 +1,17 @@
+# Work log — `du-an/cap-nhat` "Quy trình không thể đổi"
+
+## 2026-08-18
+
+- **Phân tích lỗi** `PUT /api/du-an/cap-nhat`.
+- Trace luồng: `DuAnController.Update` → `DuAnUpdateCommandHandler.Handle`.
+- Xác định root cause: guard tại `DuAnUpdateCommand.cs:51-54` ném `ManagedException("Quy trình không thể đổi")` khi request đổi `quyTrinhId` trên dự án đã có tiến độ (`HasDuAnBuocTienDoAsync`, dòng 114–127).
+- Xác nhận bằng log thật `QLDA.WebApi/logs/service-20260817.log` (dòng 1574, 1615).
+- Xác nhận phần `400 → 500` + chuỗi `"Response status code does not indicate success: 400"` không nằm trong code QLDA (không có `HttpClient`/`EnsureSuccessStatusCode`); do proxy/gateway trước QLDA gây ra.
+- Tạo bộ docs issue `du-an-cap-nhat-quy-trinh-khong-the-doi`: `index.md`, `report.md`, `test-workflow.md`, `journal.md`.
+
+### Quyết định / ghi chú
+
+- Chưa implement fix (đang chờ xác nhận nghiệp vụ: có cho phép đổi quy trình khi dự án đã nhập tiến độ không).
+- Nếu FE không nên đổi quy trình → Phương án A (không gửi `quyTrinhId`).
+- Nếu vẫn cần đổi → Phương án B (reset tiến độ DuAnBuoc trước khi clone).
+- Triệu chứng 400→500 → Phương án C (sửa proxy forward status thật).

--- a/docs/issues/du-an-cap-nhat-quy-trinh-khong-the-doi/report.md
+++ b/docs/issues/du-an-cap-nhat-quy-trinh-khong-the-doi/report.md
@@ -1,0 +1,195 @@
+# Báo cáo triển khai — Fix `du-an/cap-nhat` "Quy trình không thể đổi"
+
+**Module:** QLDA
+**Ngày:** 2026-08-18
+**Trạng thái:** Phân tích xong root cause — chưa implement
+**Pattern tham chiếu:** `DuAnUpdateCommand`, `DuAnBuocCloneCommand`, `ExceptionMiddleware`
+
+---
+
+## Mục lục
+
+1. [Tóm tắt vấn đề](#1-tóm-tắt-vấn-đề)
+2. [Chỗ lỗi (root cause)](#2-chỗ-lỗi-root-cause)
+3. [Luồng request](#3-luồng-request)
+4. [Vì sao 400 bị biến thành 500](#4-vì-sao-400-bị-biến-thành-500)
+5. [Field/value gây lỗi](#5-fieldvalue-gây-lỗi)
+6. [Cách sửa](#6-cách-sửa)
+7. [Files liên quan](#7-files-liên-quan)
+8. [Test plan](#8-test-plan)
+
+---
+
+## 1. Tóm tắt vấn đề
+
+### 1.1. Case test
+
+| Thuộc tính | Giá trị |
+|------------|---------|
+| Endpoint | `PUT /api/du-an/cap-nhat` |
+| `id` | `08defc3c-2db8-a6d1-687a-7b252c02763d` (payload user) / `08de9abc-c7ea-4b75-687a-7b210c03e6c1` (log thật) |
+| `quyTrinhId` | 48 (payload user) / 46 (log thật) — khác quy trình hiện tại |
+
+### 1.2. Triệu chứng
+
+| # | Triệu chứng | Mức độ |
+|---|-------------|--------|
+| 1 | FE báo `Request failed with status code 500` | Blocker |
+| 2 | Body trả về `errorMessage: "Response status code does not indicate success: 400 (Bad Request)."` | — |
+| 3 | Backend log ghi `"Quy trình không thể đổi"` | — |
+
+---
+
+## 2. Chỗ lỗi (root cause)
+
+### 2.1. Nơi ném lỗi
+
+```
+File:   QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs
+Method: DuAnUpdateCommandHandler.Handle — dòng 51–54
+```
+
+```csharp
+// dòng 51
+var doiQuyTrinh = entity.QuyTrinhId != request.Model.QuyTrinhId;
+ManagedException.ThrowIf(
+    doiQuyTrinh && await HasDuAnBuocTienDoAsync(entity.Id, cancellationToken),  // dòng 52-53
+    "Quy trình không thể đổi");                                                 // dòng 54
+```
+
+### 2.2. Helper kiểm tra tiến độ
+
+```
+File:   QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs
+Method: HasDuAnBuocTienDoAsync — dòng 114–127
+```
+
+```csharp
+private async Task<bool> HasDuAnBuocTienDoAsync(Guid duAnId, CancellationToken cancellationToken) {
+    return await DuAnBuoc.GetQueryableSet(OnlyUsed: false)
+        .AnyAsync(e =>
+            e.DuAnId == duAnId && (
+                e.NgayDuKienBatDau != null
+                || e.NgayDuKienKetThuc != null
+                || e.NgayThucTeBatDau != null
+                || e.NgayThucTeKetThuc != null
+                || e.TrangThaiId != null
+                || e.IsKetThuc
+                || (e.GhiChu != null && e.GhiChu != "")
+                || (e.TrachNhiemThucHien != null && e.TrachNhiemThucHien != "")
+            ), cancellationToken);
+}
+```
+
+### 2.3. Cơ chế kích hoạt
+
+Guard ném lỗi khi **đồng thời** thoả 2 điều kiện:
+
+1. **`doiQuyTrinh = true`** — `quyTrinhId` gửi lên khác `DuAn.QuyTrinhId` hiện tại.
+2. **`HasDuAnBuocTienDoAsync = true`** — dự án đã có ít nhất một `DuAnBuoc` mang dấu hiệu tiến độ:
+   - `NgayDuKienBatDau` / `NgayDuKienKetThuc` (ngày dự kiến)
+   - `NgayThucTeBatDau` / `NgayThucTeKetThuc` (ngày thực tế)
+   - `TrangThaiId`
+   - `IsKetThuc`
+   - `GhiChu` khác rỗng
+   - `TrachNhiemThucHien` khác rỗng
+
+> Ý nghĩa nghiệp vụ: không cho phép đổi quy trình khi dự án đã triển khai/ghi tiến độ, tránh dữ liệu `DuAnBuoc` (clone theo quy trình cũ) bị lệch so với quy trình mới.
+
+### 2.4. Bằng chứng log thật
+
+`QLDA.WebApi/logs/service-20260817.log`:
+
+```
+[2026-08-17 11:00:43  INF]  Request starting HTTP/1.1 PUT /api/du-an/cap-nhat
+[2026-08-17 11:00:43  INF]  Messenger Request: DuAnUpdateCommand {"Model":{...,"QuyTrinhId":46,...}}
+[2026-08-17 11:00:44  ERR]  Messenger Request: Unhandled Exception for Request DuAnUpdateCommand
+[2026-08-17 11:00:44  ERR]  HTTP PUT /api/du-an/cap-nhat responded 500
+[2026-08-17 11:00:44  ERR]  An error occurred with custom message: Quy trình không thể đổi. Full details: Quy trình không thể đổi
+[2026-08-17 11:00:44  INF]  Request finished HTTP/1.1 PUT /api/du-an/cap-nhat - 200
+```
+
+---
+
+## 3. Luồng request
+
+```mermaid
+sequenceDiagram
+    participant FE
+    participant Proxy as Proxy/Gateway (dxcenter)
+    participant Ctrl as DuAnController.Update
+    participant Cmd as DuAnUpdateCommandHandler
+    participant Auth as AuthorizationBehavior
+    participant Mid as ExceptionMiddleware
+
+    FE->>Proxy: PUT /api/du-an/cap-nhat
+    Proxy->>Ctrl: forward request (HttpClient + EnsureSuccessStatusCode)
+    Ctrl->>Cmd: Mediator.Send(DuAnUpdateCommand)
+    Cmd->>Cmd: entity.Update(model) → doiQuyTrinh = true
+    Cmd->>Cmd: HasDuAnBuocTienDoAsync(duAnId) = true
+    Cmd-->>Auth: throw ManagedException "Quy trình không thể đổi"
+    Auth-->>Mid: exception truyền ra
+    Mid-->>Ctrl: HTTP 200 + {result:false,errorMessage:"Quy trình không thể đổi",statusCode:200}
+    Ctrl-->>Proxy: HTTP 200 (ManagedException path)
+    alt Proxy dùng EnsureSuccessStatusCode
+        Proxy-->>FE: HTTP 500 + {errorMessage:"Response status code does not indicate success: 400"}
+    end
+```
+
+---
+
+## 4. Vì sao 400 bị biến thành 500
+
+- **Backend QLDA** không hề có `HttpClient` / `EnsureSuccessStatusCode`; chuỗi `"Response status code does not indicate success: 400"` **không tồn tại trong code QLDA** (`git grep` ra 0 kết quả ở source, chỉ có trong `QLDA.Tests`).
+- `ManagedException` được `ExceptionMiddleware` (`BuildingBlocks.Application/Middlewares/ExceptionMiddleware.cs:20-21`) bắt và trả **HTTP 200**, body `{result:false, errorMessage:"Quy trình không thể đổi", statusCode:200}`.
+- Chuỗi `"Response status code does not indicate success: 400 (Bad Request)."` + mã **500** là do **proxy/gateway trước QLDA** (dxcenter) gọi QLDA bằng `HttpClient.EnsureSuccessStatusCode()`. Khi QLDA trả status không phải 2xx, proxy ném exception này và trả **500** cho FE, đồng thời đè body bằng message của `HttpRequestException`.
+
+> Kết luận: lỗi thật là **"Quy trình không thể đổi"**; phần `400 → 500` là do proxy che đi message thật.
+
+---
+
+## 5. Field/value gây lỗi
+
+| Field | Giá trị FE gửi | Backend yêu cầu |
+|-------|----------------|-----------------|
+| `quyTrinhId` | 48 (ví dụ) / 46 (log thật) — khác quy trình hiện tại | Không cho đổi vì dự án đã có tiến độ ở `DuAnBuoc` |
+
+Các field khác (`id`, `tenDuAn`, `diaDiem`) đều hợp lệ; model binding và validation pass.
+
+---
+
+## 6. Cách sửa
+
+> Chọn phương án theo nghiệp vụ. Không thay đổi những phần không liên quan.
+
+### Phương án A (khuyến nghị — đúng nghiệp vụ): FE không đổi quy trình khi đã có tiến độ
+
+- Khi dự án đã nhập tiến độ, FE **không gửi** `quyTrinhId` (hoặc gửi đúng giá trị hiện tại) trong lúc sửa.
+- Không cần đổi backend; guard vẫn bảo vệ dữ liệu.
+
+### Phương án B: Cho phép đổi nhưng xử lý dữ liệu DuAnBuoc
+
+- Trước khi đổi quy trình, **xoá tiến độ / reset** các `DuAnBuoc` cũ, rồi gọi `DuAnBuocCloneCommand` để clone lại theo quy trình mới.
+- Vị trí sửa: `DuAnUpdateCommand.cs` (bỏ/siết guard) + `DuAnController.Update` (đã gọi `DuAnBuocCloneCommand` khi quy trình đổi, dòng 322–325).
+
+### Phương án C: Sửa tầng proxy (giải quyết triệu chứng 400→500)
+
+- Proxy không dùng `EnsureSuccessStatusCode()` mù; **forward đúng HTTP status + body** thật của QLDA xuống FE để FE hiển thị message rõ ràng thay vì `500`.
+
+---
+
+## 7. Files liên quan
+
+| File | Vai trò |
+|------|---------|
+| `QLDA.Application/DuAns/Commands/DuAnUpdateCommand.cs` | Nơi ném `"Quy trình không thể đổi"` (dòng 51–54, 114–127) |
+| `QLDA.WebApi/Controllers/DuAnController.cs` | Endpoint `Update` (dòng 302–368); gọi clone khi đổi quy trình |
+| `QLDA.Application/DuAnBuocs/Commands/DuAnBuocCloneCommand.cs` | Clone bước theo quy trình |
+| `BuildingBlocks.Application/Middlewares/ExceptionMiddleware.cs` | Bắt exception, quyết định HTTP status |
+| `QLDA.WebApi/logs/service-20260817.log` | Log chứng cứ lỗi |
+
+---
+
+## 8. Test plan
+
+Xem chi tiết tại [test-workflow.md](test-workflow.md).

--- a/docs/issues/du-an-cap-nhat-quy-trinh-khong-the-doi/test-workflow.md
+++ b/docs/issues/du-an-cap-nhat-quy-trinh-khong-the-doi/test-workflow.md
@@ -1,0 +1,57 @@
+# Test workflow — `du-an/cap-nhat` "Quy trình không thể đổi"
+
+Hướng dẫn tái hiện, xác nhận lỗi và kiểm thử sau khi sửa.
+
+---
+
+## 1. Chuẩn bị
+
+- Chạy `QLDA.WebApi` (cấu hình DB `VI_DACDT` như log: server `192.168.1.13\sql2k16r2, 1439` — **chỉ dùng môi trường test/dev, không chạy migration lên prod**).
+- Có token hợp lệ của user có quyền sửa dự án.
+- Chọn 1 dự án **đã có tiến độ** ở các bước (kiểm tra `DuAnBuoc` có `NgayDuKien*` / `TrangThaiId` / `GhiChu`...).
+
+## 2. Tái hiện lỗi (trước fix)
+
+```http
+PUT /api/du-an/cap-nhat
+Content-Type: application/json
+Authorization: Bearer <token>
+
+{
+  "id": "<duAnId đã có tiến độ>",
+  "tenDuAn": "test đổi quy trình",
+  "quyTrinhId": "<một quy trình KHÁC quy trình hiện tại>",
+  "diaDiem": "test"
+}
+```
+
+**Kỳ vọng (bug):**
+- Backend log: `ERR ... custom message: Quy trình không thể đổi`
+- FE / proxy: `500` + `"Response status code does not indicate success: 400 (Bad Request)."`
+- (Nếu gọi thẳng QLDA không qua proxy) response body: `{ result:false, errorMessage:"Quy trình không thể đổi", statusCode:200 }`
+
+## 3. Ca kiểm thử sau fix
+
+| # | Kịch bản | Payload | Kỳ vọng |
+|---|----------|---------|---------|
+| 1 | Đổi quy trình của dự án **có tiến độ** | `quyTrinhId` khác | Tuỳ phương án: chặn với message rõ ràng (A) hoặc đổi + reset tiến độ (B) |
+| 2 | Sửa dự án **giữ nguyên quy trình** | `quyTrinhId` = quy trình hiện tại | ✅ Thành công, không lỗi |
+| 3 | Sửa dự án **chưa có tiến độ** | `quyTrinhId` khác | ✅ Được phép đổi, `DuAnBuoc` clone lại |
+| 4 | Sửa dự án **không gửi `quyTrinhId`** | thiếu field | ✅ Thành công (field optional) |
+| 5 | `id` không tồn tại | `id` = random | `ManagedException "Không tìm thấy dữ liệu"` (HTTP 200) |
+| 6 | Không có quyền sửa | token user không thuộc phòng | `ForbiddenException` (HTTP 200 / body 403) |
+
+## 4. Xác nhận fix
+
+1. Chạy lại các ca 1–6 ở trên.
+2. Kiểm tra body trả về từ FE phải hiển thị message thật (`"Quy trình không thể đổi"` hoặc message mới theo nghiệp vụ), **không còn** `"Response status code does not indicate success: 400"`.
+3. Nếu sửa proxy (Phương án C): đảm bảo HTTP status + body forward đúng.
+
+## 5. Chạy test hiện có
+
+```powershell
+# từ thư mục gốc repo
+.\test.bat
+```
+
+Kiểm tra không vỡ các test liên quan Dự án / DuAnBuoc clone (xem `QLDA.Tests/Integration`).

--- a/docs/issues/quyet-dinh-duyet-khlcnt-chi-tiet-thieu-field/index.md
+++ b/docs/issues/quyet-dinh-duyet-khlcnt-chi-tiet-thieu-field/index.md
@@ -1,0 +1,83 @@
+# API chi tiết Quyết định duyệt KHLCNT thiếu 5 field
+
+## Tóm tắt vấn đề
+
+Endpoint **GET `api/quyet-dinh-duyet-khlcnt/{id}/chi-tiet`** hiện chưa trả về 5 field:
+
+| Field            | Kiểu   | Ý nghĩa                          |
+| ---------------- | ------ | -------------------------------- |
+| `tongDuToan`     | long   | Tổng dự toán                     |
+| `duToanThamDinh` | long?  | Dự toán thẩm định                |
+| `nguonVonId`     | int?   | Nguồn vốn (theo nguồn vốn dự án) |
+| `thoiGianThucHien`| int?  | Thời gian thực hiện (năm)        |
+| `soLuongGoiThau` | int?   | Số lượng gói thầu                |
+
+## Case test
+
+- Endpoint: `api/quyet-dinh-duyet-khlcnt/chi-tiet`
+- `id = 08DEFCD8-E0D5-5A24-687A-7B2A14078F2D`
+
+Kết quả mong đợi (giá trị mẫu để kiểm tra, không hard-code trong code):
+
+```json
+{
+  "tongDuToan": 1234567,
+  "duToanThamDinh": 1234567,
+  "nguonVonId": 16,
+  "thoiGianThucHien": 1,
+  "soLuongGoiThau": 1
+}
+```
+
+## Phân tích nguyên nhân gốc
+
+5 field trên **không nằm trên entity** `QuyetDinhDuyetKHLCNT` mà nằm trên entity liên kết
+**`KeHoachLuaChonNhaThau`**, được trỏ qua `QuyetDinhDuyetKHLCNT.KeHoachLuaChonNhaThauId` (quan hệ 1-1).
+
+| Tầng            | File                                                                      | Trạng thái                                              |
+| --------------- | ------------------------------------------------------------------------- | ------------------------------------------------------- |
+| Entity          | `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs` (dòng 20-40)              | ✅ Đã có 5 field                                         |
+| EF Config / DB  | Bảng `KeHoachLuaChonNhaThau`                                              | ✅ Đã có cột (entity + DB sẵn sàng, không cần migration) |
+| Query Handler   | `QLDA.Application/.../Queries/QuyetDinhDuyetKHLCNTGetQuery.cs` (dòng 22)  | ❌ Không `Include(e => e.KeHoachLuaChonNhaThau)`         |
+| Response Model  | `QLDA.WebApi/Models/.../QuyetDinhDuyetKHLCNTModel.cs`                     | ❌ Không có 5 property                                   |
+| Mapping ToModel | `QLDA.WebApi/Models/.../QuyetDinhDuyetKHLCNTMappingConfiguration.cs`      | ❌ Không map 5 field                                     |
+
+### Flow hiện tại
+
+1. `QuyetDinhDuyetKHLCNTController.Get` (line 29) gọi `QuyetDinhDuyetKHLCNTGetQuery`.
+2. `QuyetDinhDuyetKHLCNTGetQueryHandler` (line 22) chỉ `.Include(e => e.VanBanQuyetDinh)`
+   → `entity.KeHoachLuaChonNhaThau` trả về `null`.
+3. `QuyetDinhDuyetKHLCNTMappingConfiguration.ToModel` (line 8-28) chỉ map
+   `Id, KeHoachLuaChonNhaThauId, VanBanQuyetDinh, DanhSachTepDinhKem` → không map 5 field
+   (cũng không có gì để map vì navigation đang null).
+
+### Vì sao "đúng nguyên nhân"
+
+- Entity `KeHoachLuaChonNhaThau` và DB đã có đủ dữ liệu (đây là dữ liệu thật của KHLCNT, không phải tạo mới).
+- 5 field chỉ đơn thuần **chưa được Include / khai báo / map** trong luồng chi tiết.
+- Không cần migration, không cần model mới, không hard-code.
+
+## Kế hoạch sửa (chỉ tác động endpoint chi tiết)
+
+1. **`QuyetDinhDuyetKHLCNTGetQuery.cs`** — thêm `.Include(e => e.KeHoachLuaChonNhaThau)`.
+2. **`QuyetDinhDuyetKHLCNTModel.cs`** — thêm 5 property khớp kiểu entity.
+3. **`QuyetDinhDuyetKHLCNTMappingConfiguration.ToModel`** — map 5 field từ `entity.KeHoachLuaChonNhaThau`.
+
+## Phạm vi ngoài chi tiết (đã rà soát)
+
+- **`danh-sach-tien-do`** (`QuyetDinhDuyetKHLCNTGetDanhSachQuery` + `QuyetDinhDuyetKHLCNTDto`) — **cũng thiếu** 5 field
+  (DTO không có property, projection không select, không Include). Đây là phạm vi mở rộng tùy chọn.
+- **`them-moi` / `cap-nhat`** — không bị ảnh hưởng: 5 field là dữ liệu chỉ-đọc đến từ KHLCNT, không nằm trong write-path
+  của Quyết định duyệt KHLCNT.
+
+## Ràng buộc (không làm)
+
+- Không tạo migration (DB đã có cột).
+- Không tạo model mới trong `QLDA.WebApi`.
+- Không refactor lan sang endpoint khác (trừ khi được xác nhận mở rộng).
+- Không hard-code giá trị mẫu.
+
+## Tài liệu liên quan
+
+- Issue gốc: mô tả ở trên.
+- Luồng chuẩn tham chiếu (module KHLCNT trả đủ field): `KeHoachLuaChonNhaThauMappings.cs`, `KeHoachLuaChonNhaThauGetDanhSachQuery.cs`.

--- a/docs/issues/quyet-dinh-duyet-khlcnt-chi-tiet-thieu-field/journal.md
+++ b/docs/issues/quyet-dinh-duyet-khlcnt-chi-tiet-thieu-field/journal.md
@@ -1,0 +1,9 @@
+# Nhật ký công việc — API chi tiết Quyết định duyệt KHLCNT thiếu 5 field
+
+## 2026-08-18
+
+- Trace flow `Controller → Query/Handler → DTO/Model → Mapping → Entity → EF Config`.
+- Xác định nguyên nhân: 5 field nằm trên `KeHoachLuaChonNhaThau`; luồng chi tiết thiếu
+  `Include`, thiếu property trên Model, thiếu mapping `ToModel`.
+- Rà soát phạm vi: endpoint `danh-sach-tien-do` cũng thiếu; `them-moi`/`cap-nhat` không bị ảnh hưởng.
+- Viết tài liệu phân tích (`index.md`, `report.md`, `test-workflow.md`, `journal.md`).

--- a/docs/issues/quyet-dinh-duyet-khlcnt-chi-tiet-thieu-field/report.md
+++ b/docs/issues/quyet-dinh-duyet-khlcnt-chi-tiet-thieu-field/report.md
@@ -1,0 +1,43 @@
+# Báo cáo triển khai — API chi tiết Quyết định duyệt KHLCNT thiếu 5 field
+
+## Tóm tắt
+
+Bổ sung 5 field `TongDuToan, DuToanThamDinh, NguonVonId, ThoiGianThucHien, SoLuongGoiThau`
+cho endpoint **GET `api/quyet-dinh-duyet-khlcnt/{id}/chi-tiet`**. Các field này đã tồn tại trên
+entity `KeHoachLuaChonNhaThau` và DB; chỉ thiếu ở tầng Include + Model + Mapping của endpoint chi tiết.
+
+## Nguyên nhân
+
+`QuyetDinhDuyetKHLCNT` không chứa 5 field; chúng nằm trên entity liên kết `KeHoachLuaChonNhaThau`
+(1-1 qua `KeHoachLuaChonNhaThauId`). Luồng chi tiết:
+- Query Handler không `Include(KeHoachLuaChonNhaThau)` → navigation null.
+- Model không khai báo 5 property.
+- Mapping `ToModel` không map.
+
+## Kiến trúc / Cách tiếp cận
+
+Clean Architecture + CQRS. Thay đổi thuộc đúng lớp:
+- **Application**: Query Handler bổ sung `Include` (đọc dữ liệu).
+- **WebApi**: Model khai báo property, Mapping `ToModel` map từ navigation.
+
+Không thêm `Application/Services`, không đưa business logic vào Controller, không migration
+(vì DB đã có cột trong bảng `KeHoachLuaChonNhaThau`).
+
+## Thay đổi code
+
+| # | File | Nội dung |
+| - | ---- | -------- |
+| 1 | `QLDA.Application/QuyetDinhDuyetKHLCNTs/Queries/QuyetDinhDuyetKHLCNTGetQuery.cs` | Thêm `.Include(e => e.KeHoachLuaChonNhaThau)` |
+| 2 | `QLDA.WebApi/Models/QuyetDinhDuyetKHLCNTs/QuyetDinhDuyetKHLCNTModel.cs` | Thêm 5 property |
+| 3 | `QLDA.WebApi/Models/QuyetDinhDuyetKHLCNTs/QuyetDinhDuyetKHLCNTMappingConfiguration.cs` | `ToModel` map 5 field từ `entity.KeHoachLuaChonNhaThau` |
+
+## Trạng thái
+
+- [ ] Đang triển khai / chờ duyệt phạm vi
+- [ ] Build thành công
+- [ ] Test case `08DEFCD8-E0D5-5A24-687A-7B2A14078F2D` trả đủ 5 field
+- [ ] Đã kiểm tra regression
+
+## PR
+
+(chưa tạo)

--- a/docs/issues/quyet-dinh-duyet-khlcnt-chi-tiet-thieu-field/test-workflow.md
+++ b/docs/issues/quyet-dinh-duyet-khlcnt-chi-tiet-thieu-field/test-workflow.md
@@ -1,0 +1,45 @@
+# Hướng dẫn kiểm thử — API chi tiết Quyết định duyệt KHLCNT thiếu 5 field
+
+## Build
+
+```bash
+dotnet build SER.sln
+```
+
+## Case test thủ công
+
+Endpoint: `GET api/quyet-dinh-duyet-khlcnt/{id}/chi-tiet`
+
+Case: `id = 08DEFCD8-E0D5-5A24-687A-7B2A14078F2D`
+
+Kiểm tra response có đủ 5 field với giá trị thật lấy từ bảng `KeHoachLuaChonNhaThau`
+(liên kết qua `KeHoachLuaChonNhaThauId`):
+
+```json
+{
+  "id": "08DEFCD8-E0D5-5A24-687A-7B2A14078F2D",
+  "tongDuToan": ...,
+  "duToanThamDinh": ...,
+  "nguonVonId": ...,
+  "thoiGianThucHien": ...,
+  "soLuongGoiThau": ...,
+  "vanBanQuyetDinh": {...},
+  "danhSachTepDinhKem": [...]
+}
+```
+
+## Verification SQL (kiểm tra dữ liệu nguồn)
+
+```sql
+SELECT k.TongDuToan, k.DuToanThamDinh, k.NguonVonId, k.ThoiGianThucHien, k.SoLuongGoiThau
+FROM QuyetDinhDuyetKHLCNT q
+JOIN KeHoachLuaChonNhaThau k ON k.Id = q.KeHoachLuaChonNhaThauId
+WHERE q.Id = '08DEFCD8-E0D5-5A24-687A-7B2A14078F2D';
+```
+
+Response API phải khớp kết quả truy vấn trên.
+
+## Regression
+
+- Endpoint `danh-sach-tien-do` (nếu có mở rộng phạm vi) trả đủ 5 field.
+- `them-moi` / `cap-nhat` không đổi hành vi.


### PR DESCRIPTION
## Summary
- `GET /api/quyet-dinh-duyet-khlcnt/{id}/chi-tiet` thiếu `tongDuToan`, `duToanThamDinh`, `nguonVonId`, `thoiGianThucHien`, `soLuongGoiThau`. 5 field lấy từ `KeHoachLuaChonNhaThau` (1-1 qua `KeHoachLuaChonNhaThauId`): Include trong GetQuery, khai báo Model, map `ToModel`. Không migration.
- Bổ sung tài liệu issue cập nhật dự án bị chặn đổi `QuyTrinhId` khi đã có tiến độ (`PUT /api/du-an/cap-nhat` → `"Quy trình không thể đổi"`). Đây là business validation, không phải crash ngẫu nhiên.

## Test plan
- [ ] GET chi tiết QĐ duyệt KHLCNT: JSON có đủ 5 field, giá trị khớp KHLCNT liên kết
- [ ] Record không có `KeHoachLuaChonNhaThauId` / navigation null → 5 field default, API không 500
- [ ] PUT `du-an/cap-nhat` đổi QT khi bước đã có tiến độ → `result: false`, message `"Quy trình không thể đổi"` (hành vi hiện tại, đã document)