### PR TITLE
fix(to-trinh-tham-dinh-nha-thau): bổ sung file Tờ trình kết quả trong danh sách tiến độ

### DIFF
--- a/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs
@@ -3,6 +3,8 @@ using QLDA.Application.Common.Interfaces;
 using QLDA.Application.Common.Mapping;
 using QLDA.Application.TepDinhKems.DTOs;
 using QLDA.Application.ToTrinhThamDinhNhaThaus.DTOs;
+using QLDA.Domain.Constants;
+using QLDA.Domain.Enums;
 
 namespace QLDA.Application.ToTrinhThamDinhNhaThaus.Queries;
 
@@ -32,6 +34,9 @@ internal class    ToTrinhThamDinhNhaThauDanhSachQueryHandler(IServiceProvider Se
     private readonly IRepository<ToTrinhThamDinhNhaThau, Guid> ToTrinhThamDinhNhaThau =  ServiceProvider.GetRequiredService<IRepository<ToTrinhThamDinhNhaThau, Guid>>();
 
     private readonly IRepository<Attachment, Guid> TepDinhKem = ServiceProvider.GetRequiredService<IRepository<Attachment, Guid>>();
+
+    private readonly IRepository<ToTrinhQuyetDinh, long> ToTrinhQuyetDinh =
+        ServiceProvider.GetRequiredService<IRepository<ToTrinhQuyetDinh, long>>();
 
     private readonly IUserProvider User = ServiceProvider.GetRequiredService<IUserProvider>();
 
@@ -75,6 +80,36 @@ internal class    ToTrinhThamDinhNhaThauDanhSachQueryHandler(IServiceProvider Se
             item.DanhSachTepDinhKem = item.Id is { } id && tepDinhKemByGroupId.TryGetValue(id.ToString(), out var files)
                 ? files
                 : [];
+
+        // File "Tờ trình kết quả" — GroupId là ToTrinhQuyetDinh.Id (long), không nằm trong
+        // groupIds của toTrinh nên danh-sach-tien-do sót file mà chi-tiet vẫn đủ (Issue #179).
+        var toTrinhIds = result.Data.Select(x => x.Id).ToList();
+        var toTrinhQuyetDinhs = toTrinhIds.Count == 0
+            ? []
+            : await ToTrinhQuyetDinh.GetQueryableSet().AsNoTracking()
+                .Where(e => toTrinhIds.Contains(e.EntityId) && e.Loai == ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau)
+                .Select(e => new { e.Id, e.EntityId })
+                .ToListAsync(cancellationToken);
+
+        var ketQuaGroupIds = toTrinhQuyetDinhs.Select(x => x.Id.ToString()).ToList();
+        var ketQuaFiles = ketQuaGroupIds.Count == 0
+            ? []
+            : await TepDinhKem.GetQueryableSet().AsNoTracking()
+                .Where(i => ketQuaGroupIds.Contains(i.GroupId) && i.GroupType == nameof(EGroupType.ToTrinhQuyetDinh))
+                .Select(i => i.ToDto())
+                .ToListAsync(cancellationToken);
+
+        var ketQuaByToTrinhId = toTrinhQuyetDinhs
+            .Where(x => x.EntityId.HasValue)
+            .SelectMany(x => ketQuaFiles.Where(f => f.GroupId == x.Id.ToString()), (x, f) => new { x.EntityId, f })
+            .GroupBy(x => x.EntityId!.Value)
+            .ToDictionary(g => g.Key, g => g.Select(x => x.f).ToList());
+
+        foreach (var item in result.Data)
+        {
+            if (item.Id is { } id && ketQuaByToTrinhId.TryGetValue(id, out var files))
+                item.DanhSachTepDinhKem = item.DanhSachTepDinhKem!.Concat(files).DistinctBy(f => f.Id).ToList();
+        }
 
         return result;
     }

--- a/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/index.md
+++ b/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/index.md
@@ -1,0 +1,63 @@
+# Danh sách tiến độ Tờ trình thẩm định nhà thầu thiếu file "Tờ trình kết quả"
+
+> Ngày ghi nhận: 19/08/2026  
+> Trạng thái: ✅ **IMPLEMENTED** (19/08/2026)  
+> Effort thực tế: ~20 phút (BE only, không migration)
+
+## Mô tả
+
+`GET /api/to-trinh-tham-dinh-nha-thau/{id}/chi-tiet` trả **7 file** đầy đủ, nhưng
+`GET /api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do` chỉ trả **6/7 file** cho cùng
+một Tờ trình — thiếu đúng 1 file **"Tờ trình kết quả"** (nhóm `ToTrinhQuyetDinh`).
+Lỗi xảy ra **đồng loạt** cho mọi dòng trong danh sách (VD item `08defd97…` và `08defc12…`).
+
+### Endpoint liên quan
+
+```http
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/{id}/chi-tiet
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=<guid>&BuocId=7040&PageIndex=1&PageSize=10
+```
+
+## Nguyên nhân
+
+File của Tờ trình **được lưu ở 2 nhóm group khác nhau**:
+
+| Nhóm | `groupId` | `groupType` | Số file |
+| ---- | --------- | ----------- | ------- |
+| File trực tiếp của Tờ trình | `ToTrinhThamDinhNhaThau.Id` (Guid) | `ToTrinhThamDinhNhaThau_*` (EHSDT, FileDanhGia, DoiChieu, ThuongThao, ThamDinh, QuyetDinh) | 6 |
+| **File "Tờ trình kết quả"** | **`ToTrinhQuyetDinh.Id` (long)** | `ToTrinhQuyetDinh` | 1 |
+
+- **`chi-tiet`** (`ToTrinhThamDinhNhaThauController.cs:62–70`) gộp **cả 2 nhóm** → đủ 7 file.
+- **`danh-sach-tien-do`** (`ToTrinhThamDinhNhaThauGetDanhSachQuery.cs:64–77`) chỉ load attachment với
+  `GroupId ∈ {toTrinh entity id}` → file Tờ trình kết quả có `groupId = ToTrinhQuyetDinh.Id`
+  ("20089", dạng long) **không khớp** → bị sót → 6/7.
+
+Thiết kế lưu file theo `ToTrinhQuyetDinh.Id` là **có chủ đích** (comment controller dòng 62) →
+fix đúng chỗ là bổ sung vào query danh sách, không đổi cách lưu.
+
+## Kết quả implement
+
+| # | Hạng mục | Trạng thái |
+|---|----------|------------|
+| 1 | `ToTrinhThamDinhNhaThauGetDanhSachQuery` — gộp file ToTrinhQuyetDinh | ✅ |
+| 2 | `dotnet build` (QLDA.Application) | ✅ 0 Error |
+| 3 | Smoke test manual (2 item 7/7 file) | ⏳ Pending |
+
+**Files sẽ sửa:**
+
+- `QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`
+
+**Không sửa:** controller, cách lưu file, migration, `chi-tiet`.
+
+## Tài liệu triển khai
+
+- **[report.md](report.md)** — Spec kỹ thuật + code sau fix + smoke test.
+  - [§0 Trạng thái](report.md#0-trạng-thái)
+  - [§3 Code sau fix](report.md#3-trạng-thái-code-sau-fix)
+  - [§8 Smoke test](report.md#8-smoke-test-manual)
+
+## Tham chiếu
+
+- Entity `ToTrinhQuyetDinh` (bảng dùng chung, `EntityId` + `Loai`): `QLDA.Domain/Entities/ToTrinhQuyetDinh.cs`
+- `ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau`: `QLDA.Domain/Constants/ToTrinhQuyetDinhLoai.cs`
+- Pattern load file theo groupId trong danh sách: `QuanLyPheDuyet/Queries/PheDuyetQueryableExtensions.cs`

--- a/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/journal.md
+++ b/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/journal.md
@@ -1,0 +1,25 @@
+# Journal — `danh-sach-tien-do` Tờ trình thẩm định nhà thầu sót file "Tờ trình kết quả"
+
+## 19/08 — Ghi nhận + khảo sát + docs
+
+- Báo lỗi: `chi-tiet` trả 7 file, `danh-sach-tien-do` chỉ 6/7 cho cùng Tờ trình (item `08defd97…`, `08defc12…`).
+- Khảo sát:
+  - File Tờ trình kết quả được lưu với `GroupId = ToTrinhQuyetDinh.Id` (long), `GroupType = ToTrinhQuyetDinh` (controller tạo mới dòng 173–196, chi-tiet đọc dòng 62–70).
+  - `ToTrinhThamDinhNhaThauGetDanhSachQuery` chỉ load attachment `GroupId ∈ {toTrinh entity ids}` (dòng 64–77) → sót nhóm `ToTrinhQuyetDinh`.
+  - `ToTrinhQuyetDinh` liên kết qua `EntityId` + `Loai = ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau`.
+- Quyết định: fix ở **query danh sách** (gộp thêm file nhóm `ToTrinhQuyetDinh`), không đổi cách lưu / chi-tiet / controller.
+- Tạo docs: `docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/` (index.md, report.md).
+
+**Files dự kiến sửa:**
+- `QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`
+
+## 19/08 — Implement
+
+- Đã sửa `ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`:
+  - Thêm `IRepository<ToTrinhQuyetDinh, long>` + using `QLDA.Domain.Constants` / `QLDA.Domain.Enums`.
+  - Sau khi gán `DanhSachTepDinhKem` theo groupId hiện có, query `ToTrinhQuyetDinh`
+    (`EntityId ∈ toTrinhIds && Loai == "ToTrinhThamDinhNhaThau"`), load attachment
+    (`GroupId ∈ ToTrinhQuyetDinh.Id`, `GroupType == "ToTrinhQuyetDinh"`) và append vào
+    từng item qua `EntityId` (`DistinctBy(f => f.Id)`).
+- Build `QLDA.Application` — 0 Error(s), 0 Warning(s).
+- Build `QLDA.WebApi` bị chặn do process đang chạy (PID 13180) khóa DLL — chỉ là lỗi copy, không phải compile error.

--- a/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/report.md
+++ b/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/report.md
@@ -1,0 +1,212 @@
+# Report — `danh-sach-tien-do` Tờ trình thẩm định nhà thầu sót file "Tờ trình kết quả"
+
+*Survey codebase — 19/08/2026 · Implemented — 19/08/2026*
+
+---
+
+## 0. Trạng thái
+
+| Hạng mục | Trạng thái | Ghi chú |
+| -------- | ---------- | ------- |
+| Investigation / docs | ✅ Done | File này |
+| `ToTrinhThamDinhNhaThauGetDanhSachQuery` | ✅ Done | Gộp file nhóm `ToTrinhQuyetDinh` |
+| Controller / `chi-tiet` | ✅ Không sửa | Giữ nguyên cách load hiện có |
+| Migration | ✅ Không cần | Chỉ query |
+| `dotnet build` | ✅ Done | `QLDA.Application` 0 Error; WebApi chỉ bị lock DLL do app đang chạy |
+| Smoke test manual | ⏳ Pending | Mẫu ở [§8](#8-smoke-test-manual) |
+
+---
+
+## 1. Tóm tắt
+
+| Thuộc tính | Giá trị |
+| ---------- | ------- |
+| Issue | `danh-sach-tien-do` thiếu 1 file Tờ trình kết quả (6/7) so với `chi-tiet` |
+| Status | ✅ **IMPLEMENTED** |
+| Method | `GET` |
+| URL | `/QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do` |
+| Controller | `ToTrinhThamDinhNhaThauController.Get` (dòng 295) |
+| Handler | `ToTrinhThamDinhNhaThauDanhSachQueryHandler` |
+| Migration | **Không** cần |
+
+---
+
+## 2. Luồng xử lý
+
+```
+GET /api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=…&BuocId=…
+        │
+        ▼
+ToTrinhThamDinhNhaThauController.Get
+        │
+        ▼
+ToTrinhThamDinhNhaThauDanhSachQueryHandler.Handle
+        │
+        ├─ queryable = ToTrinhThamDinhNhaThau (Include GoiThau) → PaginatedList
+        │
+        ├─ Load attachment: GroupId ∈ {toTrinh entity ids}   ← 6 file (nhóm ToTrinhThamDinhNhaThau_*)
+        │
+        ├─ ✅ MỚI: Load ToTrinhQuyetDinh (EntityId ∈ toTrinh ids && Loai == "ToTrinhThamDinhNhaThau")
+        │         → load attachment: GroupId ∈ {ToTrinhQuyetDinh.Id} (groupType ToTrinhQuyetDinh)
+        │         → append vào DanhSachTepDinhKem từng item qua EntityId   ← +1 file
+        │
+        └─ return result
+```
+
+---
+
+## 3. Trạng thái code sau fix
+
+### 3.1 `ToTrinhThamDinhNhaThauGetDanhSachQuery.cs` — sau fix
+
+**Thêm using:**
+
+```csharp
+using QLDA.Domain.Constants;   // ToTrinhQuyetDinhLoai
+using QLDA.Domain.Enums;       // EGroupType
+```
+
+**Thêm field (cạnh `TepDinhKem`):**
+
+```csharp
+private readonly IRepository<ToTrinhQuyetDinh, long> ToTrinhQuyetDinh =
+    ServiceProvider.GetRequiredService<IRepository<ToTrinhQuyetDinh, long>>();
+```
+
+**Thêm block gộp file Tờ trình kết quả (sau vòng gán `DanhSachTepDinhKem` hiện tại):**
+
+```csharp
+// File "Tờ trình kết quả" — GroupId là ToTrinhQuyetDinh.Id (long), không nằm trong
+// groupIds của toTrinh nên danh-sach-tien-do sót file mà chi-tiet vẫn đủ (Issue #179).
+var toTrinhIds = result.Data.Select(x => x.Id).ToList();
+var toTrinhQuyetDinhs = toTrinhIds.Count == 0
+    ? []
+    : await ToTrinhQuyetDinh.GetQueryableSet().AsNoTracking()
+        .Where(e => toTrinhIds.Contains(e.EntityId) && e.Loai == ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau)
+        .Select(e => new { e.Id, e.EntityId })
+        .ToListAsync(cancellationToken);
+
+var ketQuaGroupIds = toTrinhQuyetDinhs.Select(x => x.Id.ToString()).ToList();
+var ketQuaFiles = ketQuaGroupIds.Count == 0
+    ? []
+    : await TepDinhKem.GetQueryableSet().AsNoTracking()
+        .Where(i => ketQuaGroupIds.Contains(i.GroupId) && i.GroupType == nameof(EGroupType.ToTrinhQuyetDinh))
+        .Select(i => i.ToDto())
+        .ToListAsync(cancellationToken);
+
+var ketQuaByToTrinhId = toTrinhQuyetDinhs
+    .Where(x => x.EntityId.HasValue)
+    .SelectMany(x => ketQuaFiles.Where(f => f.GroupId == x.Id.ToString()), (x, f) => new { x.EntityId, f })
+    .GroupBy(x => x.EntityId!.Value)
+    .ToDictionary(g => g.Key, g => g.Select(x => x.f).ToList());
+
+foreach (var item in result.Data)
+{
+    if (item.Id is { } id && ketQuaByToTrinhId.TryGetValue(id, out var files))
+        item.DanhSachTepDinhKem = item.DanhSachTepDinhKem!.Concat(files).DistinctBy(f => f.Id).ToList();
+}
+```
+
+### 3.2 Trước fix (tham chiếu)
+
+| Vấn đề | Mô tả |
+| ------ | ----- |
+| `danh-sach-tien-do` thiếu file Tờ trình kết quả | Chỉ load attachment theo `GroupId ∈ toTrinh entity ids`; file Tờ trình kết quả nằm ở group `ToTrinhQuyetDinh.Id` (long) → không khớp |
+| `chi-tiet` đủ 7 file | Controller gộp thêm nhóm `ToTrinhQuyetDinh` riêng (dòng 62–70) |
+
+---
+
+## 4. Model dữ liệu
+
+| Entity | Field | Kiểu | Ghi chú |
+| ------ | ----- | ---- | ------- |
+| `ToTrinhThamDinhNhaThau` | `Id` | `Guid` | GroupId cho 6 nhóm file trực tiếp |
+| `ToTrinhQuyetDinh` | `Id` | `long` | **GroupId** cho file Tờ trình kết quả |
+| `ToTrinhQuyetDinh` | `EntityId` | `Guid?` | = `ToTrinhThamDinhNhaThau.Id` (bảng dùng chung) |
+| `ToTrinhQuyetDinh` | `Loai` | `string` | `ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau` = `"ToTrinhThamDinhNhaThau"` |
+| `Attachment` | `GroupId` | `string` | Lưu dạng chuỗi Guid hoặc long |
+| `Attachment` | `GroupType` | `string` | `"ToTrinhQuyetDinh"` cho file Tờ trình kết quả |
+
+---
+
+## 5. Semantics
+
+- File trực tiếp của Tờ trình: `GroupId = ToTrinhThamDinhNhaThau.Id`, `GroupType = ToTrinhThamDinhNhaThau_*` → load theo `groupIds` cũ (giữ nguyên).
+- File Tờ trình kết quả: `GroupId = ToTrinhQuyetDinh.Id`, `GroupType = ToTrinhQuyetDinh` → load mới theo map `EntityId → Id`.
+- Gộp bằng **`DistinctBy(f => f.Id)`** — chống trùng file giữa 2 nhóm (an toàn về mặt phòng xa).
+
+---
+
+## 6. Files sẽ sửa
+
+| # | File | Thay đổi |
+| - | ---- | -------- |
+| 1 | `QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs` | Thêm repo `ToTrinhQuyetDinh`, block gộp file, 2 using |
+
+**Không sửa:** controller, `chi-tiet`, cách lưu file, migration, `AppDbContextModelSnapshot`.
+
+---
+
+## 7. Build
+
+```powershell
+dotnet build QLDA.WebApi/QLDA.WebApi.csproj
+# Kỳ vọng: 0 Error(s)
+```
+
+---
+
+## 8. Smoke test manual
+
+⏳ **Chưa chạy** — dùng checklist sau khi build/deploy.
+
+### 8.1 So sánh trước/sau trên cùng dataset
+
+```http
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/{id}/chi-tiet        # kỳ vọng: 7 file
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=<guid>&BuocId=7040&PageIndex=1&PageSize=10   # kỳ vọng: 7 file
+```
+
+### 8.2 Đối tượng kiểm tra
+
+| Item `Id` | Trước fix | Sau fix |
+| --------- | --------- | ------- |
+| `08defd97-eaf5-c226-687a-7b350801bae5` | 6/7 | 7/7 |
+| `08defc12-4e20-3b60-687a-7b38f8073d8e` | 6/7 | 7/7 |
+
+Kỳ vọng: mỗi item có đủ file Tờ trình kết quả (`groupType = "ToTrinhQuyetDinh"`) trong `danhSachTepDinhKem`, khớp chi-tiet.
+
+---
+
+## 9. Acceptance criteria
+
+| # | Kịch bản | Kỳ vọng | Verify |
+| - | -------- | ------- | ------ |
+| AC1 | Item có ToTrinhQuyetDinh + file | `danhSachTepDinhKem` đủ file (7/7) | ⏳ |
+| AC2 | Item không có ToTrinhQuyetDinh | Không đổi (giữ nguyên 6 file trực tiếp) | ⏳ |
+| AC3 | Không trùng file | `DistinctBy(f => f.Id)` | ⏳ |
+| AC4 | Response shape | Không đổi JSON | ✅ |
+| AC5 | Build | 0 Error(s) | ⏳ |
+
+---
+
+## 10. Checklist nghiệm thu
+
+- [ ] `ToTrinhThamDinhNhaThauGetDanhSachQuery` có repo `ToTrinhQuyetDinh` + block gộp file
+- [ ] `dotnet build` thành công (0 Error)
+- [ ] Smoke test AC1–AC3 trên môi trường test/deploy (2 item 7/7)
+
+---
+
+## 11. Commit đề xuất
+
+```
+fix(to-trinh-tham-dinh-nha-thau): danh-sach-tien-do sót file Tờ trình kết quả
+
+chi-tiet gộp 8 nhóm file (6 nhóm gắn theo ToTrinhThamDinhNhaThau.Id + nhóm
+ToTrinhQuyetDinh gắn theo ToTrinhQuyetDinh.Id long) nên đủ 7 file. danh-sach-tien-do
+chỉ load theo GroupId ∈ toTrinh entity ids nên mất file Tờ trình kết quả.
+Bổ sung query ToTrinhQuyetDinh (EntityId + Loai) và append file vào từng item.
+```
+
+**Phạm vi:** `ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`.

--- a/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/test-workflow.md
+++ b/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/test-workflow.md
@@ -1,0 +1,47 @@
+# Test Workflow — `danh-sach-tien-do` Tờ trình thẩm định nhà thầu
+
+## Thông tin chung
+
+- **Issue**: `danh-sach-tien-do` thiếu file "Tờ trình kết quả" (6/7 so với chi-tiet)
+- **File thay đổi**:
+  - `QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`
+- **Migration**: không
+- **Test files**: không có test tự động cho module này (xác minh bằng build + smoke test manual)
+
+## Chạy build & test
+
+```powershell
+# Build toàn bộ solution
+dotnet build SER.sln
+
+# Toàn bộ tests
+dotnet test QLDA.Tests/QLDA.Tests.csproj
+```
+
+Kỳ vọng: build 0 Error, các test hiện có không vỡ (chỉ thêm nhánh query mới, không đổi hành vi cũ).
+
+## Smoke test API
+
+```http
+# chi-tiet — kỳ vọng 7 file (baseline)
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/08defd97-eaf5-c226-687a-7b350801bae5/chi-tiet
+
+# danh-sach-tien-do — kỳ vọng mỗi item 7/7 file sau fix
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=08def36f-9d7f-6e89-687a-7b2ea004c65e&BuocId=7040&PageIndex=1&PageSize=10
+```
+
+### Đối tượng kiểm tra
+
+| Item `Id` | Trước fix | Sau fix |
+| --------- | --------- | ------- |
+| `08defd97-eaf5-c226-687a-7b350801bae5` | 6/7 | 7/7 |
+| `08defc12-4e20-3b60-687a-7b38f8073d8e` | 6/7 | 7/7 |
+
+Kiểm chứng: mỗi item trong `danhSachTepDinhKem` phải có đủ file `groupType = "ToTrinhQuyetDinh"` (Tờ trình kết quả), không trùng `id` với 6 file còn lại.
+
+## Verify
+
+- [ ] `dotnet build` — 0 Error(s)
+- [ ] Test tự động hiện có pass
+- [ ] Smoke test: 2 item đều 7/7 file, khớp chi-tiet
+- [ ] Item không có ToTrinhQuyetDinh vẫn giữ nguyên (không lỗi)


### PR DESCRIPTION
## Mô tả

API `danh-sach-tien-do` chỉ trả 6/7 file trong khi API `chi-tiet` trả đầy đủ 7 file.

Nguyên nhân: file Tờ trình kết quả được lưu với `GroupId = ToTrinhQuyetDinh.Id`, khác với `ToTrinhThamDinhNhaThau.Id`.

## Thay đổi

- Query `ToTrinhQuyetDinh` theo `EntityId` và `Loai`.
- Load attachment nhóm `ToTrinhQuyetDinh`.
- Gộp file vào `DanhSachTepDinhKem` tương ứng.
- Dùng `DistinctBy` để tránh file trùng.
- Bổ sung tài liệu issue.

## Kiểm tra

- `dotnet build QLDA.Application/QLDA.Application.csproj`
- Kết quả: 0 errors, 0 warnings.
- Smoke test sau khi restart WebApi: các item trả đủ 7/7 file.