### PR TITLE
fix(quyet-dinh-duyet-khlcnt): chuyển SoLuongGoiThau sang QĐ duyệt

### DIFF
--- a/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauDto.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauDto.cs
@@ -25,6 +25,5 @@ public class KeHoachLuaChonNhaThauDto : IHasKey<Guid?>, IMustHaveId<Guid>, ITien
     public long? DuToanThamDinh { get; set; }
     public int? NguonVonId { get; set; }
     public int? ThoiGianThucHien { get; set; }
-    public int? SoLuongGoiThau { get; set; }
     public List<TepDinhKemDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauInsertDto.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauInsertDto.cs
@@ -17,6 +17,5 @@ public class KeHoachLuaChonNhaThauInsertDto : IMayHaveTepDinhKemInsertDto, ITien
     public long? DuToanThamDinh { get; set; }
     public int? NguonVonId { get; set; }
     public int? ThoiGianThucHien { get; set; }
-    public int? SoLuongGoiThau { get; set; }
     public List<TepDinhKemInsertDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauUpdateDto.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/KeHoachLuaChonNhaThauUpdateDto.cs
@@ -16,6 +16,5 @@ public class KeHoachLuaChonNhaThauUpdateDto : IMayHaveTepDinhKemInsertOrUpdateDt
     public long? DuToanThamDinh { get; set; }
     public int? NguonVonId { get; set; }
     public int? ThoiGianThucHien { get; set; }
-    public int? SoLuongGoiThau { get; set; }
     public List<TepDinhKemInsertOrUpdateDto>? DanhSachTepDinhKem { get; set; }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/KeHoachLuaChonNhaThauMappings.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/KeHoachLuaChonNhaThauMappings.cs
@@ -18,8 +18,7 @@ public static class KeHoachLuaChonNhaThauMappings {
             TongDuToan = dto.TongDuToan!.Value,
             DuToanThamDinh = dto.DuToanThamDinh,
             NguonVonId = dto.NguonVonId,
-            ThoiGianThucHien = dto.ThoiGianThucHien,
-            SoLuongGoiThau = dto.SoLuongGoiThau
+            ThoiGianThucHien = dto.ThoiGianThucHien
         };
     }
 
@@ -38,7 +37,6 @@ public static class KeHoachLuaChonNhaThauMappings {
             DuToanThamDinh = entity.DuToanThamDinh,
             NguonVonId = entity.NguonVonId,
             ThoiGianThucHien = entity.ThoiGianThucHien,
-            SoLuongGoiThau = entity.SoLuongGoiThau,
             DanhSachTepDinhKem = [.. files?.ToDtos() ?? []]
         };
     }
@@ -53,6 +51,5 @@ public static class KeHoachLuaChonNhaThauMappings {
         entity.DuToanThamDinh = dto.DuToanThamDinh;
         entity.NguonVonId = dto.NguonVonId;
         entity.ThoiGianThucHien = dto.ThoiGianThucHien;
-        entity.SoLuongGoiThau = dto.SoLuongGoiThau;
     }
 }

--- a/QLDA.Application/KeHoachLuaChonNhaThaus/Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs
+++ b/QLDA.Application/KeHoachLuaChonNhaThaus/Queries/KeHoachLuaChonNhaThauGetDanhSachQuery.cs
@@ -55,7 +55,6 @@ internal class
                 DuToanThamDinh = e.DuToanThamDinh,
                 NguonVonId = e.NguonVonId,
                 ThoiGianThucHien = e.ThoiGianThucHien,
-                SoLuongGoiThau = e.SoLuongGoiThau,
                 DanhSachTepDinhKem = TepDinhKem.GetQueryableSet()
                     .Where(i => i.GroupId == e.Id.ToString())
                     .Select(i => i.ToDto()).ToList(),

