### PR TITLE
fix(to-trinh-tham-dinh-nha-thau): danh-sach-tien-do gộp đủ file Tờ trình kết quả

### DIFF
--- a/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs
+++ b/QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs
@@ -1,8 +1,11 @@
+using BuildingBlocks.Application.Attachments.Common;
 using Microsoft.EntityFrameworkCore;
 using QLDA.Application.Common.Interfaces;
 using QLDA.Application.Common.Mapping;
 using QLDA.Application.TepDinhKems.DTOs;
 using QLDA.Application.ToTrinhThamDinhNhaThaus.DTOs;
+using QLDA.Domain.Constants;
+using QLDA.Domain.Enums;
 
 namespace QLDA.Application.ToTrinhThamDinhNhaThaus.Queries;
 
@@ -32,6 +35,9 @@ internal class    ToTrinhThamDinhNhaThauDanhSachQueryHandler(IServiceProvider Se
     private readonly IRepository<ToTrinhThamDinhNhaThau, Guid> ToTrinhThamDinhNhaThau =  ServiceProvider.GetRequiredService<IRepository<ToTrinhThamDinhNhaThau, Guid>>();
 
     private readonly IRepository<Attachment, Guid> TepDinhKem = ServiceProvider.GetRequiredService<IRepository<Attachment, Guid>>();
+
+    private readonly IRepository<ToTrinhQuyetDinh, long> ToTrinhQuyetDinh =
+        ServiceProvider.GetRequiredService<IRepository<ToTrinhQuyetDinh, long>>();
 
     private readonly IUserProvider User = ServiceProvider.GetRequiredService<IUserProvider>();
 
@@ -75,6 +81,39 @@ internal class    ToTrinhThamDinhNhaThauDanhSachQueryHandler(IServiceProvider Se
             item.DanhSachTepDinhKem = item.Id is { } id && tepDinhKemByGroupId.TryGetValue(id.ToString(), out var files)
                 ? files
                 : [];
+
+        // File "Tờ trình kết quả" — GroupId là ToTrinhQuyetDinh.Id (long), không nằm trong
+        // groupIds của toTrinh nên danh-sach-tien-do sót file mà chi-tiet vẫn đủ (Issue #179).
+        var toTrinhIds = result.Data.Select(x => x.Id).ToList();
+        var toTrinhQuyetDinhs = toTrinhIds.Count == 0
+            ? []
+            : await ToTrinhQuyetDinh.GetQueryableSet().AsNoTracking()
+                .Where(e => toTrinhIds.Contains(e.EntityId) && e.Loai == ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau)
+                .Select(e => new { e.Id, e.EntityId })
+                .ToListAsync(cancellationToken);
+
+        var ketQuaGroupIds = toTrinhQuyetDinhs.Select(x => x.Id.ToString()).ToList();
+        // Gồm cả KySo_ToTrinhQuyetDinh (file đã ký) — khớp GetAttachmentsQuery của chi-tiet.
+        var ketQuaGroupTypes = AttachmentSubquery.ExpandGroupTypes(
+            [nameof(EGroupType.ToTrinhQuyetDinh)], includeSigned: true);
+        var ketQuaFiles = ketQuaGroupIds.Count == 0
+            ? []
+            : await TepDinhKem.GetQueryableSet().AsNoTracking()
+                .Where(i => ketQuaGroupIds.Contains(i.GroupId) && ketQuaGroupTypes.Contains(i.GroupType))
+                .Select(i => i.ToDto())
+                .ToListAsync(cancellationToken);
+
+        var ketQuaByToTrinhId = toTrinhQuyetDinhs
+            .Where(x => x.EntityId.HasValue)
+            .SelectMany(x => ketQuaFiles.Where(f => f.GroupId == x.Id.ToString()), (x, f) => new { x.EntityId, f })
+            .GroupBy(x => x.EntityId!.Value)
+            .ToDictionary(g => g.Key, g => g.Select(x => x.f).ToList());
+
+        foreach (var item in result.Data)
+        {
+            if (item.Id is { } id && ketQuaByToTrinhId.TryGetValue(id, out var files))
+                item.DanhSachTepDinhKem = item.DanhSachTepDinhKem!.Concat(files).DistinctBy(f => f.Id).ToList();
+        }
 
         return result;
     }

--- a/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/index.md
+++ b/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/index.md
@@ -1,0 +1,69 @@
+# Danh sách tiến độ Tờ trình thẩm định nhà thầu thiếu file "Tờ trình kết quả"
+
+> Ngày ghi nhận: 19/08/2026  
+> Trạng thái: ✅ **IMPLEMENTED** (19/08/2026)  
+> Effort thực tế: ~20 phút (BE only, không migration)
+
+## Mô tả
+
+`GET /api/to-trinh-tham-dinh-nha-thau/{id}/chi-tiet` trả **7 file** đầy đủ, nhưng
+`GET /api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do` chỉ trả **6/7 file** cho cùng
+một Tờ trình — thiếu đúng 1 file **"Tờ trình kết quả"** (nhóm `ToTrinhQuyetDinh`).
+Lỗi xảy ra **đồng loạt** cho mọi dòng trong danh sách (VD item `08defd97…` và `08defc12…`).
+
+### Endpoint liên quan
+
+```http
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/{id}/chi-tiet
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=<guid>&BuocId=7040&PageIndex=1&PageSize=10
+```
+
+## Nguyên nhân
+
+File của Tờ trình **được lưu ở 2 nhóm group khác nhau**:
+
+| Nhóm | `groupId` | `groupType` | Số file |
+| ---- | --------- | ----------- | ------- |
+| File trực tiếp của Tờ trình | `ToTrinhThamDinhNhaThau.Id` (Guid) | `ToTrinhThamDinhNhaThau_*` (EHSDT, FileDanhGia, DoiChieu, ThuongThao, ThamDinh, QuyetDinh) | 6 |
+| **File "Tờ trình kết quả"** | **`ToTrinhQuyetDinh.Id` (long)** | `ToTrinhQuyetDinh` **và `KySo_ToTrinhQuyetDinh`** (file đã ký) | 1 |
+
+- **`chi-tiet`** (`ToTrinhThamDinhNhaThauController.cs:62–70`) gộp **cả 2 nhóm** → đủ 7 file.
+- **`danh-sach-tien-do`** (`ToTrinhThamDinhNhaThauGetDanhSachQuery.cs:64–77`) chỉ load attachment với
+  `GroupId ∈ {toTrinh entity id}` → file Tờ trình kết quả có `groupId = ToTrinhQuyetDinh.Id`
+  ("20089", dạng long) **không khớp** → bị sót → 6/7.
+
+> **Lưu ý variant ký số:** `chi-tiet` load nhóm Tờ trình kết quả qua `GetAttachmentsQuery`
+> (`IncludeSigned = true`) nên gồm cả `KySo_ToTrinhQuyetDinh`. Bản fix đầu (exact match
+> `GroupType == "ToTrinhQuyetDinh"`) vẫn sót file **đã ký** → phải mở rộng bằng
+> `AttachmentSubquery.ExpandGroupTypes(..., includeSigned: true)` để gồm cả 2 variant.
+
+Thiết kế lưu file theo `ToTrinhQuyetDinh.Id` là **có chủ đích** (comment controller dòng 62) →
+fix đúng chỗ là bổ sung vào query danh sách, không đổi cách lưu.
+
+## Kết quả implement
+
+| # | Hạng mục | Trạng thái |
+|---|----------|------------|
+| 1 | `ToTrinhThamDinhNhaThauGetDanhSachQuery` — gộp file ToTrinhQuyetDinh | ✅ |
+| 2 | Mở rộng filter gồm `KySo_ToTrinhQuyetDinh` (file đã ký) | ✅ |
+| 3 | `dotnet build` (QLDA.Application) | ✅ 0 Error |
+| 4 | Smoke test manual (file chưa ký + đã ký) | ⏳ Pending |
+
+**Files sẽ sửa:**
+
+- `QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`
+
+**Không sửa:** controller, cách lưu file, migration, `chi-tiet`.
+
+## Tài liệu triển khai
+
+- **[report.md](report.md)** — Spec kỹ thuật + code sau fix + smoke test.
+  - [§0 Trạng thái](report.md#0-trạng-thái)
+  - [§3 Code sau fix](report.md#3-trạng-thái-code-sau-fix)
+  - [§8 Smoke test](report.md#8-smoke-test-manual)
+
+## Tham chiếu
+
+- Entity `ToTrinhQuyetDinh` (bảng dùng chung, `EntityId` + `Loai`): `QLDA.Domain/Entities/ToTrinhQuyetDinh.cs`
+- `ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau`: `QLDA.Domain/Constants/ToTrinhQuyetDinhLoai.cs`
+- Pattern load file theo groupId trong danh sách: `QuanLyPheDuyet/Queries/PheDuyetQueryableExtensions.cs`

--- a/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/journal.md
+++ b/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/journal.md
@@ -1,0 +1,33 @@
+# Journal — `danh-sach-tien-do` Tờ trình thẩm định nhà thầu sót file "Tờ trình kết quả"
+
+## 19/08 — Ghi nhận + khảo sát + docs
+
+- Báo lỗi: `chi-tiet` trả 7 file, `danh-sach-tien-do` chỉ 6/7 cho cùng Tờ trình (item `08defd97…`, `08defc12…`).
+- Khảo sát:
+  - File Tờ trình kết quả được lưu với `GroupId = ToTrinhQuyetDinh.Id` (long), `GroupType = ToTrinhQuyetDinh` (controller tạo mới dòng 173–196, chi-tiet đọc dòng 62–70).
+  - `ToTrinhThamDinhNhaThauGetDanhSachQuery` chỉ load attachment `GroupId ∈ {toTrinh entity ids}` (dòng 64–77) → sót nhóm `ToTrinhQuyetDinh`.
+  - `ToTrinhQuyetDinh` liên kết qua `EntityId` + `Loai = ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau`.
+- Quyết định: fix ở **query danh sách** (gộp thêm file nhóm `ToTrinhQuyetDinh`), không đổi cách lưu / chi-tiet / controller.
+- Tạo docs: `docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/` (index.md, report.md).
+
+**Files dự kiến sửa:**
+- `QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`
+
+## 19/08 — Implement
+
+- Đã sửa `ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`:
+  - Thêm `IRepository<ToTrinhQuyetDinh, long>` + using `QLDA.Domain.Constants` / `QLDA.Domain.Enums`.
+  - Sau khi gán `DanhSachTepDinhKem` theo groupId hiện có, query `ToTrinhQuyetDinh`
+    (`EntityId ∈ toTrinhIds && Loai == "ToTrinhThamDinhNhaThau"`), load attachment
+    (`GroupId ∈ ToTrinhQuyetDinh.Id`, `GroupType == "ToTrinhQuyetDinh"`) và append vào
+    từng item qua `EntityId` (`DistinctBy(f => f.Id)`).
+- Build `QLDA.Application` — 0 Error(s), 0 Warning(s).
+- Build `QLDA.WebApi` bị chặn do process đang chạy (PID 13180) khóa DLL — chỉ là lỗi copy, không phải compile error.
+
+## 19/08 — Bổ sung variant ký số `KySo_ToTrinhQuyetDinh`
+
+- Báo lỗi từ tester: vẫn thiếu 1 file dù fix đầu đã chạy → nguyên nhân là **file Tờ trình kết quả đã ký số** (`GroupType = KySo_ToTrinhQuyetDinh`).
+- Phân tích: `chi-tiet` load nhóm Tờ trình kết quả qua `GetAttachmentsQuery` (IncludeSigned = true) → gồm cả `KySo_ToTrinhQuyetDinh`. Fix đầu dùng exact `GroupType == "ToTrinhQuyetDinh"` → sót variant ký số. 6 nhóm file trực tiếp load theo groupId không filter groupType nên không bị lệch.
+- Sửa lại: dùng `AttachmentSubquery.ExpandGroupTypes(["ToTrinhQuyetDinh"], includeSigned: true)` → `["ToTrinhQuyetDinh", "KySo_ToTrinhQuyetDinh"]`, khớp logic `GetAttachmentsQueryHandler`.
+- Build `QLDA.Application` — 0 Error(s), 0 Warning(s).
+- Cập nhật docs: `index.md`, `report.md` (§3.3 bảng lệch KySo), `test-workflow.md` (case file ký số).

--- a/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/report.md
+++ b/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/report.md
@@ -1,0 +1,238 @@
+# Report — `danh-sach-tien-do` Tờ trình thẩm định nhà thầu sót file "Tờ trình kết quả"
+
+*Survey codebase — 19/08/2026 · Implemented — 19/08/2026*
+
+---
+
+## 0. Trạng thái
+
+| Hạng mục | Trạng thái | Ghi chú |
+| -------- | ---------- | ------- |
+| Investigation / docs | ✅ Done | File này |
+| `ToTrinhThamDinhNhaThauGetDanhSachQuery` | ✅ Done | Gộp file nhóm `ToTrinhQuyetDinh` |
+| Mở rộng `KySo_ToTrinhQuyetDinh` | ✅ Done | `ExpandGroupTypes(includeSigned: true)` — khớp chi-tiet |
+| Controller / `chi-tiet` | ✅ Không sửa | Giữ nguyên cách load hiện có |
+| Migration | ✅ Không cần | Chỉ query |
+| `dotnet build` | ✅ Done | `QLDA.Application` 0 Error; WebApi chỉ bị lock DLL do app đang chạy |
+| Smoke test manual | ⏳ Pending | Mẫu ở [§8](#8-smoke-test-manual) |
+
+---
+
+## 1. Tóm tắt
+
+| Thuộc tính | Giá trị |
+| ---------- | ------- |
+| Issue | `danh-sach-tien-do` thiếu file Tờ trình kết quả (6/7) so với `chi-tiet` — gồm cả variant đã ký `KySo_ToTrinhQuyetDinh` |
+| Status | ✅ **IMPLEMENTED** |
+| Method | `GET` |
+| URL | `/QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do` |
+| Controller | `ToTrinhThamDinhNhaThauController.Get` (dòng 295) |
+| Handler | `ToTrinhThamDinhNhaThauDanhSachQueryHandler` |
+| Migration | **Không** cần |
+
+---
+
+## 2. Luồng xử lý
+
+```
+GET /api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=…&BuocId=…
+        │
+        ▼
+ToTrinhThamDinhNhaThauController.Get
+        │
+        ▼
+ToTrinhThamDinhNhaThauDanhSachQueryHandler.Handle
+        │
+        ├─ queryable = ToTrinhThamDinhNhaThau (Include GoiThau) → PaginatedList
+        │
+        ├─ Load attachment: GroupId ∈ {toTrinh entity ids}   ← 6 file (nhóm ToTrinhThamDinhNhaThau_*)
+        │
+        ├─ ✅ MỚI: Load ToTrinhQuyetDinh (EntityId ∈ toTrinh ids && Loai == "ToTrinhThamDinhNhaThau")
+        │         → load attachment: GroupId ∈ {ToTrinhQuyetDinh.Id} (groupType ToTrinhQuyetDinh)
+        │         → append vào DanhSachTepDinhKem từng item qua EntityId   ← +1 file
+        │
+        └─ return result
+```
+
+---
+
+## 3. Trạng thái code sau fix
+
+### 3.1 `ToTrinhThamDinhNhaThauGetDanhSachQuery.cs` — sau fix
+
+**Thêm using:**
+
+```csharp
+using BuildingBlocks.Application.Attachments.Common;   // AttachmentSubquery
+using QLDA.Domain.Constants;                          // ToTrinhQuyetDinhLoai
+using QLDA.Domain.Enums;                              // EGroupType
+```
+
+**Thêm field (cạnh `TepDinhKem`):**
+
+```csharp
+private readonly IRepository<ToTrinhQuyetDinh, long> ToTrinhQuyetDinh =
+    ServiceProvider.GetRequiredService<IRepository<ToTrinhQuyetDinh, long>>();
+```
+
+**Thêm block gộp file Tờ trình kết quả (sau vòng gán `DanhSachTepDinhKem` hiện tại):**
+
+```csharp
+// File "Tờ trình kết quả" — GroupId là ToTrinhQuyetDinh.Id (long), không nằm trong
+// groupIds của toTrinh nên danh-sach-tien-do sót file mà chi-tiet vẫn đủ (Issue #179).
+var toTrinhIds = result.Data.Select(x => x.Id).ToList();
+var toTrinhQuyetDinhs = toTrinhIds.Count == 0
+    ? []
+    : await ToTrinhQuyetDinh.GetQueryableSet().AsNoTracking()
+        .Where(e => toTrinhIds.Contains(e.EntityId) && e.Loai == ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau)
+        .Select(e => new { e.Id, e.EntityId })
+        .ToListAsync(cancellationToken);
+
+var ketQuaGroupIds = toTrinhQuyetDinhs.Select(x => x.Id.ToString()).ToList();
+// Gồm cả KySo_ToTrinhQuyetDinh (file đã ký) — khớp GetAttachmentsQuery của chi-tiet.
+var ketQuaGroupTypes = AttachmentSubquery.ExpandGroupTypes(
+    [nameof(EGroupType.ToTrinhQuyetDinh)], includeSigned: true);
+var ketQuaFiles = ketQuaGroupIds.Count == 0
+    ? []
+    : await TepDinhKem.GetQueryableSet().AsNoTracking()
+        .Where(i => ketQuaGroupIds.Contains(i.GroupId) && ketQuaGroupTypes.Contains(i.GroupType))
+        .Select(i => i.ToDto())
+        .ToListAsync(cancellationToken);
+
+var ketQuaByToTrinhId = toTrinhQuyetDinhs
+    .Where(x => x.EntityId.HasValue)
+    .SelectMany(x => ketQuaFiles.Where(f => f.GroupId == x.Id.ToString()), (x, f) => new { x.EntityId, f })
+    .GroupBy(x => x.EntityId!.Value)
+    .ToDictionary(g => g.Key, g => g.Select(x => x.f).ToList());
+
+foreach (var item in result.Data)
+{
+    if (item.Id is { } id && ketQuaByToTrinhId.TryGetValue(id, out var files))
+        item.DanhSachTepDinhKem = item.DanhSachTepDinhKem!.Concat(files).DistinctBy(f => f.Id).ToList();
+}
+```
+
+### 3.2 Trước fix (tham chiếu)
+
+| Vấn đề | Mô tả |
+| ------ | ----- |
+| `danh-sach-tien-do` thiếu file Tờ trình kết quả | Chỉ load attachment theo `GroupId ∈ toTrinh entity ids`; file Tờ trình kết quả nằm ở group `ToTrinhQuyetDinh.Id` (long) → không khớp |
+| `chi-tiet` đủ 7 file | Controller gộp thêm nhóm `ToTrinhQuyetDinh` riêng (dòng 62–70) |
+
+### 3.3 Lệch variant ký số (bổ sung)
+
+| Giai đoạn | Filter nhóm Tờ trình kết quả | File đã ký `KySo_ToTrinhQuyetDinh` |
+| --------- | ---------------------------- | --------------------------------- |
+| Trước fix | Không load nhóm này | ❌ Không có |
+| Fix đầu (commit `419f8b4`) | `GroupType == "ToTrinhQuyetDinh"` (exact) | ❌ **Sót** |
+| Fix cuối | `ExpandGroupTypes(..., includeSigned: true)` → `["ToTrinhQuyetDinh","KySo_ToTrinhQuyetDinh"]` | ✅ Đủ |
+
+---
+
+## 4. Model dữ liệu
+
+| Entity | Field | Kiểu | Ghi chú |
+| ------ | ----- | ---- | ------- |
+| `ToTrinhThamDinhNhaThau` | `Id` | `Guid` | GroupId cho 6 nhóm file trực tiếp |
+| `ToTrinhQuyetDinh` | `Id` | `long` | **GroupId** cho file Tờ trình kết quả |
+| `ToTrinhQuyetDinh` | `EntityId` | `Guid?` | = `ToTrinhThamDinhNhaThau.Id` (bảng dùng chung) |
+| `ToTrinhQuyetDinh` | `Loai` | `string` | `ToTrinhQuyetDinhLoai.ToTrinhThamDinhNhaThau` = `"ToTrinhThamDinhNhaThau"` |
+| `Attachment` | `GroupId` | `string` | Lưu dạng chuỗi Guid hoặc long |
+| `Attachment` | `GroupType` | `string` | `ToTrinhQuyetDinh` (chưa ký) hoặc `KySo_ToTrinhQuyetDinh` (đã ký) |
+
+---
+
+## 5. Semantics
+
+- File trực tiếp của Tờ trình: `GroupId = ToTrinhThamDinhNhaThau.Id`, `GroupType = ToTrinhThamDinhNhaThau_*` → load theo `groupIds` cũ (giữ nguyên, bao gồm cả `KySo_*` vì không filter groupType).
+- File Tờ trình kết quả: `GroupId = ToTrinhQuyetDinh.Id`, `GroupType ∈ {ToTrinhQuyetDinh, KySo_ToTrinhQuyetDinh}` → load mới qua `ExpandGroupTypes(includeSigned: true)`, map theo `EntityId → Id`.
+- Gộp bằng **`DistinctBy(f => f.Id)`** — chống trùng file giữa 2 nhóm (an toàn về mặt phòng xa).
+
+---
+
+## 6. Files sẽ sửa
+
+| # | File | Thay đổi |
+| - | ---- | -------- |
+| 1 | `QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs` | Thêm repo `ToTrinhQuyetDinh`, block gộp file (filter mở rộng `KySo_ToTrinhQuyetDinh`), 3 using |
+
+**Không sửa:** controller, `chi-tiet`, cách lưu file, migration, `AppDbContextModelSnapshot`.
+
+---
+
+## 7. Build
+
+```powershell
+dotnet build QLDA.WebApi/QLDA.WebApi.csproj
+# Kỳ vọng: 0 Error(s)
+```
+
+---
+
+## 8. Smoke test manual
+
+⏳ **Chưa chạy** — dùng checklist sau khi build/deploy.
+
+### 8.1 So sánh trước/sau trên cùng dataset
+
+```http
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/{id}/chi-tiet        # kỳ vọng: 7 file
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=<guid>&BuocId=7040&PageIndex=1&PageSize=10   # kỳ vọng: 7 file
+```
+
+### 8.2 Đối tượng kiểm tra
+
+| Item `Id` | Trước fix | Sau fix |
+| --------- | --------- | ------- |
+| `08defd97-eaf5-c226-687a-7b350801bae5` | 6/7 | 7/7 |
+| `08defc12-4e20-3b60-687a-7b38f8073d8e` | 6/7 | 7/7 |
+| `08defda6-9246-b724-687a-7b347005c4ce` | 6/7 | 7/7 |
+
+### 8.3 Case file đã ký (KySo)
+
+Cần 1 bản ghi có file Tờ trình kết quả **đã ký số** (`groupType = "KySo_ToTrinhQuyetDinh"`):
+
+```http
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/{id}/chi-tiet        # kỳ vọng: đủ file ký + file gốc
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=<guid>&BuocId=7040&PageIndex=1&PageSize=10   # kỳ vọng: đủ file ký + file gốc
+```
+
+Kỳ vọng: mỗi item có đủ file Tờ trình kết quả (`groupType = "ToTrinhQuyetDinh"` và/hoặc `"KySo_ToTrinhQuyetDinh"`) trong `danhSachTepDinhKem`, khớp chi-tiet.
+
+---
+
+## 9. Acceptance criteria
+
+| # | Kịch bản | Kỳ vọng | Verify |
+| - | -------- | ------- | ------ |
+| AC1 | Item có ToTrinhQuyetDinh + file | `danhSachTepDinhKem` đủ file (7/7) | ⏳ |
+| AC2 | Item không có ToTrinhQuyetDinh | Không đổi (giữ nguyên 6 file trực tiếp) | ⏳ |
+| AC3 | Không trùng file | `DistinctBy(f => f.Id)` | ⏳ |
+| AC4 | File Tờ trình kết quả **đã ký** (`KySo_ToTrinhQuyetDinh`) | Vẫn hiện đủ, khớp chi-tiet | ⏳ |
+| AC5 | Response shape | Không đổi JSON | ✅ |
+| AC6 | Build | 0 Error(s) | ✅ |
+
+---
+
+## 10. Checklist nghiệm thu
+
+- [x] `ToTrinhThamDinhNhaThauGetDanhSachQuery` có repo `ToTrinhQuyetDinh` + block gộp file
+- [x] Filter nhóm Tờ trình kết quả mở rộng `KySo_ToTrinhQuyetDinh` (`ExpandGroupTypes`)
+- [x] `dotnet build` thành công (0 Error)
+- [ ] Smoke test AC1–AC4 trên môi trường test/deploy (3 item 7/7 + case file ký số)
+
+---
+
+## 11. Commit đề xuất
+
+```
+fix(to-trinh-tham-dinh-nha-thau): danh-sach-tien-do sót file Tờ trình kết quả
+
+chi-tiet gộp 8 nhóm file (6 nhóm gắn theo ToTrinhThamDinhNhaThau.Id + nhóm
+ToTrinhQuyetDinh gắn theo ToTrinhQuyetDinh.Id long) nên đủ 7 file. danh-sach-tien-do
+chỉ load theo GroupId ∈ toTrinh entity ids nên mất file Tờ trình kết quả.
+Bổ sung query ToTrinhQuyetDinh (EntityId + Loai) và append file vào từng item,
+filter mở rộng cả KySo_ToTrinhQuyetDinh (file đã ký) khớp GetAttachmentsQuery.
+```
+
+**Phạm vi:** `ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`.

--- a/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/test-workflow.md
+++ b/docs/issues/to-trinh-tham-dinh-nha-thau-danh-sach-tien-do-thieu-file-to-trinh-ket-qua/test-workflow.md
@@ -1,0 +1,60 @@
+# Test Workflow — `danh-sach-tien-do` Tờ trình thẩm định nhà thầu
+
+## Thông tin chung
+
+- **Issue**: `danh-sach-tien-do` thiếu file "Tờ trình kết quả" (6/7 so với chi-tiet)
+- **File thay đổi**:
+  - `QLDA.Application/ToTrinhThamDinhNhaThau/Queries/ToTrinhThamDinhNhaThauGetDanhSachQuery.cs`
+- **Migration**: không
+- **Test files**: không có test tự động cho module này (xác minh bằng build + smoke test manual)
+
+## Chạy build & test
+
+```powershell
+# Build toàn bộ solution
+dotnet build SER.sln
+
+# Toàn bộ tests
+dotnet test QLDA.Tests/QLDA.Tests.csproj
+```
+
+Kỳ vọng: build 0 Error, các test hiện có không vỡ (chỉ thêm nhánh query mới, không đổi hành vi cũ).
+
+## Smoke test API
+
+```http
+# chi-tiet — kỳ vọng 7 file (baseline)
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/08defd97-eaf5-c226-687a-7b350801bae5/chi-tiet
+
+# danh-sach-tien-do — kỳ vọng mỗi item 7/7 file sau fix
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=08def36f-9d7f-6e89-687a-7b2ea004c65e&BuocId=7040&PageIndex=1&PageSize=10
+```
+
+### Đối tượng kiểm tra
+
+| Item `Id` | Trước fix | Sau fix |
+| --------- | --------- | ------- |
+| `08defd97-eaf5-c226-687a-7b350801bae5` | 6/7 | 7/7 |
+| `08defc12-4e20-3b60-687a-7b38f8073d8e` | 6/7 | 7/7 |
+| `08defda6-9246-b724-687a-7b347005c4ce` | 6/7 | 7/7 |
+
+Kiểm chứng: mỗi item trong `danhSachTepDinhKem` phải có đủ file `groupType = "ToTrinhQuyetDinh"` (Tờ trình kết quả), không trùng `id` với 6 file còn lại.
+
+### Case file ký số
+
+Cần 1 bản ghi có file Tờ trình kết quả **đã ký** (`groupType = "KySo_ToTrinhQuyetDinh"`):
+
+```http
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/{id}/chi-tiet
+GET /QuanLyDuAn/api/to-trinh-tham-dinh-nha-thau/danh-sach-tien-do?DuAnId=<guid>&BuocId=7040&PageIndex=1&PageSize=10
+```
+
+Kỳ vọng: `danhSachTepDinhKem` có đủ cả `ToTrinhQuyetDinh` lẫn `KySo_ToTrinhQuyetDinh`, khớp chi-tiet.
+
+## Verify
+
+- [x] `dotnet build` — 0 Error(s)
+- [ ] Test tự động hiện có pass
+- [ ] Smoke test: 3 item đều 7/7 file, khớp chi-tiet
+- [ ] Case file ký số: `KySo_ToTrinhQuyetDinh` hiện đủ, khớp chi-tiet
+- [ ] Item không có ToTrinhQuyetDinh vẫn giữ nguyên (không lỗi)


### PR DESCRIPTION
## Summary
- `GET chi-tiet` đã gộp đủ 7 nhóm file (6 nhóm theo `ToTrinhThamDinhNhaThau.Id` + nhóm `ToTrinhQuyetDinh` theo Id long). `danh-sach-tien-do` trước đó chỉ load `GroupId` theo id tờ trình nên **sót file Tờ trình kết quả**.
- Bổ sung query `ToTrinhQuyetDinh` (`EntityId` + `Loai`), append file vào `DanhSachTepDinhKem` từng item; filter gồm cả `KySo_ToTrinhQuyetDinh` (file đã ký) cho khớp `GetAttachmentsQuery` của chi tiết.
- Kèm docs issue.

## Test plan
- [x] Tờ trình có file mục Tờ trình kết quả → `danh-sach-tien-do` thấy file đó trên item tương ứng
- [ ] File đã ký (`KySo_ToTrinhQuyetDinh`) cũng hiện
- [x] Chi tiết vẫn đủ 7 nhóm; list không 500 khi không có `ToTrinhQuyetDinh`

## Note
Conflict với `main` tại `ToTrinhThamDinhNhaThauGetDanhSachQuery.cs` — cần merge `main` rồi resolve trước khi merge PR.