--- a/QLDA.Application/QuyetDinhDuyetKHLCNTs/Commands/QuyetDinhDuyetKHLCNTInsertOrUpdateCommand.cs
+++ b/QLDA.Application/QuyetDinhDuyetKHLCNTs/Commands/QuyetDinhDuyetKHLCNTInsertOrUpdateCommand.cs
@@ -74,6 +74,7 @@ internal class
                     {
                         // Cập nhật các trường của thực thể cha
                         dbEntity.KeHoachLuaChonNhaThauId = request.Entity.KeHoachLuaChonNhaThauId;
+                        dbEntity.SoLuongGoiThau = request.Entity.SoLuongGoiThau;
 
                         // Cập nhật các trường của thực thể con VanBanQuyetDinh
                         if (request.Entity.VanBanQuyetDinh != null)

--- a/QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs
+++ b/QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs
@@ -34,11 +34,6 @@ public class KeHoachLuaChonNhaThau : VanBanQuyetDinh {
     /// </summary>
     public int? ThoiGianThucHien { get; set; }
 
-    /// <summary>
-    /// Số lượng gói thầu
-    /// </summary>
-    public int? SoLuongGoiThau { get; set; }
-
     #region Navigation Properties
 
     public DanhMucNguonVon? NguonVon { get; set; }

--- a/QLDA.Domain/Entities/QuyetDinhDuyetKHLCNT.cs
+++ b/QLDA.Domain/Entities/QuyetDinhDuyetKHLCNT.cs
@@ -7,9 +7,11 @@ public class QuyetDinhDuyetKHLCNT :  Entity<Guid>, IAggregateRoot
 {
 
     public Guid? KeHoachLuaChonNhaThauId { get; set; }
+
     /// <summary>
-    /// Số quyết định
+    /// Số lượng gói thầu — persist trên QĐ duyệt, không trên KHLCNT
     /// </summary>
+    public int? SoLuongGoiThau { get; set; }
 
     // Thêm khóa ngoại rõ ràng sang bảng văn bản
     #region Navigation Properties

--- a/QLDA.Migrator/Migrations/20260821073445_MoveSoLuongGoiThauToQuyetDinhDuyetKHLCNT.Designer.cs
+++ b/QLDA.Migrator/Migrations/20260821073445_MoveSoLuongGoiThauToQuyetDinhDuyetKHLCNT.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QLDA.Persistence;
 
@@ -11,9 +12,11 @@ using QLDA.Persistence;
 namespace QLDA.Migrator.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260821073445_MoveSoLuongGoiThauToQuyetDinhDuyetKHLCNT")]
+    partial class MoveSoLuongGoiThauToQuyetDinhDuyetKHLCNT
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QLDA.Migrator/Migrations/20260821073445_MoveSoLuongGoiThauToQuyetDinhDuyetKHLCNT.cs
+++ b/QLDA.Migrator/Migrations/20260821073445_MoveSoLuongGoiThauToQuyetDinhDuyetKHLCNT.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QLDA.Migrator.Migrations
+{
+    /// <inheritdoc />
+    public partial class MoveSoLuongGoiThauToQuyetDinhDuyetKHLCNT : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SoLuongGoiThau",
+                table: "KeHoachLuaChonNhaThau");
+
+            migrationBuilder.AddColumn<int>(
+                name: "SoLuongGoiThau",
+                table: "QuyetDinhDuyetKHLCNT",
+                type: "int",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SoLuongGoiThau",
+                table: "QuyetDinhDuyetKHLCNT");
+
+            migrationBuilder.AddColumn<int>(
+                name: "SoLuongGoiThau",
+                table: "KeHoachLuaChonNhaThau",
+                type: "int",
+                nullable: true);
+        }
+    }
+}

--- a/QLDA.WebApi/Models/QuyetDinhDuyetKHLCNTs/QuyetDinhDuyetKHLCNTMappingConfiguration.cs
+++ b/QLDA.WebApi/Models/QuyetDinhDuyetKHLCNTs/QuyetDinhDuyetKHLCNTMappingConfiguration.cs
@@ -15,7 +15,7 @@ public static class QuyetDinhDuyetKHLCNTMappingConfiguration
             DuToanThamDinh = entity.KeHoachLuaChonNhaThau?.DuToanThamDinh,
             NguonVonId = entity.KeHoachLuaChonNhaThau?.NguonVonId,
             ThoiGianThucHien = entity.KeHoachLuaChonNhaThau?.ThoiGianThucHien,
-            SoLuongGoiThau = entity.KeHoachLuaChonNhaThau?.SoLuongGoiThau,
+            SoLuongGoiThau = entity.SoLuongGoiThau,
             VanBanQuyetDinh = new TongHopVanBanQuyetDinhs.VanBanQuyetDinhModel()
             {
                 DuAnId = entity.VanBanQuyetDinh!.DuAnId,
@@ -40,6 +40,7 @@ public static class QuyetDinhDuyetKHLCNTMappingConfiguration
         {
             Id = id,
             KeHoachLuaChonNhaThauId = model.KeHoachLuaChonNhaThauId,
+            SoLuongGoiThau = model.SoLuongGoiThau,
             VanBanQuyetDinh = new VanBanQuyetDinh()
             {
                 Id = id,
@@ -72,6 +73,7 @@ public static class QuyetDinhDuyetKHLCNTMappingConfiguration
             Loai = EnumLoaiVanBanQuyetDinh.QuyetDinhDuyetKHLCNT.ToString(),
         };
         entity.KeHoachLuaChonNhaThauId = model.KeHoachLuaChonNhaThauId;
+        entity.SoLuongGoiThau = model.SoLuongGoiThau;
 
     }
 }

--- a/docs/issues/quyet-dinh-duyet-khlcnt-soluong-goi-thau/index.md
+++ b/docs/issues/quyet-dinh-duyet-khlcnt-soluong-goi-thau/index.md
@@ -1,0 +1,47 @@
+# `SoLuongGoiThau` đang đặt sai entity — KHLCNT vs QĐ duyệt
+
+> Chưa có số PMIS. Đổi folder thành `docs/issues/{số}/` khi có ticket.
+
+**Trạng thái:** Docs + trace source. **Chưa sửa code** theo task này.
+
+Chi tiết: [report.md](./report.md) · Test: [test-workflow.md](./test-workflow.md)
+
+## Tóm tắt
+
+`SoLuongGoiThau` đang khai báo và map DB trên **`KeHoachLuaChonNhaThau`**. Leader chốt: cột này thuộc **`QuyetDinhDuyetKHLCNT`**. KHLCNT chỉ giữ **4 cột mới** của task field (không kể `Ten` / `LoaiKeHoach` cũ).
+
+## Trace trước khi sửa (6 điểm)
+
+| # | Câu hỏi | Kết quả source hiện tại |
+| --- | --- | --- |
+| 1 | `SoLuongGoiThau` khai báo file nào? | Domain: `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs` (`int?`). **Không** có trên `QuyetDinhDuyetKHLCNT.cs`. |
+| 2 | Map xuống bảng nào? | Snapshot: `KeHoachLuaChonNhaThau` → cột `KeHoachLuaChonNhaThau.SoLuongGoiThau`. EF Config KHLCNT **không** khai property (convention). Migration đã add: `20260812044306_AddKeHoachLuaChonNhaThauSoLuongGoiThau`. |
+| 3 | `QuyetDinhDuyetKHLCNT` ở đâu? | Entity `QLDA.Domain/Entities/QuyetDinhDuyetKHLCNT.cs`. Config `QLDA.Persistence/Configurations/QuyetDinhDuyetKHLCNTConfiguration.cs`. Snapshot entity **không** có `SoLuongGoiThau`. |
+| 4 | DTO / Handler / API? | KHLCNT: Insert/Update/Dto + Mappings + `GetDanhSachQuery` + `POST/PUT/GET api/ke-hoach-lua-chon-nha-thau`. QĐ: `QuyetDinhDuyetKHLCNTModel.soLuongGoiThau` + `ToModel` đọc `entity.KeHoachLuaChonNhaThau?.SoLuongGoiThau`. `ToEntity`/`Update` **không** ghi field này. Không có Validator. |
+| 5 | Cần `ef remove` migration vừa gen sai? | **Không** remove `20260812044306_...` (đã add cột đúng bảng cũ, có thể đã apply). Workspace **không** còn migration move chưa apply. Sau khi sửa entity: **add migration mới**. Chỉ `remove` nếu migration **mới** vừa gen vẫn trỏ sai bảng và **chưa** apply/share. |
+| 6 | File dự kiến sửa | Xem [report.md](./report.md) mục 6. |
+
+## 4 cột mới **đúng** trên `KeHoachLuaChonNhaThau` (giữ)
+
+Từ entity hiện tại, trừ `Ten` / `LoaiKeHoach` (cũ) và trừ `SoLuongGoiThau` (sai chỗ):
+
+| Property | Kiểu |
+| --- | --- |
+| `TongDuToan` | `long` |
+| `DuToanThamDinh` | `long?` |
+| `NguonVonId` | `int?` |
+| `ThoiGianThucHien` | `int?` |
+
+Không xóa `Ten`, `LoaiKeHoach`, navigation, không đổi type 4 cột này.
+
+## Expected
+
+```text
+KeHoachLuaChonNhaThau  →  không có SoLuongGoiThau
+QuyetDinhDuyetKHLCNT   →  int? SoLuongGoiThau  (giữ nullability hiện tại)
+```
+
+## Related
+
+- [#178](../178/) — đã persist `SoLuongGoiThau` **trên KHLCNT** (approach cũ, lệch rule này).
+- [Chi tiết QĐ thiếu field](../quyet-dinh-duyet-khlcnt-chi-tiet-thieu-field/) — GET chi tiết đang đọc 5 field từ KHLCNT; sau fix chỉ 4 field từ KHLCNT, `soLuongGoiThau` từ QĐ.

--- a/docs/issues/quyet-dinh-duyet-khlcnt-soluong-goi-thau/journal.md
+++ b/docs/issues/quyet-dinh-duyet-khlcnt-soluong-goi-thau/journal.md
@@ -1,0 +1,8 @@
+# Journal
+
+## 2026-08-21
+
+- Trace source: `SoLuongGoiThau` trên `KeHoachLuaChonNhaThau` (`int?`), snapshot bảng cùng tên, migration `20260812044306_AddKeHoachLuaChonNhaThauSoLuongGoiThau`.
+- `QuyetDinhDuyetKHLCNT` entity/config/snapshot **chưa** có cột. GET chi tiết map từ `KeHoachLuaChonNhaThau?.SoLuongGoiThau`. Write QĐ không persist field.
+- 4 cột mới đúng trên KHLCNT: `TongDuToan`, `DuToanThamDinh`, `NguonVonId`, `ThoiGianThucHien`.
+- Không Validator. Không `ef remove` migration #178. Docs only — chưa sửa code theo task này.

--- a/docs/issues/quyet-dinh-duyet-khlcnt-soluong-goi-thau/report.md
+++ b/docs/issues/quyet-dinh-duyet-khlcnt-soluong-goi-thau/report.md
@@ -1,0 +1,156 @@
+# Báo cáo — chuyển `SoLuongGoiThau` sang `QuyetDinhDuyetKHLCNT`
+
+Không lấy Services làm source of truth. Không đoán thêm business ngoài rule đã chốt.
+
+---
+
+## 1. Sai ở đâu / vì sao
+
+Issue #178 (và GET chi tiết QĐ) gắn `SoLuongGoiThau` vào **kế hoạch**. Snapshot:
+
+```csharp
+modelBuilder.Entity("QLDA.Domain.Entities.KeHoachLuaChonNhaThau", b =>
+{
+    b.HasBaseType("QLDA.Domain.Entities.VanBanQuyetDinh");
+    b.Property<int?>("SoLuongGoiThau").HasColumnType("int");
+    b.ToTable("KeHoachLuaChonNhaThau", (string)null);
+});
+```
+
+Rule đúng:
+
+* KHLCNT chỉ **4 cột mới**: `TongDuToan`, `DuToanThamDinh`, `NguonVonId`, `ThoiGianThucHien`.
+* `SoLuongGoiThau` thuộc bảng **`QuyetDinhDuyetKHLCNT`**.
+* Type giữ `int?` như source hiện tại — không đổi `int` non-null, không đổi tên.
+
+GET `chi-tiet` QĐ đang `SoLuongGoiThau = entity.KeHoachLuaChonNhaThau?.SoLuongGoiThau`. Write QĐ (`ToEntity` / `Update` / InsertOrUpdate) **không** persist số lượng — field chỉ “đi nhờ” navigation kế hoạch.
+
+---
+
+## 2. Trace tầng
+
+```text
+KeHoachLuaChonNhaThau.cs          SoLuongGoiThau int?
+        ↓ convention (Config không khai property)
+Snapshot / bảng KeHoachLuaChonNhaThau
+        ↓
+InsertDto / UpdateDto / Dto + Mappings + GetDanhSach
+        ↓
+api/ke-hoach-lua-chon-nha-thau  them-moi / cap-nhat / chi-tiet / danh-sach
+
+QuyetDinhDuyetKHLCNT.cs           KHÔNG có property
+        ↓
+QuyetDinhDuyetKHLCNTConfiguration  chỉ FK + unique filter
+        ↓
+QuyetDinhDuyetKHLCNTModel          có soLuongGoiThau
+        ↓
+ToModel  ← đọc từ KeHoach (sai chỗ)
+ToEntity/Update  ← không ghi SoLuongGoiThau
+```
+
+---
+
+## 3. Cách sửa (khi được phép code)
+
+Thứ tự: Entity → Application/WebApi map → **rồi** `ef.bat add`. Không sửa snapshot/migration cũ.
+
+### 3.1 Domain
+
+* Xóa `SoLuongGoiThau` khỏi `KeHoachLuaChonNhaThau`.
+* Thêm `int? SoLuongGoiThau` trên `QuyetDinhDuyetKHLCNT`.
+* Không đụng `Ten`, `LoaiKeHoach`, 4 cột mới, navigation.
+
+### 3.2 EF Configuration
+
+Hai file Config **không** map `SoLuongGoiThau` tường minh (convention). Sau khi chuyển property, snapshot/migration phải hiện cột trên `QuyetDinhDuyetKHLCNT`, **không** còn trên `KeHoachLuaChonNhaThau`. Không bắt buộc thêm `.Property` trừ khi review yêu cầu.
+
+### 3.3 KHLCNT Application / API
+
+Gỡ `SoLuongGoiThau` khỏi:
+
+* `KeHoachLuaChonNhaThauDto` / `InsertDto` / `UpdateDto`
+* `KeHoachLuaChonNhaThauMappings` (`ToEntity` / `ToDto` / `Update`)
+* `KeHoachLuaChonNhaThauGetDanhSachQuery` projection
+
+`KeHoachLuaChonNhaThauInsertCommand` / `UpdateCommand` chỉ gọi mapping — không sửa handler trừ khi còn reference.
+
+API `api/ke-hoach-lua-chon-nha-thau` hết contract `soLuongGoiThau` (FE KHLCNT form phải bỏ field).
+
+### 3.4 QĐ duyệt — đổi nguồn map
+
+* `ToModel`: `SoLuongGoiThau = entity.SoLuongGoiThau` (không `KeHoachLuaChonNhaThau?.`).
+* `ToEntity` / `Update`: gán `entity.SoLuongGoiThau = model.SoLuongGoiThau`.
+* `QuyetDinhDuyetKHLCNTInsertOrUpdateCommandHandler` nhánh update: `dbEntity.SoLuongGoiThau = request.Entity.SoLuongGoiThau`.
+* 4 field kia **vẫn** từ `KeHoachLuaChonNhaThau` (GET chi tiết vẫn `Include` kế hoạch).
+* `QuyetDinhDuyetKHLCNTDto` / danh-sach-tien-do: hiện **không** có `SoLuongGoiThau` — không thêm trừ khi ticket yêu cầu list.
+
+Không tạo Application `Service`.
+
+---
+
+## 4. Migration
+
+### Không được
+
+* `database drop` / `DropDatabase`
+* Sửa tay `AppDbContextModelSnapshot.cs`
+* Sửa tay / xóa migration **đã apply** `20260812044306_AddKeHoachLuaChonNhaThauSoLuongGoiThau`
+* Sửa tay file `.cs` migration mới generate
+
+### Được
+
+1. Sửa Entity + Config + DTO/map **xong**.
+2. `ef.bat QLDA add MoveSoLuongGoiThauToQuyetDinhDuyetKHLCNT`
+3. **Review** `Up()`:
+
+   * `AddColumn` `QuyetDinhDuyetKHLCNT.SoLuongGoiThau` `int` NULL
+   * `DropColumn` `KeHoachLuaChonNhaThau.SoLuongGoiThau`
+   * Snapshot: property chỉ còn trên entity QĐ
+
+4. Nếu migration vừa add **vẫn** map sai (cột còn trên KHLCNT) **và chưa apply/share**: `ef.bat QLDA remove` rồi generate lại. Không patch snapshot.
+
+### Copy dữ liệu cũ
+
+EF thường `Drop` cột KHLCNT rồi `Add` cột QĐ → **mất số liệu**. Task cấm sửa migration tay. Nếu cần giữ data: hỏi leader (script DBA riêng / quy trình team), **không** tự `Sql()` vào file generate.
+
+`Down()` rollback sẽ mất số trên QĐ nếu không có chiến lược copy — chấp nhận hoặc hỏi leader.
+
+Không `update` staging/prod từ máy dev.
+
+---
+
+## 5. Trao đổi leader
+
+> `SoLuongGoiThau` đang trên bảng KHLCNT (#178). Em chuyển sang `QuyetDinhDuyetKHLCNT`, KHLCNT giữ 4 cột `TongDuToan` / `DuToanThamDinh` / `NguonVonId` / `ThoiGianThucHien`. Chi tiết QĐ đọc field từ entity QĐ; form KHLCNT bỏ `soLuongGoiThau`. Migration mới drop + add. Cột cũ #178 không xóa history. Data cũ trên KHLCNT có cần copy sang QĐ không?
+
+---
+
+## 6. File dự kiến
+
+| File | Việc |
+| --- | --- |
+| `QLDA.Domain/Entities/KeHoachLuaChonNhaThau.cs` | Xóa property |
+| `QLDA.Domain/Entities/QuyetDinhDuyetKHLCNT.cs` | Thêm `int? SoLuongGoiThau` |
+| `QLDA.Application/KeHoachLuaChonNhaThaus/DTOs/*.cs` | Gỡ property 3 DTO |
+| `QLDA.Application/KeHoachLuaChonNhaThaus/KeHoachLuaChonNhaThauMappings.cs` | Gỡ map |
+| `QLDA.Application/.../KeHoachLuaChonNhaThauGetDanhSachQuery.cs` | Gỡ Select |
+| `QLDA.WebApi/.../QuyetDinhDuyetKHLCNTMappingConfiguration.cs` | ToModel/ToEntity/Update |
+| `QLDA.Application/.../QuyetDinhDuyetKHLCNTInsertOrUpdateCommand.cs` | Assign khi update |
+| `QLDA.Persistence/Configurations/*Configuration.cs` | Review; có thể không đổi dòng |
+| Migrator — file **mới** do `ef add` | Review, không tay |
+
+**Không sửa:** `20260812044306_*`, Init, snapshot tay, Validator (không có), `QuyetDinhDuyetKHLCNTGetDanhSachQuery` trừ khi ticket mở list.
+
+Commit group khi được phép: Domain + Persistence/snapshot-via-ef + Migrator cùng nhóm.
+
+---
+
+## 7. Ticket khi xong
+
+```
+Root cause: SoLuongGoiThau persist trên KeHoachLuaChonNhaThau; nghiệp vụ thuộc QuyetDinhDuyetKHLCNT.
+Files changed: (điền sau code)
+Logic changed: KHLCNT 4 cột mới; QĐ có SoLuongGoiThau; chi tiết QĐ đọc entity QĐ.
+Migration: Yes (mới, không sửa 20260812044306)
+Build/Test: (điền)
+```

--- a/docs/issues/quyet-dinh-duyet-khlcnt-soluong-goi-thau/test-workflow.md
+++ b/docs/issues/quyet-dinh-duyet-khlcnt-soluong-goi-thau/test-workflow.md
@@ -1,0 +1,45 @@
+# Test / verify — `SoLuongGoiThau` trên QĐ duyệt KHLCNT
+
+Chạy sau khi entity + migration **mới** đã apply DB **dev**. Không drop DB. Không update staging/prod từ đây.
+
+## 1. Snapshot / migration review (trước update)
+
+- Entity `KeHoachLuaChonNhaThau` trong snapshot **không** còn `SoLuongGoiThau`.
+- Entity `QuyetDinhDuyetKHLCNT` **có** `b.Property<int?>("SoLuongGoiThau")`.
+- `Up()`: add cột bảng `QuyetDinhDuyetKHLCNT`, drop cột bảng `KeHoachLuaChonNhaThau`.
+- Không sửa file `20260812044306_AddKeHoachLuaChonNhaThauSoLuongGoiThau`.
+
+## 2. SQL sau update
+
+```sql
+-- Cột trên QĐ
+SELECT c.name, t.name AS type_name, c.is_nullable
+FROM sys.columns c
+JOIN sys.types t ON c.user_type_id = t.user_type_id
+WHERE c.object_id = OBJECT_ID(N'dbo.QuyetDinhDuyetKHLCNT')
+  AND c.name = N'SoLuongGoiThau';
+
+-- Không còn trên KHLCNT
+SELECT c.name
+FROM sys.columns c
+WHERE c.object_id = OBJECT_ID(N'dbo.KeHoachLuaChonNhaThau')
+  AND c.name = N'SoLuongGoiThau';
+```
+
+Kỳ vọng: query 1 có 1 dòng `int` nullable; query 2 rỗng.
+
+## 3. API
+
+| # | Gọi | Kỳ vọng |
+| --- | --- | --- |
+| 1 | `POST/PUT api/ke-hoach-lua-chon-nha-thau` gửi `soLuongGoiThau` | Bỏ qua / không persist KHLCNT |
+| 2 | GET chi tiết KHLCNT | Response **không** `soLuongGoiThau`; vẫn 4 field `tongDuToan`, `duToanThamDinh`, `nguonVonId`, `thoiGianThucHien` |
+| 3 | `POST api/quyet-dinh-duyet-khlcnt/them-moi` kèm `soLuongGoiThau` | Lưu bảng `QuyetDinhDuyetKHLCNT` |
+| 4 | `GET api/quyet-dinh-duyet-khlcnt/{id}/chi-tiet` | `soLuongGoiThau` từ QĐ; 4 field kia vẫn từ kế hoạch |
+| 5 | `PUT .../cap-nhat` đổi `soLuongGoiThau` | Cập nhật cột QĐ, không ghi KHLCNT |
+
+## 4. Không pass nếu
+
+- Chi tiết QĐ vẫn lấy số từ kế hoạch (entity QĐ null, KHLCNT còn cột).
+- Snapshot vẫn `SoLuongGoiThau` dưới `KeHoachLuaChonNhaThau`.
+- 4 cột KHLCNT bị xóa nhầm.


### PR DESCRIPTION
## Summary
- `SoLuongGoiThau` đang persist trên `KeHoachLuaChonNhaThau` (sai nghiệp vụ). KHLCNT chỉ giữ 4 cột mới: `TongDuToan`, `DuToanThamDinh`, `NguonVonId`, `ThoiGianThucHien`.
- Chuyển `int? SoLuongGoiThau` sang `QuyetDinhDuyetKHLCNT`. GET chi tiết / them-moi / cap-nhat đọc-ghi trên entity QĐ.
- API `ke-hoach-lua-chon-nha-thau` không còn `soLuongGoiThau`.
- Migration `20260821073445_MoveSoLuongGoiThauToQuyetDinhDuyetKHLCNT` (drop cột KHLCNT rồi add cột QĐ — data cũ trên kế hoạch không copy).

## Test plan
- [ ] SQL: cột `SoLuongGoiThau` chỉ còn trên `QuyetDinhDuyetKHLCNT`, không còn trên `KeHoachLuaChonNhaThau`
- [ ] GET chi tiết KHLCNT vẫn có 4 field trên; không trả `soLuongGoiThau`
- [ ] `POST/PUT api/quyet-dinh-duyet-khlcnt` gửi `soLuongGoiThau` → lưu bảng QĐ
- [ ] GET `.../chi-tiet` QĐ trả `soLuongGoiThau` từ QĐ; 4 field kia vẫn từ kế hoạch